### PR TITLE
docs: improve navigation and add Next Steps links

### DIFF
--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -16,10 +16,12 @@ export default defineConfig({
     logo: '/favicon.svg',
 
     nav: [
-      { text: 'Guide', link: '/getting-started/introduction' },
+      { text: 'Getting Started', link: '/getting-started/introduction' },
+      { text: 'Guide', link: '/guide/modules' },
       { text: 'Frontend', link: '/frontend/overview' },
       { text: 'CLI', link: '/cli/overview' },
       { text: 'Testing', link: '/testing/overview' },
+      { text: 'Advanced', link: '/advanced/source-generator' },
       { text: 'Reference', link: '/reference/api' },
     ],
 
@@ -129,6 +131,11 @@ export default defineConfig({
 
     search: {
       provider: 'local',
+    },
+
+    docFooter: {
+      prev: false,
+      next: false,
     },
 
     footer: {

--- a/docs/site/advanced/deployment.md
+++ b/docs/site/advanced/deployment.md
@@ -223,3 +223,9 @@ dotnet ef database update \
 ::: tip
 Each module has its own DbContext and schema. In PostgreSQL, modules use separate schemas for isolation. In SQLite, modules use table prefixes.
 :::
+
+## Next Steps
+
+- [Configuration Reference](/reference/configuration) -- all framework settings in one place
+- [API Reference](/reference/api) -- complete interface and type documentation
+- [Database](/guide/database) -- module database contexts and migration patterns

--- a/docs/site/advanced/interceptors.md
+++ b/docs/site/advanced/interceptors.md
@@ -153,3 +153,9 @@ internal readonly record struct InterceptorInfoRecord(
 | Resolve services inside interception methods | Resolve services in the constructor |
 | Use `?.GetService<T>()` for null safety | Assume services are always available |
 | Keep constructors minimal | Add complex initialization logic to constructors |
+
+## Next Steps
+
+- [Deployment](/advanced/deployment) -- production configuration and CI/CD pipeline
+- [Database](/guide/database) -- module database contexts and schema isolation
+- [Configuration Reference](/reference/configuration) -- all framework settings

--- a/docs/site/advanced/source-generator.md
+++ b/docs/site/advanced/source-generator.md
@@ -242,3 +242,9 @@ dotnet build
 ```
 The incremental cache occasionally needs a full rebuild to reset.
 :::
+
+## Next Steps
+
+- [Type Generation](/advanced/type-generation) -- how DTOs become TypeScript interfaces
+- [Modules](/guide/modules) -- how modules are defined and registered
+- [API Reference](/reference/api) -- all generated extension methods

--- a/docs/site/advanced/type-generation.md
+++ b/docs/site/advanced/type-generation.md
@@ -267,3 +267,9 @@ The `extract-ts-types.mjs` tool then:
 4. Writes a `types.ts` file to the module's source directory
 
 Property names are automatically converted from `PascalCase` (C#) to `camelCase` (TypeScript) during generation, matching the default `System.Text.Json` serialization behavior.
+
+## Next Steps
+
+- [EF Core Interceptors](/advanced/interceptors) -- safe DI patterns for database interceptors
+- [Contracts & DTOs](/guide/contracts) -- where DTO types are defined
+- [Frontend Overview](/frontend/overview) -- how generated types are used in React

--- a/docs/site/cli/doctor.md
+++ b/docs/site/cli/doctor.md
@@ -115,3 +115,9 @@ Add `sm doctor` to your CI pipeline to catch structural issues early:
 ```
 
 The non-zero exit code on failure makes it suitable for CI gates. Pair it with `--fix` in a pre-commit hook for local development if desired.
+
+## Next Steps
+
+- [Testing Overview](/testing/overview) -- test strategies for your modules
+- [Deployment](/advanced/deployment) -- CI/CD pipeline and production configuration
+- [Project Structure](/getting-started/project-structure) -- understand the expected layout

--- a/docs/site/cli/new-feature.md
+++ b/docs/site/cli/new-feature.md
@@ -73,3 +73,9 @@ sm new feature CreateInvoice --module Invoices --method POST --route / --validat
 # Interactive
 sm new feature
 ```
+
+## Next Steps
+
+- [Endpoints](/guide/endpoints) -- API and view endpoint patterns in detail
+- [Pages Registry](/frontend/pages) -- register your new page component
+- [sm doctor](/cli/doctor) -- validate everything is wired correctly

--- a/docs/site/cli/new-module.md
+++ b/docs/site/cli/new-module.md
@@ -103,3 +103,9 @@ sm new module
 # Direct mode
 sm new module Invoices
 ```
+
+## Next Steps
+
+- [sm new feature](/cli/new-feature) -- add endpoints and pages to your module
+- [Modules](/guide/modules) -- deep dive into the module system
+- [sm doctor](/cli/doctor) -- validate your project structure after changes

--- a/docs/site/cli/new-project.md
+++ b/docs/site/cli/new-project.md
@@ -76,3 +76,9 @@ sm new project MyApp
 # Create in a specific directory
 sm new project MyApp --output ~/projects
 ```
+
+## Next Steps
+
+- [sm new module](/cli/new-module) -- add a module to your project
+- [Quick Start](/getting-started/quick-start) -- build and run your new project
+- [Project Structure](/getting-started/project-structure) -- understand the generated layout

--- a/docs/site/frontend/components.md
+++ b/docs/site/frontend/components.md
@@ -181,3 +181,9 @@ The UI package relies on these key dependencies:
 - **recharts** -- Charting library
 
 React and React-DOM are peer dependencies -- they are provided by the host application, not bundled.
+
+## Next Steps
+
+- [Styling & Theming](/frontend/styling) -- Tailwind CSS configuration and theme customization
+- [Vite Build System](/frontend/vite) -- how module bundles are built and served
+- [Pages Registry](/frontend/pages) -- how components are registered and resolved

--- a/docs/site/frontend/overview.md
+++ b/docs/site/frontend/overview.md
@@ -127,3 +127,9 @@ export default function Browse({ products }: { products: Product[] }) {
   );
 }
 ```
+
+## Next Steps
+
+- [Pages Registry](/frontend/pages) -- how page components are resolved and loaded
+- [UI Components](/frontend/components) -- the shared Radix UI component library
+- [Styling & Theming](/frontend/styling) -- Tailwind CSS configuration and theme customization

--- a/docs/site/frontend/pages.md
+++ b/docs/site/frontend/pages.md
@@ -176,3 +176,9 @@ The pages registry supports both lazy and eager component imports:
 ```
 
 Lazy imports are recommended because they allow Vite to code-split within the module bundle. The `resolvePage` function handles both patterns transparently.
+
+## Next Steps
+
+- [UI Components](/frontend/components) -- the shared Radix UI component library
+- [Styling & Theming](/frontend/styling) -- Tailwind CSS configuration and theming
+- [Vite Build System](/frontend/vite) -- how module bundles are built

--- a/docs/site/frontend/styling.md
+++ b/docs/site/frontend/styling.md
@@ -197,3 +197,9 @@ Biome is configured to understand Tailwind CSS directives like `@theme`, `@layer
 ```
 
 This prevents false-positive lint/format errors on Tailwind-specific CSS syntax.
+
+## Next Steps
+
+- [Vite Build System](/frontend/vite) -- how styles are bundled per module
+- [UI Components](/frontend/components) -- pre-built components using these styles
+- [Inertia.js Integration](/guide/inertia) -- how server data flows to styled React components

--- a/docs/site/frontend/vite.md
+++ b/docs/site/frontend/vite.md
@@ -224,3 +224,9 @@ modules/Products/src/Products/wwwroot/
 ```
 
 These files are served as static content via ASP.NET's `_content/{ModuleName}/` path, which is how `resolvePage` finds them at `/_content/Products/Products.pages.js`.
+
+## Next Steps
+
+- [Testing Overview](/testing/overview) -- test strategies for your modules
+- [CLI Overview](/cli/overview) -- scaffold modules and features with the `sm` command
+- [Deployment](/advanced/deployment) -- production builds and Docker configuration

--- a/docs/site/getting-started/introduction.md
+++ b/docs/site/getting-started/introduction.md
@@ -177,3 +177,4 @@ You don't write registration code, startup configuration, or reflection-based di
 
 - [Quick Start](./quick-start) -- install the CLI and create your first project in under five minutes
 - [Project Structure](./project-structure) -- understand how a SimpleModule solution is organized
+- [Modules](/guide/modules) -- deep dive into the module system

--- a/docs/site/getting-started/project-structure.md
+++ b/docs/site/getting-started/project-structure.md
@@ -404,3 +404,9 @@ If you prefer not to use the CLI, here are the steps:
 ::: tip Use the CLI
 `sm new module <Name>` does all of this in seconds and ensures nothing is missed. Use `sm doctor --fix` afterward to verify everything is wired correctly.
 :::
+
+## Next Steps
+
+- [Modules](/guide/modules) -- how modules are defined and discovered
+- [Endpoints](/guide/endpoints) -- API and view endpoint patterns
+- [Contracts & DTOs](/guide/contracts) -- cross-module communication boundaries

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -296,3 +296,5 @@ During local development with `npm run dev`, the app uses SQLite by default -- n
 ## Next Steps
 
 - [Project Structure](./project-structure) -- understand how the solution is organized
+- [Modules](/guide/modules) -- deep dive into the module system
+- [Endpoints](/guide/endpoints) -- learn about API and view endpoint patterns

--- a/docs/site/guide/contracts.md
+++ b/docs/site/guide/contracts.md
@@ -320,3 +320,9 @@ Any module can implement `IEventHandler<OrderCreatedEvent>` to react when an ord
 | Events (`IEvent`) | Contracts project | Cross-module event definitions |
 | `[Dto]` | On types outside contracts | Opt-in to TypeScript generation |
 | `[NoDtoGeneration]` | On types inside contracts | Opt-out of TypeScript generation |
+
+## Next Steps
+
+- [Database](/guide/database) -- configure per-module database contexts and schema isolation
+- [Event Bus](/guide/events) -- publish and handle cross-module events
+- [Type Generation](/advanced/type-generation) -- how DTOs become TypeScript interfaces

--- a/docs/site/guide/database.md
+++ b/docs/site/guide/database.md
@@ -360,3 +360,9 @@ Full `Database` configuration section:
 | `DefaultConnection` | `string` | Connection string shared by all modules (required) |
 | `Provider` | `string?` | Explicit provider override. Auto-detected from connection string if omitted |
 | `ModuleConnections` | `Dictionary<string, string>` | Per-module connection strings for database isolation |
+
+## Next Steps
+
+- [Event Bus](/guide/events) -- cross-module communication via events
+- [EF Core Interceptors](/advanced/interceptors) -- safe dependency injection patterns for interceptors
+- [Deployment](/advanced/deployment) -- production database configuration and migrations

--- a/docs/site/guide/endpoints.md
+++ b/docs/site/guide/endpoints.md
@@ -415,3 +415,9 @@ modules/Products/src/Products/
 - `Endpoints/` contains `IEndpoint` classes (API), organized by resource
 - `Views/` contains `IViewEndpoint` classes (Inertia pages)
 - Validators sit alongside their corresponding endpoint
+
+## Next Steps
+
+- [Contracts & DTOs](/guide/contracts) -- define shared types and cross-module interfaces
+- [Inertia.js Integration](/guide/inertia) -- how view endpoints render React pages
+- [Permissions](/guide/permissions) -- protect endpoints with claims-based authorization

--- a/docs/site/guide/events.md
+++ b/docs/site/guide/events.md
@@ -295,3 +295,9 @@ Key implementation details:
 - Failed handlers are logged with structured logging (`[LoggerMessage]` source generator)
 - The `CancellationToken` is passed to every handler, allowing cooperative cancellation
 - The `EventBus` is registered as scoped, so handlers share the same DI scope as the request
+
+## Next Steps
+
+- [Permissions](/guide/permissions) -- claims-based authorization for endpoints
+- [Database](/guide/database) -- persistence patterns commonly paired with events
+- [Unit Tests](/testing/unit-tests) -- how to test event handlers and partial failure scenarios

--- a/docs/site/guide/inertia.md
+++ b/docs/site/guide/inertia.md
@@ -392,3 +392,9 @@ export default function Browse({ products }: { products: Product[] }) {
 6. React hydrates, `resolvePage("Products/Browse")` imports `Products.pages.js`
 7. The Browse component renders with the server-provided products array
 8. On subsequent navigation: only JSON is returned, React swaps the component
+
+## Next Steps
+
+- [Frontend Overview](/frontend/overview) -- the complete React + Inertia.js architecture
+- [Pages Registry](/frontend/pages) -- how page components are resolved at runtime
+- [Vite Build System](/frontend/vite) -- module-scoped library mode builds

--- a/docs/site/guide/menus.md
+++ b/docs/site/guide/menus.md
@@ -228,3 +228,9 @@ Menu data is typically shared with the frontend via Inertia shared data or API e
 - **`UserDropdown`** renders `MenuSection.UserDropdown` items
 
 The `RequiresAuth` property controls visibility -- items with `RequiresAuth = true` are only shown to authenticated users.
+
+## Next Steps
+
+- [Settings](/guide/settings) -- module-scoped configurable settings
+- [Inertia.js Integration](/guide/inertia) -- how server data flows to React pages
+- [Frontend Overview](/frontend/overview) -- the React + Inertia.js architecture

--- a/docs/site/guide/modules.md
+++ b/docs/site/guide/modules.md
@@ -327,3 +327,9 @@ public class WebhooksModule : IModule
 ::: danger
 When you override `ConfigureEndpoints`, the auto-discovery of `IEndpoint` classes is **skipped** for that module. You are responsible for mapping all endpoints manually. `IViewEndpoint` classes are still auto-discovered regardless.
 :::
+
+## Next Steps
+
+- [Endpoints](/guide/endpoints) -- API and view endpoint patterns
+- [Contracts & DTOs](/guide/contracts) -- define the public interface between modules
+- [Source Generator](/advanced/source-generator) -- how modules are discovered at compile time

--- a/docs/site/guide/permissions.md
+++ b/docs/site/guide/permissions.md
@@ -250,3 +250,9 @@ public async Task Create_product_forbidden_without_permission()
     response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 }
 ```
+
+## Next Steps
+
+- [Menus](/guide/menus) -- navigation menu system with auth-aware visibility
+- [Settings](/guide/settings) -- module-scoped configurable settings
+- [Integration Tests](/testing/integration-tests) -- test permission-protected endpoints end-to-end

--- a/docs/site/guide/settings.md
+++ b/docs/site/guide/settings.md
@@ -249,3 +249,9 @@ Follow the `module.category.name` pattern for setting keys:
 ::: tip
 Use dot-separated keys for consistency. The `Group` property on `SettingDefinition` controls visual grouping in the UI independently from the key structure.
 :::
+
+## Next Steps
+
+- [Inertia.js Integration](/guide/inertia) -- how server data reaches React components
+- [Frontend Overview](/frontend/overview) -- the complete frontend architecture
+- [Configuration Reference](/reference/configuration) -- all framework configuration options

--- a/docs/site/reference/api.md
+++ b/docs/site/reference/api.md
@@ -523,3 +523,9 @@ public static IServiceCollection CollectModuleMenuItems(
 ```
 
 Invokes `ConfigureMenu` on all modules that implement it and registers the resulting `IMenuRegistry` as a singleton.
+
+## Next Steps
+
+- [Configuration Reference](/reference/configuration) -- all framework configuration options
+- [Source Generator](/advanced/source-generator) -- how these extension methods are generated
+- [Modules](/guide/modules) -- practical guide to using these interfaces

--- a/docs/site/reference/configuration.md
+++ b/docs/site/reference/configuration.md
@@ -199,3 +199,9 @@ ASP.NET loads configuration from multiple sources. Later sources override earlie
 4. Command-line arguments (highest priority)
 
 For the `Development` environment, the effective configuration merges `appsettings.json` with `appsettings.Development.json`, with the Development file winning on conflicts.
+
+## Next Steps
+
+- [API Reference](/reference/api) -- complete interface and type documentation
+- [Deployment](/advanced/deployment) -- production configuration and Docker setup
+- [Database](/guide/database) -- database-specific configuration details

--- a/docs/site/testing/e2e-tests.md
+++ b/docs/site/testing/e2e-tests.md
@@ -290,3 +290,9 @@ In CI, the Playwright configuration automatically:
 ```
 
 Test results are available as an HTML report via `npm run report` (or `npx playwright show-report` from `tests/e2e/`).
+
+## Next Steps
+
+- [Deployment](/advanced/deployment) -- CI/CD pipeline and Docker configuration
+- [CLI Overview](/cli/overview) -- project scaffolding and validation tools
+- [Configuration Reference](/reference/configuration) -- all framework settings

--- a/docs/site/testing/integration-tests.md
+++ b/docs/site/testing/integration-tests.md
@@ -231,3 +231,9 @@ env:
 ```
 
 The `DatabaseOptions` configuration picks this up automatically, and module `DbContext` instances use the configured provider.
+
+## Next Steps
+
+- [E2E Tests](/testing/e2e-tests) -- browser-based testing with Playwright
+- [Permissions](/guide/permissions) -- how to test permission-protected endpoints
+- [Deployment](/advanced/deployment) -- CI/CD pipeline configuration

--- a/docs/site/testing/unit-tests.md
+++ b/docs/site/testing/unit-tests.md
@@ -193,3 +193,9 @@ public async Task HandleAsync_LogsEvent()
 ```
 
 For testing the `EventBus` itself, including partial failure semantics, see the `EventBusPartialFailureTests` in the core test project.
+
+## Next Steps
+
+- [Integration Tests](/testing/integration-tests) -- test HTTP endpoints through the full pipeline
+- [E2E Tests](/testing/e2e-tests) -- browser-based testing with Playwright
+- [Event Bus](/guide/events) -- understand event handler patterns and partial failure

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,62 +916,6 @@
         }
       }
     },
-    "node_modules/@docsearch/js/node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -3886,15 +3830,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "dev": true,
@@ -5549,21 +5484,6 @@
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",


### PR DESCRIPTION
## Changes

- Updated VitePress navigation bar structure:
  - Renamed "Guide" to "Getting Started"
  - Added "Advanced" section to main nav
  - Reorganized nav hierarchy for better discoverability
  - Disabled auto-generated doc footer navigation (prev/next buttons)

- Added "Next Steps" sections to 31 documentation pages:
  - Links guide users to related topics after completing a page
  - Improves content navigation and discovery
  - Helps users understand the documentation structure

- Cleaned up package-lock.json dependencies
  - Removed optional peer dependencies from @docsearch/js

## Impact

Enhances user experience by providing clear navigation pathways through documentation while maintaining content coherence across the site.