### PR TITLE
Add opt-in EF Core entity improvements at framework level

### DIFF
--- a/framework/SimpleModule.Core/Entities/AuditableAggregateRoot.cs
+++ b/framework/SimpleModule.Core/Entities/AuditableAggregateRoot.cs
@@ -1,0 +1,18 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Aggregate root with audit tracking, soft delete, versioning, and domain events.
+/// Domain events are automatically dispatched via <see cref="IEventBus"/> after SaveChanges.
+/// </summary>
+public abstract class AuditableAggregateRoot<TId> : FullAuditableEntity<TId>, IHasDomainEvents
+{
+    private readonly List<IEvent> _domainEvents = [];
+
+    public IReadOnlyList<IEvent> GetDomainEvents() => _domainEvents.AsReadOnly();
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+
+    protected void AddDomainEvent(IEvent domainEvent) => _domainEvents.Add(domainEvent);
+}

--- a/framework/SimpleModule.Core/Entities/AuditableEntity.cs
+++ b/framework/SimpleModule.Core/Entities/AuditableEntity.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entity with full audit tracking: timestamps and the user who created/modified the entity.
+/// </summary>
+public abstract class AuditableEntity<TId> : Entity<TId>, IAuditable
+{
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/Entity.cs
+++ b/framework/SimpleModule.Core/Entities/Entity.cs
@@ -1,0 +1,12 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Base entity with a strongly-typed ID, creation/modification timestamps, and a concurrency stamp.
+/// </summary>
+public abstract class Entity<TId> : IHasCreationTime, IHasModificationTime, IHasConcurrencyStamp
+{
+    public TId Id { get; set; } = default!;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}

--- a/framework/SimpleModule.Core/Entities/EntityChangeContext.cs
+++ b/framework/SimpleModule.Core/Entities/EntityChangeContext.cs
@@ -1,0 +1,6 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Context passed to <see cref="IEntityChangeHandler{T}"/> when an entity change is detected after SaveChanges.
+/// </summary>
+public sealed record EntityChangeContext<T>(T Entity, EntityChangeType ChangeType) where T : class;

--- a/framework/SimpleModule.Core/Entities/EntityChangeType.cs
+++ b/framework/SimpleModule.Core/Entities/EntityChangeType.cs
@@ -1,0 +1,11 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// The type of change that occurred on an entity.
+/// </summary>
+public enum EntityChangeType
+{
+    Created,
+    Updated,
+    Deleted,
+}

--- a/framework/SimpleModule.Core/Entities/FullAuditableEntity.cs
+++ b/framework/SimpleModule.Core/Entities/FullAuditableEntity.cs
@@ -1,0 +1,13 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entity with full audit tracking, soft delete, and versioning.
+/// This is the most commonly used base class for business entities.
+/// </summary>
+public abstract class FullAuditableEntity<TId> : AuditableEntity<TId>, ISoftDelete, IVersioned
+{
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public string? DeletedBy { get; set; }
+    public int Version { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IAuditable.cs
+++ b/framework/SimpleModule.Core/Entities/IAuditable.cs
@@ -1,0 +1,11 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface get full audit tracking:
+/// timestamps and the user who created/modified the entity (resolved from the current HTTP context).
+/// </summary>
+public interface IAuditable : IHasCreationTime, IHasModificationTime
+{
+    string? CreatedBy { get; set; }
+    string? UpdatedBy { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IEntityChangeHandler.cs
+++ b/framework/SimpleModule.Core/Entities/IEntityChangeHandler.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Typed handler invoked automatically after SaveChanges when an entity of type <typeparamref name="T"/> changes.
+/// Useful for cache invalidation, denormalized data updates, or triggering side effects.
+/// </summary>
+public interface IEntityChangeHandler<T> where T : class
+{
+    Task HandleAsync(EntityChangeContext<T> context, CancellationToken cancellationToken = default);
+}

--- a/framework/SimpleModule.Core/Entities/IHasConcurrencyStamp.cs
+++ b/framework/SimpleModule.Core/Entities/IHasConcurrencyStamp.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface get a random concurrency stamp set on each save.
+/// Configured as a concurrency token for optimistic concurrency control.
+/// </summary>
+public interface IHasConcurrencyStamp
+{
+    string ConcurrencyStamp { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IHasCreationTime.cs
+++ b/framework/SimpleModule.Core/Entities/IHasCreationTime.cs
@@ -1,0 +1,9 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface get <see cref="CreatedAt"/> automatically set on insert.
+/// </summary>
+public interface IHasCreationTime
+{
+    DateTimeOffset CreatedAt { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IHasDomainEvents.cs
+++ b/framework/SimpleModule.Core/Entities/IHasDomainEvents.cs
@@ -1,0 +1,13 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface can raise domain events that are automatically
+/// dispatched via <see cref="IEventBus"/> after a successful SaveChanges.
+/// </summary>
+public interface IHasDomainEvents
+{
+    IReadOnlyList<IEvent> GetDomainEvents();
+    void ClearDomainEvents();
+}

--- a/framework/SimpleModule.Core/Entities/IHasExtraProperties.cs
+++ b/framework/SimpleModule.Core/Entities/IHasExtraProperties.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface have a flexible key-value property bag
+/// stored as a JSON column. Useful for extensibility without schema changes.
+/// </summary>
+public interface IHasExtraProperties
+{
+    Dictionary<string, object?> ExtraProperties { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IHasModificationTime.cs
+++ b/framework/SimpleModule.Core/Entities/IHasModificationTime.cs
@@ -1,0 +1,9 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface get <see cref="UpdatedAt"/> automatically set on insert and update.
+/// </summary>
+public interface IHasModificationTime
+{
+    DateTimeOffset UpdatedAt { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/IMultiTenant.cs
+++ b/framework/SimpleModule.Core/Entities/IMultiTenant.cs
@@ -1,0 +1,11 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface are automatically assigned a tenant ID
+/// from the current <see cref="ITenantContext"/> on insert. A global query filter
+/// restricts queries to the current tenant.
+/// </summary>
+public interface IMultiTenant
+{
+    string TenantId { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/ISoftDelete.cs
+++ b/framework/SimpleModule.Core/Entities/ISoftDelete.cs
@@ -1,0 +1,13 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface are soft-deleted instead of hard-deleted.
+/// When EF Core <c>Remove()</c> is called, the entity state is changed to Modified and
+/// the soft-delete fields are set automatically. A global query filter excludes soft-deleted entities.
+/// </summary>
+public interface ISoftDelete
+{
+    bool IsDeleted { get; set; }
+    DateTimeOffset? DeletedAt { get; set; }
+    string? DeletedBy { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/ITenantContext.cs
+++ b/framework/SimpleModule.Core/Entities/ITenantContext.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Provides the current tenant ID for multi-tenant entity filtering and assignment.
+/// Resolved from the current request context (e.g., HTTP header, claim, or subdomain).
+/// </summary>
+public interface ITenantContext
+{
+    string? TenantId { get; }
+}

--- a/framework/SimpleModule.Core/Entities/IVersioned.cs
+++ b/framework/SimpleModule.Core/Entities/IVersioned.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entities implementing this interface get an auto-incrementing version number.
+/// Starts at 1 on insert, increments on each update. Configured as a concurrency token.
+/// </summary>
+public interface IVersioned
+{
+    int Version { get; set; }
+}

--- a/framework/SimpleModule.Core/Entities/MultiTenantFullAuditableEntity.cs
+++ b/framework/SimpleModule.Core/Entities/MultiTenantFullAuditableEntity.cs
@@ -1,0 +1,11 @@
+namespace SimpleModule.Core.Entities;
+
+/// <summary>
+/// Entity with full audit tracking, soft delete, versioning, multi-tenancy, and extra properties.
+/// Use this for entities in multi-tenant modules that need maximum extensibility.
+/// </summary>
+public abstract class MultiTenantFullAuditableEntity<TId> : FullAuditableEntity<TId>, IMultiTenant, IHasExtraProperties
+{
+    public string TenantId { get; set; } = string.Empty;
+    public Dictionary<string, object?> ExtraProperties { get; set; } = [];
+}

--- a/framework/SimpleModule.Database/DatabaseConstants.cs
+++ b/framework/SimpleModule.Database/DatabaseConstants.cs
@@ -8,4 +8,12 @@ public static class DatabaseConstants
     public const string SqlServerCatalogPrefix = "Initial Catalog=";
     public const string SqlServerLocalPrefix = @"Server=.\";
     public const string SqlServerExpressionPrefix = @"Server=(";
+
+    /// <summary>Named query filter key for <see cref="Core.Entities.ISoftDelete"/> entities.</summary>
+    public const string SoftDeleteQueryFilterKey = "SimpleModule:SoftDelete";
+
+    /// <summary>Named query filter key for <see cref="Core.Entities.IMultiTenant"/> entities.</summary>
+    public const string MultiTenantQueryFilterKey = "SimpleModule:MultiTenant";
+
+    internal const string EntityConventionsAppliedAnnotation = "SimpleModule:EntityConventionsApplied";
 }

--- a/framework/SimpleModule.Database/Interceptors/DomainEventInterceptor.cs
+++ b/framework/SimpleModule.Database/Interceptors/DomainEventInterceptor.cs
@@ -1,0 +1,86 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core.Entities;
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Database.Interceptors;
+
+/// <summary>
+/// Interceptor that collects domain events from <see cref="IHasDomainEvents"/> entities
+/// before SaveChanges and dispatches them via <see cref="IEventBus"/> after a successful save.
+/// Events are cleared from entities after dispatch to prevent re-processing.
+/// Registered as scoped — each DbContext gets its own instance, so instance fields are safe.
+/// </summary>
+public sealed class DomainEventInterceptor(IServiceProvider serviceProvider) : SaveChangesInterceptor
+{
+    private static readonly MethodInfo PublishAsyncMethod =
+        typeof(IEventBus).GetMethod(nameof(IEventBus.PublishAsync))!;
+    private static readonly ConcurrentDictionary<Type, MethodInfo> PublishMethodCache = new();
+
+    private List<IEvent>? _collectedEvents;
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not null)
+        {
+            var events = new List<IEvent>();
+
+            foreach (var entry in eventData.Context.ChangeTracker.Entries<IHasDomainEvents>())
+            {
+                var domainEvents = entry.Entity.GetDomainEvents();
+                if (domainEvents.Count > 0)
+                {
+                    events.AddRange(domainEvents);
+                    entry.Entity.ClearDomainEvents();
+                }
+            }
+
+            _collectedEvents = events.Count > 0 ? events : null;
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        var events = _collectedEvents;
+        _collectedEvents = null;
+
+        if (events is { Count: > 0 })
+        {
+            var eventBus = serviceProvider.GetService<IEventBus>();
+            if (eventBus is not null)
+            {
+                foreach (var domainEvent in events)
+                {
+                    // Invoke PublishAsync<T> with the concrete event type so that
+                    // IEventHandler<T> registrations are resolved correctly.
+                    // A static call to PublishAsync(IEvent) would resolve T as IEvent,
+                    // missing all concrete handlers.
+                    var concreteMethod = PublishMethodCache.GetOrAdd(
+                        domainEvent.GetType(),
+                        static type => PublishAsyncMethod.MakeGenericMethod(type));
+                    await (Task)concreteMethod.Invoke(eventBus, [domainEvent, cancellationToken])!;
+                }
+            }
+        }
+
+        return await base.SavedChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        _collectedEvents = null;
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+}

--- a/framework/SimpleModule.Database/Interceptors/EntityChangeInterceptor.cs
+++ b/framework/SimpleModule.Database/Interceptors/EntityChangeInterceptor.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.Interceptors;
+
+/// <summary>
+/// Interceptor that captures entity changes before SaveChanges and dispatches them to
+/// typed <see cref="IEntityChangeHandler{T}"/> implementations after a successful save.
+/// Registered as scoped — each DbContext gets its own instance, so instance fields are safe.
+/// Caches compiled delegates per entity type to avoid per-save reflection overhead.
+/// </summary>
+public sealed class EntityChangeInterceptor(
+    IServiceProvider serviceProvider,
+    ILogger<EntityChangeInterceptor> logger
+) : SaveChangesInterceptor
+{
+    private static readonly ConcurrentDictionary<Type, HandlerMetadata> MetadataCache = new();
+
+    private List<(object Entity, EntityChangeType ChangeType)>? _capturedChanges;
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not null)
+        {
+            var changes = new List<(object Entity, EntityChangeType ChangeType)>();
+
+            foreach (var entry in eventData.Context.ChangeTracker.Entries())
+            {
+                if (entry.State is not (EntityState.Added or EntityState.Modified or EntityState.Deleted))
+                    continue;
+
+                var changeType = entry.State switch
+                {
+                    EntityState.Added => EntityChangeType.Created,
+                    EntityState.Deleted => EntityChangeType.Deleted,
+                    EntityState.Modified when entry.Entity is ISoftDelete { IsDeleted: true }
+                        && entry.Property(nameof(ISoftDelete.IsDeleted)).IsModified
+                        => EntityChangeType.Deleted,
+                    _ => EntityChangeType.Updated,
+                };
+
+                changes.Add((entry.Entity, changeType));
+            }
+
+            _capturedChanges = changes.Count > 0 ? changes : null;
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        var changes = _capturedChanges;
+        _capturedChanges = null;
+
+        if (changes is { Count: > 0 })
+        {
+            foreach (var (entity, changeType) in changes)
+            {
+                await DispatchToHandlersAsync(entity, changeType, cancellationToken);
+            }
+        }
+
+        return await base.SavedChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override Task SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        _capturedChanges = null;
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+
+    private async Task DispatchToHandlersAsync(
+        object entity,
+        EntityChangeType changeType,
+        CancellationToken cancellationToken)
+    {
+        var entityType = entity.GetType();
+        var metadata = MetadataCache.GetOrAdd(entityType, BuildMetadata);
+        var handlers = serviceProvider.GetServices(metadata.HandlerType);
+
+        foreach (var handler in handlers)
+        {
+            try
+            {
+                var context = metadata.ContextFactory(entity, changeType);
+                await metadata.Invoker(handler!, context, cancellationToken);
+            }
+#pragma warning disable CA1031 // Handlers should not crash the save pipeline
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                logger.LogError(
+                    ex,
+                    "Entity change handler {HandlerType} failed for {EntityType} ({ChangeType})",
+                    handler?.GetType().Name,
+                    entityType.Name,
+                    changeType);
+            }
+        }
+    }
+
+    private static HandlerMetadata BuildMetadata(Type entityType)
+    {
+        var handlerType = typeof(IEntityChangeHandler<>).MakeGenericType(entityType);
+        var contextType = typeof(EntityChangeContext<>).MakeGenericType(entityType);
+
+        // Compile a factory delegate: (object entity, EntityChangeType ct) => new EntityChangeContext<T>((T)entity, ct)
+        var entityParam = Expression.Parameter(typeof(object), "entity");
+        var changeTypeParam = Expression.Parameter(typeof(EntityChangeType), "changeType");
+        var ctor = contextType.GetConstructor([entityType, typeof(EntityChangeType)])!;
+        var newExpr = Expression.New(ctor, Expression.Convert(entityParam, entityType), changeTypeParam);
+        var contextFactory = Expression.Lambda<Func<object, EntityChangeType, object>>(
+            Expression.Convert(newExpr, typeof(object)),
+            entityParam, changeTypeParam).Compile();
+
+        // Compile an invoker delegate: (object handler, object ctx, CancellationToken ct) => ((IEntityChangeHandler<T>)handler).HandleAsync((EntityChangeContext<T>)ctx, ct)
+        var handlerParam = Expression.Parameter(typeof(object), "handler");
+        var ctxParam = Expression.Parameter(typeof(object), "ctx");
+        var ctParam = Expression.Parameter(typeof(CancellationToken), "ct");
+        var handleMethod = handlerType.GetMethod(nameof(IEntityChangeHandler<object>.HandleAsync))!;
+        var callExpr = Expression.Call(
+            Expression.Convert(handlerParam, handlerType),
+            handleMethod,
+            Expression.Convert(ctxParam, contextType),
+            ctParam);
+        var invoker = Expression.Lambda<Func<object, object, CancellationToken, Task>>(
+            callExpr, handlerParam, ctxParam, ctParam).Compile();
+
+        return new HandlerMetadata(handlerType, contextFactory, invoker);
+    }
+
+    private sealed record HandlerMetadata(
+        Type HandlerType,
+        Func<object, EntityChangeType, object> ContextFactory,
+        Func<object, object, CancellationToken, Task> Invoker);
+}

--- a/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
+++ b/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.Interceptors;
+
+/// <summary>
+/// Interceptor that automatically populates entity fields based on implemented interfaces:
+/// <list type="bullet">
+///   <item><see cref="IHasCreationTime"/> — sets <c>CreatedAt</c> on insert</item>
+///   <item><see cref="IHasModificationTime"/> — sets <c>UpdatedAt</c> on insert and update</item>
+///   <item><see cref="IAuditable"/> — sets <c>CreatedBy</c>/<c>UpdatedBy</c> from the current user</item>
+///   <item><see cref="ISoftDelete"/> — converts hard delete to soft delete</item>
+///   <item><see cref="IVersioned"/> — auto-increments <c>Version</c></item>
+///   <item><see cref="IHasConcurrencyStamp"/> — sets a new random concurrency stamp</item>
+///   <item><see cref="IMultiTenant"/> — sets <c>TenantId</c> from <see cref="ITenantContext"/></item>
+/// </list>
+/// </summary>
+public sealed class EntityInterceptor(
+    IHttpContextAccessor httpContextAccessor,
+    ITenantContext? tenantContext = null
+) : SaveChangesInterceptor
+{
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is null)
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+
+        var userId = httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var entry in eventData.Context.ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified or EntityState.Deleted))
+                continue;
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    SetCreationFields(entry, now, userId);
+                    SetModificationFields(entry, now, userId);
+                    SetConcurrencyFields(entry);
+                    SetTenantId(entry);
+                    if (entry.Entity is IVersioned v)
+                        v.Version = 1;
+                    break;
+
+                case EntityState.Modified:
+                    SetModificationFields(entry, now, userId);
+                    SetConcurrencyFields(entry);
+                    if (entry.Entity is IVersioned v2)
+                        v2.Version++;
+                    break;
+
+                case EntityState.Deleted when entry.Entity is ISoftDelete sd:
+                    entry.State = EntityState.Modified;
+                    sd.IsDeleted = true;
+                    sd.DeletedAt = now;
+                    sd.DeletedBy = userId;
+                    SetModificationFields(entry, now, userId);
+                    SetConcurrencyFields(entry);
+                    if (entry.Entity is IVersioned v3)
+                        v3.Version++;
+                    break;
+            }
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private static void SetCreationFields(EntityEntry entry, DateTimeOffset now, string? userId)
+    {
+        if (entry.Entity is IHasCreationTime c)
+            c.CreatedAt = now;
+
+        if (entry.Entity is IAuditable a)
+            a.CreatedBy = userId;
+    }
+
+    private static void SetModificationFields(EntityEntry entry, DateTimeOffset now, string? userId)
+    {
+        if (entry.Entity is IHasModificationTime m)
+            m.UpdatedAt = now;
+
+        if (entry.Entity is IAuditable a)
+            a.UpdatedBy = userId;
+    }
+
+    private static void SetConcurrencyFields(EntityEntry entry)
+    {
+        if (entry.Entity is IHasConcurrencyStamp cs)
+            cs.ConcurrencyStamp = Guid.NewGuid().ToString("N");
+    }
+
+    private void SetTenantId(EntityEntry entry)
+    {
+        if (entry.Entity is IMultiTenant mt && tenantContext?.TenantId is not null)
+            mt.TenantId = tenantContext.TenantId;
+    }
+}

--- a/framework/SimpleModule.Database/ModuleModelBuilderExtensions.cs
+++ b/framework/SimpleModule.Database/ModuleModelBuilderExtensions.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using SimpleModule.Core.Entities;
 
 namespace SimpleModule.Database;
 
 public static class ModuleModelBuilderExtensions
 {
+
 #pragma warning disable CA1308 // Schema names are conventionally lowercase in PostgreSQL/SQL Server
     public static void ApplyModuleSchema(
         this ModelBuilder modelBuilder,
@@ -41,6 +44,110 @@ public static class ModuleModelBuilderExtensions
                 entity.SetSchema(schema);
             }
         }
+
+        ApplyEntityConventions(modelBuilder, provider);
     }
 #pragma warning restore CA1308
+
+    /// <summary>
+    /// Applies multi-tenant query filters to all <see cref="IMultiTenant"/> entities.
+    /// Call this from your DbContext's <c>OnModelCreating</c> after <see cref="ApplyModuleSchema"/>.
+    /// <para>
+    /// The filter expression closes over the <paramref name="tenantContext"/> field reference,
+    /// so EF Core evaluates the current tenant ID at query time (parameterized).
+    /// </para>
+    /// <example>
+    /// <code>
+    /// protected override void OnModelCreating(ModelBuilder modelBuilder)
+    /// {
+    ///     modelBuilder.ApplyModuleSchema("Products", dbOptions.Value);
+    ///     modelBuilder.ApplyMultiTenantFilters(tenantContext);
+    /// }
+    /// </code>
+    /// </example>
+    /// </summary>
+    public static void ApplyMultiTenantFilters(
+        this ModelBuilder modelBuilder,
+        ITenantContext tenantContext
+    )
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (!typeof(IMultiTenant).IsAssignableFrom(entityType.ClrType))
+                continue;
+
+            var parameter = Expression.Parameter(entityType.ClrType, "e");
+            var tenantIdProperty = Expression.Property(parameter, nameof(IMultiTenant.TenantId));
+            var tenantContextExpr = Expression.Constant(tenantContext);
+            var currentTenantId = Expression.Property(tenantContextExpr, nameof(ITenantContext.TenantId));
+
+            // Handle null tenant: when no tenant is set, the filter becomes e.TenantId == null
+            // which effectively returns no rows (TenantId is non-nullable string).
+            var filter = Expression.Lambda(
+                Expression.Equal(tenantIdProperty, Expression.Coalesce(currentTenantId, Expression.Constant(""))),
+                parameter
+            );
+
+            entityType.SetQueryFilter(DatabaseConstants.MultiTenantQueryFilterKey, filter);
+        }
+    }
+
+    /// <summary>
+    /// Applies EF Core conventions for entity interfaces. Guarded against re-entry
+    /// so it runs at most once per model even if <see cref="ApplyModuleSchema"/> is called
+    /// multiple times.
+    /// </summary>
+    private static void ApplyEntityConventions(ModelBuilder modelBuilder, DatabaseProvider provider)
+    {
+        if (modelBuilder.Model.FindAnnotation(DatabaseConstants.EntityConventionsAppliedAnnotation) is not null)
+            return;
+
+        modelBuilder.Model.AddAnnotation(DatabaseConstants.EntityConventionsAppliedAnnotation, true);
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var clrType = entityType.ClrType;
+
+            if (typeof(ISoftDelete).IsAssignableFrom(clrType))
+            {
+                var parameter = Expression.Parameter(clrType, "e");
+                var property = Expression.Property(parameter, nameof(ISoftDelete.IsDeleted));
+                var filter = Expression.Lambda(Expression.Not(property), parameter);
+                entityType.SetQueryFilter(DatabaseConstants.SoftDeleteQueryFilterKey, filter);
+            }
+
+            if (typeof(IHasConcurrencyStamp).IsAssignableFrom(clrType))
+            {
+                var concurrencyProp = entityType.FindProperty(nameof(IHasConcurrencyStamp.ConcurrencyStamp));
+                if (concurrencyProp is not null)
+                {
+                    concurrencyProp.IsConcurrencyToken = true;
+                }
+            }
+
+            if (typeof(IVersioned).IsAssignableFrom(clrType))
+            {
+                var versionProp = entityType.FindProperty(nameof(IVersioned.Version));
+                if (versionProp is not null)
+                {
+                    versionProp.IsConcurrencyToken = true;
+                }
+            }
+
+            if (typeof(IHasExtraProperties).IsAssignableFrom(clrType))
+            {
+                var prop = entityType.FindProperty(nameof(IHasExtraProperties.ExtraProperties));
+                if (prop is not null)
+                {
+                    var columnType = provider switch
+                    {
+                        DatabaseProvider.PostgreSql => "jsonb",
+                        DatabaseProvider.SqlServer => "nvarchar(max)",
+                        _ => "TEXT",
+                    };
+                    prop.SetColumnType(columnType);
+                }
+            }
+        }
+    }
 }

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -16,6 +17,7 @@ using SimpleModule.Core.Inertia;
 using SimpleModule.Core.Menu;
 using SimpleModule.Database;
 using SimpleModule.Database.Health;
+using SimpleModule.Database.Interceptors;
 using SimpleModule.DevTools;
 
 namespace SimpleModule.Hosting;
@@ -67,6 +69,11 @@ public static class SimpleModuleHostExtensions
         builder.Services.AddHostedService<BackgroundEventDispatcher>();
         builder.Services.AddScoped<IEventBus, EventBus>();
         builder.Services.AddScoped<InertiaSharedData>();
+
+        // Entity framework interceptors for automatic entity field population
+        builder.Services.AddScoped<ISaveChangesInterceptor, EntityInterceptor>();
+        builder.Services.AddScoped<ISaveChangesInterceptor, DomainEventInterceptor>();
+        builder.Services.AddScoped<ISaveChangesInterceptor, EntityChangeInterceptor>();
 
         // Authentication is configured by modules via their ConfigureServices
         // (e.g., OpenIddict registers SmartAuth policy scheme).

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Interceptors/AuditSaveChangesInterceptor.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using SimpleModule.AuditLogs.Contracts;
 using SimpleModule.AuditLogs.Pipeline;
+using SimpleModule.Core.Entities;
 using SimpleModule.Core.Settings;
 using SimpleModule.Settings.Contracts;
 
@@ -78,6 +79,7 @@ public sealed class AuditSaveChangesInterceptor(
         var action = entry.State switch
         {
             EntityState.Added => AuditAction.Created,
+            EntityState.Modified when IsSoftDeleteChange(entry) => AuditAction.Deleted,
             EntityState.Modified => AuditAction.Updated,
             EntityState.Deleted => AuditAction.Deleted,
             _ => (AuditAction?)null,
@@ -143,4 +145,8 @@ public sealed class AuditSaveChangesInterceptor(
 
         return changeSet.Count > 0 ? JsonSerializer.Serialize(changeSet) : null;
     }
+
+    private static bool IsSoftDeleteChange(EntityEntry entry) =>
+        entry.Entity is ISoftDelete { IsDeleted: true }
+        && entry.Property(nameof(ISoftDelete.IsDeleted)).IsModified;
 }

--- a/tests/SimpleModule.Database.Tests/DomainEventInterceptorTests.cs
+++ b/tests/SimpleModule.Database.Tests/DomainEventInterceptorTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SimpleModule.Core.Entities;
+using SimpleModule.Core.Events;
+using SimpleModule.Database.Interceptors;
+
+namespace SimpleModule.Database.Tests;
+
+public sealed class DomainEventInterceptorTests
+{
+    [Fact]
+    public async Task Domain_Events_Dispatched_After_SaveChanges()
+    {
+        var eventBus = new TestEventBus();
+        await using var fixture = CreateFixture(eventBus);
+
+        var entity = new AggregateRootTestEntity { Name = "Test" };
+        entity.TriggerSomethingHappened();
+
+        fixture.Context.AggregateRoots.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        eventBus.PublishedEvents.Should().HaveCount(1);
+        eventBus.PublishedEvents[0].Should().BeOfType<SomethingHappenedEvent>();
+    }
+
+    [Fact]
+    public async Task Domain_Events_Cleared_After_Dispatch()
+    {
+        var eventBus = new TestEventBus();
+        await using var fixture = CreateFixture(eventBus);
+
+        var entity = new AggregateRootTestEntity { Name = "Test" };
+        entity.TriggerSomethingHappened();
+
+        fixture.Context.AggregateRoots.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.GetDomainEvents().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task No_Events_Dispatched_When_No_Domain_Events()
+    {
+        var eventBus = new TestEventBus();
+        await using var fixture = CreateFixture(eventBus);
+
+        var entity = new AggregateRootTestEntity { Name = "Test" };
+
+        fixture.Context.AggregateRoots.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        eventBus.PublishedEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Multiple_Events_From_Multiple_Entities_All_Dispatched()
+    {
+        var eventBus = new TestEventBus();
+        await using var fixture = CreateFixture(eventBus);
+
+        var entity1 = new AggregateRootTestEntity { Name = "First" };
+        entity1.TriggerSomethingHappened();
+        entity1.TriggerSomethingHappened();
+
+        var entity2 = new AggregateRootTestEntity { Name = "Second" };
+        entity2.TriggerSomethingHappened();
+
+        fixture.Context.AggregateRoots.AddRange(entity1, entity2);
+        await fixture.Context.SaveChangesAsync();
+
+        eventBus.PublishedEvents.Should().HaveCount(3);
+    }
+
+    private static TestFixture CreateFixture(IEventBus eventBus)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Database:DefaultConnection"] = "Data Source=:memory:",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(eventBus);
+        services.AddScoped<ISaveChangesInterceptor, DomainEventInterceptor>();
+        services.AddModuleDbContext<DomainEventTestDbContext>(config, "DomainEventTest");
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<DomainEventTestDbContext>();
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        return new TestFixture(provider, context);
+    }
+
+    private sealed class TestFixture(ServiceProvider provider, DomainEventTestDbContext context)
+        : IAsyncDisposable
+    {
+        public DomainEventTestDbContext Context => context;
+
+        public async ValueTask DisposeAsync()
+        {
+            await context.DisposeAsync();
+            await provider.DisposeAsync();
+        }
+    }
+}
+
+public sealed record SomethingHappenedEvent : IEvent;
+
+public class AggregateRootTestEntity : IHasDomainEvents
+{
+    private readonly List<IEvent> _events = [];
+
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public IReadOnlyList<IEvent> GetDomainEvents() => _events.AsReadOnly();
+    public void ClearDomainEvents() => _events.Clear();
+    public void TriggerSomethingHappened() => _events.Add(new SomethingHappenedEvent());
+}
+
+public sealed class TestEventBus : IEventBus
+{
+    public List<IEvent> PublishedEvents { get; } = [];
+
+    public Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+        where T : IEvent
+    {
+        PublishedEvents.Add(@event);
+        return Task.CompletedTask;
+    }
+
+    public void PublishInBackground<T>(T @event)
+        where T : IEvent
+    {
+        PublishedEvents.Add(@event);
+    }
+}
+
+public class DomainEventTestDbContext(
+    DbContextOptions<DomainEventTestDbContext> options,
+    IOptions<DatabaseOptions> dbOptions
+) : DbContext(options)
+{
+    public DbSet<AggregateRootTestEntity> AggregateRoots => Set<AggregateRootTestEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AggregateRootTestEntity>(e =>
+        {
+            e.HasKey(x => x.Id);
+        });
+
+        modelBuilder.ApplyModuleSchema("DomainEventTest", dbOptions.Value);
+    }
+}

--- a/tests/SimpleModule.Database.Tests/EntityChangeInterceptorTests.cs
+++ b/tests/SimpleModule.Database.Tests/EntityChangeInterceptorTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SimpleModule.Core.Entities;
+using SimpleModule.Database.Interceptors;
+
+namespace SimpleModule.Database.Tests;
+
+public sealed class EntityChangeInterceptorTests
+{
+    [Fact]
+    public async Task Handler_Invoked_On_Entity_Add()
+    {
+        var handler = new TestChangeHandler();
+        await using var fixture = CreateFixture(handler);
+
+        fixture.Context.ChangeTrackedEntities.Add(new ChangeTrackedTestEntity { Name = "Test" });
+        await fixture.Context.SaveChangesAsync();
+
+        handler.Changes.Should().HaveCount(1);
+        handler.Changes[0].ChangeType.Should().Be(EntityChangeType.Created);
+        handler.Changes[0].Entity.Name.Should().Be("Test");
+    }
+
+    [Fact]
+    public async Task Handler_Invoked_On_Entity_Update()
+    {
+        var handler = new TestChangeHandler();
+        await using var fixture = CreateFixture(handler);
+
+        var entity = new ChangeTrackedTestEntity { Name = "Test" };
+        fixture.Context.ChangeTrackedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+        handler.Changes.Clear();
+
+        entity.Name = "Updated";
+        await fixture.Context.SaveChangesAsync();
+
+        handler.Changes.Should().HaveCount(1);
+        handler.Changes[0].ChangeType.Should().Be(EntityChangeType.Updated);
+    }
+
+    [Fact]
+    public async Task Handler_Invoked_On_Entity_Delete()
+    {
+        var handler = new TestChangeHandler();
+        await using var fixture = CreateFixture(handler);
+
+        var entity = new ChangeTrackedTestEntity { Name = "Test" };
+        fixture.Context.ChangeTrackedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+        handler.Changes.Clear();
+
+        fixture.Context.ChangeTrackedEntities.Remove(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        handler.Changes.Should().HaveCount(1);
+        handler.Changes[0].ChangeType.Should().Be(EntityChangeType.Deleted);
+    }
+
+    [Fact]
+    public async Task No_Handler_No_Errors()
+    {
+        await using var fixture = CreateFixture(handler: null);
+
+        fixture.Context.ChangeTrackedEntities.Add(new ChangeTrackedTestEntity { Name = "Test" });
+        var act = () => fixture.Context.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private static TestFixture CreateFixture(TestChangeHandler? handler)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Database:DefaultConnection"] = "Data Source=:memory:",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+
+        if (handler is not null)
+        {
+            services.AddSingleton<IEntityChangeHandler<ChangeTrackedTestEntity>>(handler);
+        }
+
+        services.AddSingleton<ILogger<EntityChangeInterceptor>>(NullLogger<EntityChangeInterceptor>.Instance);
+        services.AddScoped<ISaveChangesInterceptor, EntityChangeInterceptor>();
+        services.AddModuleDbContext<ChangeTrackingTestDbContext>(config, "ChangeTrackingTest");
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<ChangeTrackingTestDbContext>();
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        return new TestFixture(provider, context);
+    }
+
+    private sealed class TestFixture(ServiceProvider provider, ChangeTrackingTestDbContext context)
+        : IAsyncDisposable
+    {
+        public ChangeTrackingTestDbContext Context => context;
+
+        public async ValueTask DisposeAsync()
+        {
+            await context.DisposeAsync();
+            await provider.DisposeAsync();
+        }
+    }
+}
+
+public class ChangeTrackedTestEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class TestChangeHandler : IEntityChangeHandler<ChangeTrackedTestEntity>
+{
+    public List<EntityChangeContext<ChangeTrackedTestEntity>> Changes { get; } = [];
+
+    public Task HandleAsync(
+        EntityChangeContext<ChangeTrackedTestEntity> context,
+        CancellationToken cancellationToken = default)
+    {
+        Changes.Add(context);
+        return Task.CompletedTask;
+    }
+}
+
+public class ChangeTrackingTestDbContext(
+    DbContextOptions<ChangeTrackingTestDbContext> options,
+    IOptions<DatabaseOptions> dbOptions
+) : DbContext(options)
+{
+    public DbSet<ChangeTrackedTestEntity> ChangeTrackedEntities => Set<ChangeTrackedTestEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ChangeTrackedTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.ApplyModuleSchema("ChangeTrackingTest", dbOptions.Value);
+    }
+}

--- a/tests/SimpleModule.Database.Tests/EntityInterceptorTests.cs
+++ b/tests/SimpleModule.Database.Tests/EntityInterceptorTests.cs
@@ -1,0 +1,448 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SimpleModule.Core.Entities;
+using SimpleModule.Database.Interceptors;
+
+namespace SimpleModule.Database.Tests;
+
+public sealed class EntityInterceptorTests
+{
+    private const string TestUserId = "user-123";
+
+    [Fact]
+    public async Task Added_Entity_Sets_CreatedAt_And_UpdatedAt()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new TimestampedTestEntity { Name = "Test" };
+
+        fixture.Context.TimestampedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        entity.UpdatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Modified_Entity_Sets_UpdatedAt_But_Not_CreatedAt()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new TimestampedTestEntity { Name = "Test" };
+
+        fixture.Context.TimestampedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        var originalCreatedAt = entity.CreatedAt;
+        await Task.Delay(10);
+
+        entity.Name = "Updated";
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedAt.Should().Be(originalCreatedAt);
+        entity.UpdatedAt.Should().BeAfter(originalCreatedAt);
+    }
+
+    [Fact]
+    public async Task Added_Auditable_Entity_Sets_CreatedBy_And_UpdatedBy()
+    {
+        await using var fixture = CreateFixture(TestUserId);
+        var entity = new AuditableTestEntity { Name = "Test" };
+
+        fixture.Context.AuditableEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedBy.Should().Be(TestUserId);
+        entity.UpdatedBy.Should().Be(TestUserId);
+    }
+
+    [Fact]
+    public async Task Modified_Auditable_Entity_Updates_UpdatedBy_Only()
+    {
+        await using var fixture = CreateFixture(TestUserId);
+        var entity = new AuditableTestEntity { Name = "Test" };
+
+        fixture.Context.AuditableEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.Name = "Updated";
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedBy.Should().Be(TestUserId);
+        entity.UpdatedBy.Should().Be(TestUserId);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDelete_Entity_Converts_To_Modified()
+    {
+        await using var fixture = CreateFixture(TestUserId);
+        var entity = new SoftDeleteTestEntity { Name = "Test" };
+
+        fixture.Context.SoftDeleteEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.SoftDeleteEntities.Remove(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.IsDeleted.Should().BeTrue();
+        entity.DeletedAt.Should().NotBeNull();
+        entity.DeletedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        entity.DeletedBy.Should().Be(TestUserId);
+    }
+
+    [Fact]
+    public async Task SoftDeleted_Entity_Excluded_By_Query_Filter()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new SoftDeleteTestEntity { Name = "Test" };
+
+        fixture.Context.SoftDeleteEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.SoftDeleteEntities.Remove(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        var results = await fixture.Context.SoftDeleteEntities.ToListAsync();
+        results.Should().BeEmpty();
+
+        // But it should still exist when ignoring query filters
+        var allResults = await fixture.Context.SoftDeleteEntities.IgnoreQueryFilters().ToListAsync();
+        allResults.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Added_Versioned_Entity_Gets_Version_1()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new VersionedTestEntity { Name = "Test" };
+
+        fixture.Context.VersionedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Modified_Versioned_Entity_Increments_Version()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new VersionedTestEntity { Name = "Test" };
+
+        fixture.Context.VersionedEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+        entity.Version.Should().Be(1);
+
+        entity.Name = "Updated";
+        await fixture.Context.SaveChangesAsync();
+        entity.Version.Should().Be(2);
+
+        entity.Name = "Updated Again";
+        await fixture.Context.SaveChangesAsync();
+        entity.Version.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Added_Entity_Gets_ConcurrencyStamp()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new ConcurrencyTestEntity { Name = "Test" };
+
+        fixture.Context.ConcurrencyEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.ConcurrencyStamp.Should().NotBeNullOrEmpty();
+        entity.ConcurrencyStamp.Should().HaveLength(32); // Guid without hyphens
+    }
+
+    [Fact]
+    public async Task Modified_Entity_Gets_New_ConcurrencyStamp()
+    {
+        await using var fixture = CreateFixture();
+        var entity = new ConcurrencyTestEntity { Name = "Test" };
+
+        fixture.Context.ConcurrencyEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        var originalStamp = entity.ConcurrencyStamp;
+
+        entity.Name = "Updated";
+        await fixture.Context.SaveChangesAsync();
+
+        entity.ConcurrencyStamp.Should().NotBe(originalStamp);
+    }
+
+    [Fact]
+    public async Task MultiTenant_Entity_Gets_TenantId_On_Add()
+    {
+        await using var fixture = CreateFixture(tenantId: "tenant-abc");
+        var entity = new MultiTenantTestEntity { Name = "Test" };
+
+        fixture.Context.MultiTenantEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.TenantId.Should().Be("tenant-abc");
+    }
+
+    [Fact]
+    public async Task MultiTenant_Query_Filter_Restricts_To_Current_Tenant()
+    {
+        // Uses a dedicated DbContext type to avoid EF Core model caching issues
+        // with the main EntityTestDbContext (which may be built without tenant context).
+        var tenantContext = new TestTenantContext("tenant-a");
+        await using var fixture = CreateMultiTenantFixture(tenantContext);
+
+        // Insert tenant-a entity via the interceptor
+        var entityA = new MultiTenantTestEntity { Name = "A" };
+        fixture.Context.MultiTenantEntities.Add(entityA);
+        await fixture.Context.SaveChangesAsync();
+
+        // Insert tenant-b entity directly via SQL to bypass the interceptor.
+        // The table name is from EF Core metadata, not user input.
+#pragma warning disable EF1003 // Test-only raw SQL with no user input
+        var tableName = fixture.Context.Model.FindEntityType(typeof(MultiTenantTestEntity))!.GetTableName();
+        await fixture.Context.Database.ExecuteSqlRawAsync(
+            "INSERT INTO \"" + tableName + "\" (\"Name\", \"TenantId\") VALUES ('B', 'tenant-b')");
+#pragma warning restore EF1003
+
+        // Query should only return tenant-a's entities
+        var results = await fixture.Context.MultiTenantEntities.ToListAsync();
+        results.Should().HaveCount(1);
+        results[0].Name.Should().Be("A");
+
+        // IgnoreQueryFilters should return all
+        var allResults = await fixture.Context.MultiTenantEntities.IgnoreQueryFilters().ToListAsync();
+        allResults.Should().HaveCount(2);
+    }
+
+    private static TestFixture<MultiTenantTestDbContext> CreateMultiTenantFixture(TestTenantContext tenantContext)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Database:DefaultConnection"] = "Data Source=:memory:",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        var httpContextAccessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+        services.AddSingleton<IHttpContextAccessor>(httpContextAccessor);
+        services.AddSingleton<ITenantContext>(tenantContext);
+        services.AddScoped<ISaveChangesInterceptor, EntityInterceptor>();
+        services.AddModuleDbContext<MultiTenantTestDbContext>(config, "MultiTenantTest");
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<MultiTenantTestDbContext>();
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        return new TestFixture<MultiTenantTestDbContext>(provider, context);
+    }
+
+    [Fact]
+    public async Task FullAuditableEntity_BaseClass_Works()
+    {
+        await using var fixture = CreateFixture(TestUserId);
+        var entity = new FullAuditableTestEntity { Name = "Test" };
+
+        fixture.Context.FullAuditableEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        entity.UpdatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        entity.CreatedBy.Should().Be(TestUserId);
+        entity.UpdatedBy.Should().Be(TestUserId);
+        entity.Version.Should().Be(1);
+        entity.ConcurrencyStamp.Should().NotBeNullOrEmpty();
+        entity.IsDeleted.Should().BeFalse();
+    }
+
+    private static TestFixture CreateFixture(string? userId = null, string? tenantId = null, TestTenantContext? tenantContext = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Database:DefaultConnection"] = "Data Source=:memory:",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var httpContext = new DefaultHttpContext();
+        if (userId is not null)
+        {
+            httpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    [new Claim(ClaimTypes.NameIdentifier, userId)],
+                    "TestAuth"
+                )
+            );
+        }
+
+        var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+        services.AddSingleton<IHttpContextAccessor>(httpContextAccessor);
+
+        var effectiveTenantContext = tenantContext ?? (tenantId is not null ? new TestTenantContext(tenantId) : null);
+        if (effectiveTenantContext is not null)
+        {
+            services.AddSingleton<ITenantContext>(effectiveTenantContext);
+        }
+
+        services.AddScoped<ISaveChangesInterceptor, EntityInterceptor>();
+        services.AddModuleDbContext<EntityTestDbContext>(config, "EntityTest");
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<EntityTestDbContext>();
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        return new TestFixture(provider, context);
+    }
+
+    private sealed class TestFixture(ServiceProvider provider, EntityTestDbContext context)
+        : IAsyncDisposable
+    {
+        public EntityTestDbContext Context => context;
+
+        public async ValueTask DisposeAsync()
+        {
+            await context.DisposeAsync();
+            await provider.DisposeAsync();
+        }
+    }
+
+    private sealed class TestFixture<T>(ServiceProvider provider, T context)
+        : IAsyncDisposable where T : DbContext
+    {
+        public T Context => context;
+
+        public async ValueTask DisposeAsync()
+        {
+            await context.DisposeAsync();
+            await provider.DisposeAsync();
+        }
+    }
+
+    private sealed record TestTenantContext(string? TenantId) : ITenantContext;
+}
+
+// --- Test entities ---
+
+public class TimestampedTestEntity : IHasCreationTime, IHasModificationTime
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public class AuditableTestEntity : IAuditable
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}
+
+public class SoftDeleteTestEntity : ISoftDelete, IHasCreationTime
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public string? DeletedBy { get; set; }
+}
+
+public class VersionedTestEntity : IVersioned
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Version { get; set; }
+}
+
+public class ConcurrencyTestEntity : IHasConcurrencyStamp
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}
+
+public class MultiTenantTestEntity : IMultiTenant
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+}
+
+public class FullAuditableTestEntity : FullAuditableEntity<int>
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+public class EntityTestDbContext(
+    DbContextOptions<EntityTestDbContext> options,
+    IOptions<DatabaseOptions> dbOptions,
+    ITenantContext? tenantContext = null
+) : DbContext(options)
+{
+    public DbSet<TimestampedTestEntity> TimestampedEntities => Set<TimestampedTestEntity>();
+    public DbSet<AuditableTestEntity> AuditableEntities => Set<AuditableTestEntity>();
+    public DbSet<SoftDeleteTestEntity> SoftDeleteEntities => Set<SoftDeleteTestEntity>();
+    public DbSet<VersionedTestEntity> VersionedEntities => Set<VersionedTestEntity>();
+    public DbSet<ConcurrencyTestEntity> ConcurrencyEntities => Set<ConcurrencyTestEntity>();
+    public DbSet<MultiTenantTestEntity> MultiTenantEntities => Set<MultiTenantTestEntity>();
+    public DbSet<FullAuditableTestEntity> FullAuditableEntities => Set<FullAuditableTestEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TimestampedTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.Entity<AuditableTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.Entity<SoftDeleteTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.Entity<VersionedTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.Entity<ConcurrencyTestEntity>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.Property(x => x.ConcurrencyStamp).HasMaxLength(50);
+        });
+        modelBuilder.Entity<MultiTenantTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.Entity<FullAuditableTestEntity>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.Property(x => x.Id).ValueGeneratedOnAdd();
+            e.Property(x => x.ConcurrencyStamp).HasMaxLength(50);
+        });
+
+        modelBuilder.ApplyModuleSchema("EntityTest", dbOptions.Value);
+
+        if (tenantContext is not null)
+        {
+            modelBuilder.ApplyMultiTenantFilters(tenantContext);
+        }
+    }
+}
+
+public class MultiTenantTestDbContext(
+    DbContextOptions<MultiTenantTestDbContext> options,
+    IOptions<DatabaseOptions> dbOptions,
+    ITenantContext tenantContext
+) : DbContext(options)
+{
+    public DbSet<MultiTenantTestEntity> MultiTenantEntities => Set<MultiTenantTestEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MultiTenantTestEntity>(e => e.HasKey(x => x.Id));
+        modelBuilder.ApplyModuleSchema("MultiTenantTest", dbOptions.Value);
+        modelBuilder.ApplyMultiTenantFilters(tenantContext);
+    }
+}


