### PR TITLE
Update getting started links and add marketplace section to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -54,7 +54,7 @@
             </svg>
             GitHub
           </a>
-          <a href="/getting-started/introduction" class="btn-primary btn-sm no-underline"
+          <a href="https://docs.simplemodule.dev/getting-started/quick-start" class="btn-primary btn-sm no-underline"
             >Get Started</a
           >
         </div>
@@ -82,7 +82,7 @@
           at build time. React 19 + Inertia.js frontend. Full-stack type safety.
         </p>
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a href="/getting-started/introduction" class="btn-primary btn-lg no-underline">
+          <a href="https://docs.simplemodule.dev/getting-started/quick-start" class="btn-primary btn-lg no-underline">
             Get Started
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
@@ -421,6 +421,22 @@
             <p class="text-xs text-text-secondary">Dynamic page composition</p>
           </div>
         </div>
+
+        <div class="text-center mt-10">
+          <p class="text-text-secondary text-lg mb-4">
+            ...and many more to come!
+          </p>
+          <a
+            href="https://docs.simplemodule.dev/marketplace"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-border bg-surface text-text-secondary text-sm font-semibold no-underline hover:border-primary hover:text-text transition-colors"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z" />
+            </svg>
+            Module Marketplace
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary-subtle text-primary">Coming Soon</span>
+          </a>
+        </div>
       </div>
     </section>
 
@@ -565,7 +581,7 @@
           Start building your modular .NET application today. Open source, MIT licensed.
         </p>
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a href="/getting-started/introduction" class="btn-primary btn-lg no-underline">
+          <a href="https://docs.simplemodule.dev/getting-started/quick-start" class="btn-primary btn-lg no-underline">
             Read the Docs
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />


### PR DESCRIPTION
- Update all "Get Started" and "Read the Docs" links to point to
  https://docs.simplemodule.dev/getting-started/quick-start
- Add "and many more to come" message below module cards
- Add Module Marketplace link with "Coming Soon" badge