### PR TITLE
Add GitHub Release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,25 @@ jobs:
           for pkg in packages/SimpleModule.Client packages/SimpleModule.UI packages/SimpleModule.Theme.Default; do
             (cd "$pkg" && npm version "$VERSION" --no-git-tag-version && npm publish --access public)
           done
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: [version, publish-nuget, publish-npm]
+    if: needs.version.outputs.skip != 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Summary

- Adds a `github-release` job to the release workflow that creates a GitHub Release with auto-generated release notes after NuGet and npm packages are published
- Uses `gh release create` with `--generate-notes` to automatically build a changelog from merged PRs and commits since the previous tag
- The job runs only after both `publish-nuget` and `publish-npm` succeed, so the release page is created once packages are available

## Changes

- `.github/workflows/release.yml` — new `github-release` job at the end of the pipeline