### PR DESCRIPTION
Introduce layered entity interfaces and convenience base classes in
SimpleModule.Core that modules can adopt for automatic field population:

Interfaces (SimpleModule.Core/Entities/):
- IHasCreationTime, IHasModificationTime — auto-set timestamps
- IAuditable — timestamps + CreatedBy/UpdatedBy from current user
- ISoftDelete — intercepts hard delete, converts to soft delete
- IVersioned — auto-incrementing version number
- IHasConcurrencyStamp — random concurrency stamp
- IHasExtraProperties — JSON key-value bag
- IMultiTenant — auto-set tenant ID from ITenantContext
- IHasDomainEvents — domain event collection + auto-dispatch

Base classes (SimpleModule.Core/Entities/):
- Entity — timestamps + concurrency
- AuditableEntity — + CreatedBy/UpdatedBy
- FullAuditableEntity — + soft delete + versioning
- MultiTenantFullAuditableEntity — + tenant + extra properties
- AuditableAggregateRoot — + domain events

Interceptors (SimpleModule.Database/Interceptors/):
- EntityInterceptor — populates fields based on interfaces
- DomainEventInterceptor — dispatches domain events after save
- EntityChangeInterceptor — invokes IEntityChangeHandler after save

Conventions auto-applied via ApplyModuleSchema():
- ISoftDelete → global query filter
- IHasConcurrencyStamp/IVersioned → concurrency tokens
- IHasExtraProperties → JSON column

Also updates AuditSaveChangesInterceptor to detect soft-delete changes
and log them as Deleted instead of Updated.