### PR TITLE
fix(ci): use annotated tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add version.json
           git commit -m "release: v${VERSION}"
-          git tag "v${VERSION}"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
           git push origin main --follow-tags
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.version.outputs.sha }}
+          ref: v${{ needs.version.outputs.version }}
           fetch-depth: 0
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Use annotated tags (`git tag -a`) instead of lightweight tags so `--follow-tags` actually pushes them to the remote
- Check out by tag ref instead of SHA in the `github-release` job so `--verify-tag` can find the tag

## Root cause
`git push origin main --follow-tags` only pushes **annotated** tags. The workflow was creating lightweight tags, so the tag never reached the remote — causing `gh release create --verify-tag` to fail.

## Test plan
- [ ] Trigger a release via `workflow_dispatch` and verify the tag is pushed and GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)