### PR TITLE
Add tenant management module with multi-host resolution

### DIFF
--- a/SimpleModule.slnx
+++ b/SimpleModule.slnx
@@ -84,6 +84,11 @@
         <Project Path="modules/Marketplace/src/SimpleModule.Marketplace/SimpleModule.Marketplace.csproj" />
         <Project Path="modules/Marketplace/tests/SimpleModule.Marketplace.Tests/SimpleModule.Marketplace.Tests.csproj" />
     </Folder>
+    <Folder Name="/modules/Tenants/">
+        <Project Path="modules/Tenants/src/SimpleModule.Tenants.Contracts/SimpleModule.Tenants.Contracts.csproj" />
+        <Project Path="modules/Tenants/src/SimpleModule.Tenants/SimpleModule.Tenants.csproj" />
+        <Project Path="modules/Tenants/tests/SimpleModule.Tenants.Tests/SimpleModule.Tenants.Tests.csproj" />
+    </Folder>
     <Folder Name="/template/">
         <Project Path="template/SimpleModule.Host/SimpleModule.Host.csproj" />
     </Folder>

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/OverrideType.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/OverrideType.cs
@@ -4,4 +4,5 @@ public enum OverrideType
 {
     User = 0,
     Role = 1,
+    Tenant = 2,
 }

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
@@ -17,7 +17,9 @@ public sealed partial class FeatureFlagService(
     IServiceProvider serviceProvider
 ) : IFeatureFlagContracts, IFeatureFlagService
 {
-    private ITenantContext? TenantContext => serviceProvider.GetService<ITenantContext>();
+    private readonly Lazy<ITenantContext?> _tenantContext = new(
+        () => serviceProvider.GetService<ITenantContext>()
+    );
     private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
     private const string AllFlagDataCacheKey = "ff:all-data";
 
@@ -321,7 +323,7 @@ public sealed partial class FeatureFlagService(
             }
         }
 
-        var currentTenantId = TenantContext?.TenantId;
+        var currentTenantId = _tenantContext.Value?.TenantId;
         if (currentTenantId is not null
             && data.TenantOverrides.TryGetValue(currentTenantId, out var tenantEnabled))
         {

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SimpleModule.Core.Entities;
 using SimpleModule.Core.FeatureFlags;
 using SimpleModule.FeatureFlags.Contracts;
 using SimpleModule.FeatureFlags.Entities;
@@ -11,16 +13,19 @@ public sealed partial class FeatureFlagService(
     FeatureFlagsDbContext db,
     IFeatureFlagRegistry registry,
     IMemoryCache cache,
-    ILogger<FeatureFlagService> logger
+    ILogger<FeatureFlagService> logger,
+    IServiceProvider serviceProvider
 ) : IFeatureFlagContracts, IFeatureFlagService
 {
+    private ITenantContext? TenantContext => serviceProvider.GetService<ITenantContext>();
     private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
     private const string AllFlagDataCacheKey = "ff:all-data";
 
     private sealed record FlagData(
         bool IsEnabled,
         Dictionary<string, bool> UserOverrides,
-        Dictionary<string, bool> RoleOverrides
+        Dictionary<string, bool> RoleOverrides,
+        Dictionary<string, bool> TenantOverrides
     );
 
     public async Task<bool> IsEnabledAsync(
@@ -273,23 +278,28 @@ public sealed partial class FeatureFlagService(
     {
         var userOverrides = new Dictionary<string, bool>(StringComparer.Ordinal);
         var roleOverrides = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var tenantOverrides = new Dictionary<string, bool>(StringComparer.Ordinal);
 
         foreach (var o in overrides)
         {
-            if (o.OverrideType == OverrideType.User)
+            switch (o.OverrideType)
             {
-                userOverrides[o.OverrideValue] = o.IsEnabled;
-            }
-            else
-            {
-                roleOverrides[o.OverrideValue] = o.IsEnabled;
+                case OverrideType.User:
+                    userOverrides[o.OverrideValue] = o.IsEnabled;
+                    break;
+                case OverrideType.Role:
+                    roleOverrides[o.OverrideValue] = o.IsEnabled;
+                    break;
+                case OverrideType.Tenant:
+                    tenantOverrides[o.OverrideValue] = o.IsEnabled;
+                    break;
             }
         }
 
-        return new FlagData(isEnabled, userOverrides, roleOverrides);
+        return new FlagData(isEnabled, userOverrides, roleOverrides, tenantOverrides);
     }
 
-    private static bool ResolveFlagState(
+    private bool ResolveFlagState(
         FlagData data,
         string? userId,
         IEnumerable<string>? roles
@@ -309,6 +319,13 @@ public sealed partial class FeatureFlagService(
                     return roleEnabled;
                 }
             }
+        }
+
+        var currentTenantId = TenantContext?.TenantId;
+        if (currentTenantId is not null
+            && data.TenantOverrides.TryGetValue(currentTenantId, out var tenantEnabled))
+        {
+            return tenantEnabled;
         }
 
         return data.IsEnabled;

--- a/modules/FeatureFlags/tests/SimpleModule.FeatureFlags.Tests/Unit/FeatureFlagServiceTests.cs
+++ b/modules/FeatureFlags/tests/SimpleModule.FeatureFlags.Tests/Unit/FeatureFlagServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using SimpleModule.Core.FeatureFlags;
@@ -54,7 +55,8 @@ public sealed class FeatureFlagServiceTests : IDisposable
             _db,
             _registry,
             _cache,
-            NullLogger<FeatureFlagService>.Instance
+            NullLogger<FeatureFlagService>.Instance,
+            new ServiceCollection().BuildServiceProvider()
         );
     }
 
@@ -78,7 +80,8 @@ public sealed class FeatureFlagServiceTests : IDisposable
             _db,
             _registry,
             freshCache,
-            NullLogger<FeatureFlagService>.Instance
+            NullLogger<FeatureFlagService>.Instance,
+            new ServiceCollection().BuildServiceProvider()
         );
     }
 

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/AddTenantHostRequest.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/AddTenantHostRequest.cs
@@ -1,0 +1,6 @@
+namespace SimpleModule.Tenants.Contracts;
+
+public class AddTenantHostRequest
+{
+    public string HostName { get; set; } = string.Empty;
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/CreateTenantRequest.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/CreateTenantRequest.cs
@@ -1,0 +1,12 @@
+namespace SimpleModule.Tenants.Contracts;
+
+public class CreateTenantRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string? AdminEmail { get; set; }
+    public string? EditionName { get; set; }
+    public string? ConnectionString { get; set; }
+    public DateTimeOffset? ValidUpTo { get; set; }
+    public List<string>? Hosts { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantCreatedEvent.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantCreatedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Tenants.Contracts.Events;
+
+public sealed record TenantCreatedEvent(TenantId TenantId, string Name, string Slug) : IEvent;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantHostAddedEvent.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantHostAddedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Tenants.Contracts.Events;
+
+public sealed record TenantHostAddedEvent(TenantId TenantId, string HostName) : IEvent;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantHostRemovedEvent.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantHostRemovedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Tenants.Contracts.Events;
+
+public sealed record TenantHostRemovedEvent(TenantId TenantId, string HostName) : IEvent;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantStatusChangedEvent.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantStatusChangedEvent.cs
@@ -1,0 +1,9 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Tenants.Contracts.Events;
+
+public sealed record TenantStatusChangedEvent(
+    TenantId TenantId,
+    TenantStatus OldStatus,
+    TenantStatus NewStatus
+) : IEvent;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantUpdatedEvent.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Events/TenantUpdatedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Tenants.Contracts.Events;
+
+public sealed record TenantUpdatedEvent(TenantId TenantId, string Name) : IEvent;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/ITenantContracts.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/ITenantContracts.cs
@@ -1,0 +1,15 @@
+namespace SimpleModule.Tenants.Contracts;
+
+public interface ITenantContracts
+{
+    Task<IEnumerable<Tenant>> GetAllTenantsAsync();
+    Task<Tenant?> GetTenantByIdAsync(TenantId id);
+    Task<Tenant?> GetTenantBySlugAsync(string slug);
+    Task<Tenant?> GetTenantByHostNameAsync(string hostName);
+    Task<Tenant> CreateTenantAsync(CreateTenantRequest request);
+    Task<Tenant> UpdateTenantAsync(TenantId id, UpdateTenantRequest request);
+    Task DeleteTenantAsync(TenantId id);
+    Task<Tenant> ChangeStatusAsync(TenantId id, TenantStatus status);
+    Task<TenantHost> AddHostAsync(TenantId tenantId, AddTenantHostRequest request);
+    Task RemoveHostAsync(TenantId tenantId, TenantHostId hostId);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/SimpleModule.Tenants.Contracts.csproj
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/SimpleModule.Tenants.Contracts.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Vogen" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/Tenant.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/Tenant.cs
@@ -1,0 +1,19 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Tenants.Contracts;
+
+[Dto]
+public class Tenant
+{
+    public TenantId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public TenantStatus Status { get; set; }
+    public string? AdminEmail { get; set; }
+    public string? EditionName { get; set; }
+    public string? ConnectionString { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public DateTimeOffset? ValidUpTo { get; set; }
+    public List<TenantHost> Hosts { get; set; } = [];
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHost.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHost.cs
@@ -1,0 +1,12 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Tenants.Contracts;
+
+[Dto]
+public class TenantHost
+{
+    public TenantHostId Id { get; set; }
+    public TenantId TenantId { get; set; }
+    public string HostName { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHostId.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHostId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Tenants.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct TenantHostId;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantId.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Tenants.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct TenantId;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantStatus.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantStatus.cs
@@ -1,0 +1,8 @@
+namespace SimpleModule.Tenants.Contracts;
+
+public enum TenantStatus
+{
+    Active = 0,
+    Suspended = 1,
+    Inactive = 2,
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantsPermissions.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantsPermissions.cs
@@ -1,0 +1,13 @@
+using SimpleModule.Core.Authorization;
+
+namespace SimpleModule.Tenants.Contracts;
+
+public sealed class TenantsPermissions : IModulePermissions
+{
+    public const string View = "Tenants.View";
+    public const string Create = "Tenants.Create";
+    public const string Update = "Tenants.Update";
+    public const string Delete = "Tenants.Delete";
+    public const string ChangeStatus = "Tenants.ChangeStatus";
+    public const string ManageHosts = "Tenants.ManageHosts";
+}

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/UpdateTenantRequest.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/UpdateTenantRequest.cs
@@ -1,0 +1,10 @@
+namespace SimpleModule.Tenants.Contracts;
+
+public class UpdateTenantRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? AdminEmail { get; set; }
+    public string? EditionName { get; set; }
+    public string? ConnectionString { get; set; }
+    public DateTimeOffset? ValidUpTo { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/DeleteTenantFeatureEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/DeleteTenantFeatureEndpoint.cs
@@ -22,9 +22,7 @@ public class DeleteTenantFeatureEndpoint : IEndpoint
                         return Results.NotFound();
                     }
 
-                    var tenantIdStr = id.Value.ToString(
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
+                    var tenantIdStr = id.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
                     var overrides = await featureFlags.GetOverridesAsync(flagName);
                     var tenantOverride = overrides.FirstOrDefault(o =>
                         o.OverrideType == OverrideType.Tenant

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/DeleteTenantFeatureEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/DeleteTenantFeatureEndpoint.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.FeatureFlags.Contracts;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.TenantFeatures;
+
+public class DeleteTenantFeatureEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapDelete(
+                "/{id}/features/{flagName}",
+                async (TenantId id, string flagName, HttpContext context) =>
+                {
+                    var featureFlags = context.RequestServices.GetService<IFeatureFlagContracts>();
+                    if (featureFlags is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    var tenantIdStr = id.Value.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture
+                    );
+                    var overrides = await featureFlags.GetOverridesAsync(flagName);
+                    var tenantOverride = overrides.FirstOrDefault(o =>
+                        o.OverrideType == OverrideType.Tenant
+                        && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
+                    );
+
+                    if (tenantOverride is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    await featureFlags.DeleteOverrideAsync(tenantOverride.Id);
+                    return Results.NoContent();
+                }
+            )
+            .RequirePermission(TenantsPermissions.Update);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
@@ -23,22 +23,8 @@ public class GetTenantFeaturesEndpoint : IEndpoint
                     }
 
                     var flags = (await featureFlags.GetAllFlagsAsync()).ToList();
-                    var tenantIdStr = id.Value.ToString(
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
-
-                    var overrideTasks = flags
-                        .Where(f => !f.IsDeprecated)
-                        .Select(f => featureFlags.GetOverridesAsync(f.Name));
-                    var allOverrides = await Task.WhenAll(overrideTasks);
-
-                    var tenantOverrides = allOverrides
-                        .SelectMany(o => o)
-                        .Where(o =>
-                            o.OverrideType == OverrideType.Tenant
-                            && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
-                        )
-                        .ToList();
+                    var tenantOverrides = await TenantFeatureHelper.GetOverridesForTenantAsync(
+                        featureFlags, flags, id);
 
                     return Results.Ok(new TenantFeaturesResponse(flags, tenantOverrides));
                 }

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.FeatureFlags.Contracts;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.TenantFeatures;
+
+public class GetTenantFeaturesEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(
+                "/{id}/features",
+                async (TenantId id, HttpContext context) =>
+                {
+                    var featureFlags = context.RequestServices.GetService<IFeatureFlagContracts>();
+                    if (featureFlags is null)
+                    {
+                        return Results.Ok(
+                            new TenantFeaturesResponse([], [])
+                        );
+                    }
+
+                    var flags = await featureFlags.GetAllFlagsAsync();
+                    var allOverrides = new List<FeatureFlagOverride>();
+                    var tenantIdStr = id.Value.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture
+                    );
+
+                    foreach (var flag in flags)
+                    {
+                        var overrides = await featureFlags.GetOverridesAsync(flag.Name);
+                        allOverrides.AddRange(
+                            overrides.Where(o =>
+                                o.OverrideType == OverrideType.Tenant
+                                && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
+                            )
+                        );
+                    }
+
+                    return Results.Ok(new TenantFeaturesResponse(flags, allOverrides));
+                }
+            )
+            .RequirePermission(TenantsPermissions.View);
+}
+
+public sealed record TenantFeaturesResponse(
+    IEnumerable<FeatureFlag> Flags,
+    IEnumerable<FeatureFlagOverride> TenantOverrides
+);

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/GetTenantFeaturesEndpoint.cs
@@ -19,29 +19,28 @@ public class GetTenantFeaturesEndpoint : IEndpoint
                     var featureFlags = context.RequestServices.GetService<IFeatureFlagContracts>();
                     if (featureFlags is null)
                     {
-                        return Results.Ok(
-                            new TenantFeaturesResponse([], [])
-                        );
+                        return Results.Ok(new TenantFeaturesResponse([], []));
                     }
 
-                    var flags = await featureFlags.GetAllFlagsAsync();
-                    var allOverrides = new List<FeatureFlagOverride>();
+                    var flags = (await featureFlags.GetAllFlagsAsync()).ToList();
                     var tenantIdStr = id.Value.ToString(
                         System.Globalization.CultureInfo.InvariantCulture
                     );
 
-                    foreach (var flag in flags)
-                    {
-                        var overrides = await featureFlags.GetOverridesAsync(flag.Name);
-                        allOverrides.AddRange(
-                            overrides.Where(o =>
-                                o.OverrideType == OverrideType.Tenant
-                                && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
-                            )
-                        );
-                    }
+                    var overrideTasks = flags
+                        .Where(f => !f.IsDeprecated)
+                        .Select(f => featureFlags.GetOverridesAsync(f.Name));
+                    var allOverrides = await Task.WhenAll(overrideTasks);
 
-                    return Results.Ok(new TenantFeaturesResponse(flags, allOverrides));
+                    var tenantOverrides = allOverrides
+                        .SelectMany(o => o)
+                        .Where(o =>
+                            o.OverrideType == OverrideType.Tenant
+                            && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
+                        )
+                        .ToList();
+
+                    return Results.Ok(new TenantFeaturesResponse(flags, tenantOverrides));
                 }
             )
             .RequirePermission(TenantsPermissions.View);

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/SetTenantFeatureEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/SetTenantFeatureEndpoint.cs
@@ -22,15 +22,12 @@ public class SetTenantFeatureEndpoint : IEndpoint
                         return Results.NotFound();
                     }
 
-                    var tenantIdStr = id.Value.ToString(
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
                     var result = await featureFlags.SetOverrideAsync(
                         flagName,
                         new SetOverrideRequest
                         {
                             OverrideType = OverrideType.Tenant,
-                            OverrideValue = tenantIdStr,
+                            OverrideValue = id.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
                             IsEnabled = request.IsEnabled,
                         }
                     );

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/SetTenantFeatureEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/SetTenantFeatureEndpoint.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.FeatureFlags.Contracts;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.TenantFeatures;
+
+public class SetTenantFeatureEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPut(
+                "/{id}/features/{flagName}",
+                async (TenantId id, string flagName, SetTenantFeatureRequest request, HttpContext context) =>
+                {
+                    var featureFlags = context.RequestServices.GetService<IFeatureFlagContracts>();
+                    if (featureFlags is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    var tenantIdStr = id.Value.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture
+                    );
+                    var result = await featureFlags.SetOverrideAsync(
+                        flagName,
+                        new SetOverrideRequest
+                        {
+                            OverrideType = OverrideType.Tenant,
+                            OverrideValue = tenantIdStr,
+                            IsEnabled = request.IsEnabled,
+                        }
+                    );
+
+                    return Results.Ok(result);
+                }
+            )
+            .RequirePermission(TenantsPermissions.Update);
+}
+
+public class SetTenantFeatureRequest
+{
+    public bool IsEnabled { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/TenantFeatureHelper.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/TenantFeatureHelper.cs
@@ -1,0 +1,25 @@
+using SimpleModule.FeatureFlags.Contracts;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.TenantFeatures;
+
+internal static class TenantFeatureHelper
+{
+    public static async Task<List<FeatureFlagOverride>> GetOverridesForTenantAsync(
+        IFeatureFlagContracts featureFlags,
+        IEnumerable<FeatureFlag> flags,
+        TenantId tenantId)
+    {
+        var tenantIdStr = tenantId.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var overrideTasks = flags
+            .Where(f => !f.IsDeprecated)
+            .Select(f => featureFlags.GetOverridesAsync(f.Name));
+        var allOverrides = await Task.WhenAll(overrideTasks);
+        return allOverrides
+            .SelectMany(o => o)
+            .Where(o =>
+                o.OverrideType == OverrideType.Tenant
+                && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal))
+            .ToList();
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/AddHostEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/AddHostEndpoint.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Exceptions;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class AddHostEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPost(
+                "/{id}/hosts",
+                async (TenantId id, AddTenantHostRequest request, ITenantContracts contracts) =>
+                {
+                    var validation = AddHostRequestValidator.Validate(request);
+                    if (!validation.IsValid)
+                    {
+                        throw new ValidationException(validation.Errors);
+                    }
+
+                    var host = await contracts.AddHostAsync(id, request);
+                    return TypedResults.Created(
+                        $"{TenantsConstants.RoutePrefix}/{id}/hosts/{host.Id}",
+                        host
+                    );
+                }
+            )
+            .RequirePermission(TenantsPermissions.ManageHosts);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/AddHostRequestValidator.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/AddHostRequestValidator.cs
@@ -1,0 +1,21 @@
+using SimpleModule.Core.Validation;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public static class AddHostRequestValidator
+{
+    public static ValidationResult Validate(AddTenantHostRequest request) =>
+        new ValidationBuilder()
+            .AddErrorIf(
+                string.IsNullOrWhiteSpace(request.HostName),
+                "HostName",
+                "Host name is required."
+            )
+            .AddErrorIf(
+                !string.IsNullOrWhiteSpace(request.HostName) && request.HostName.Length > 512,
+                "HostName",
+                "Host name must not exceed 512 characters."
+            )
+            .Build();
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/ChangeStatusEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/ChangeStatusEndpoint.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class ChangeStatusEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPut(
+                "/{id}/status",
+                (TenantId id, ChangeStatusRequest request, ITenantContracts contracts) =>
+                    CrudEndpoints.Update(() => contracts.ChangeStatusAsync(id, request.Status))
+            )
+            .RequirePermission(TenantsPermissions.ChangeStatus);
+}
+
+public class ChangeStatusRequest
+{
+    public TenantStatus Status { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/CreateEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/CreateEndpoint.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Core.Exceptions;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class CreateEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPost(
+                "/",
+                (CreateTenantRequest request, ITenantContracts contracts) =>
+                {
+                    var validation = CreateRequestValidator.Validate(request);
+                    if (!validation.IsValid)
+                    {
+                        throw new ValidationException(validation.Errors);
+                    }
+
+                    return CrudEndpoints.Create(
+                        () => contracts.CreateTenantAsync(request),
+                        t => $"{TenantsConstants.RoutePrefix}/{t.Id}"
+                    );
+                }
+            )
+            .RequirePermission(TenantsPermissions.Create);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/CreateRequestValidator.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/CreateRequestValidator.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+using SimpleModule.Core.Validation;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public static partial class CreateRequestValidator
+{
+    public static ValidationResult Validate(CreateTenantRequest request) =>
+        new ValidationBuilder()
+            .AddErrorIf(
+                string.IsNullOrWhiteSpace(request.Name),
+                "Name",
+                "Tenant name is required."
+            )
+            .AddErrorIf(
+                string.IsNullOrWhiteSpace(request.Slug),
+                "Slug",
+                "Tenant slug is required."
+            )
+            .AddErrorIf(
+                !string.IsNullOrWhiteSpace(request.Slug) && !SlugPattern().IsMatch(request.Slug),
+                "Slug",
+                "Slug must contain only lowercase letters, numbers, and hyphens."
+            )
+            .AddErrorIf(
+                !string.IsNullOrWhiteSpace(request.AdminEmail)
+                    && !request.AdminEmail.Contains('@', StringComparison.Ordinal),
+                "AdminEmail",
+                "Invalid email format."
+            )
+            .Build();
+
+    [GeneratedRegex(@"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")]
+    private static partial Regex SlugPattern();
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/DeleteEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/DeleteEndpoint.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class DeleteEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapDelete(
+                "/{id}",
+                (TenantId id, ITenantContracts contracts) =>
+                    CrudEndpoints.Delete(() => contracts.DeleteTenantAsync(id))
+            )
+            .RequirePermission(TenantsPermissions.Delete);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/GetAllEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/GetAllEndpoint.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class GetAllEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet("/", (ITenantContracts contracts) => CrudEndpoints.GetAll(contracts.GetAllTenantsAsync))
+            .RequirePermission(TenantsPermissions.View);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/GetByIdEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/GetByIdEndpoint.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class GetByIdEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(
+                "/{id}",
+                (TenantId id, ITenantContracts contracts) =>
+                    CrudEndpoints.GetById(() => contracts.GetTenantByIdAsync(id))
+            )
+            .RequirePermission(TenantsPermissions.View);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/RemoveHostEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/RemoveHostEndpoint.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class RemoveHostEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapDelete(
+                "/{id}/hosts/{hostId}",
+                async (TenantId id, TenantHostId hostId, ITenantContracts contracts) =>
+                {
+                    await contracts.RemoveHostAsync(id, hostId);
+                    return TypedResults.NoContent();
+                }
+            )
+            .RequirePermission(TenantsPermissions.ManageHosts);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/RemoveHostEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/RemoveHostEndpoint.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using SimpleModule.Core;
 using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
 using SimpleModule.Tenants.Contracts;
 
 namespace SimpleModule.Tenants.Endpoints.Tenants;
@@ -12,11 +12,8 @@ public class RemoveHostEndpoint : IEndpoint
     public void Map(IEndpointRouteBuilder app) =>
         app.MapDelete(
                 "/{id}/hosts/{hostId}",
-                async (TenantId id, TenantHostId hostId, ITenantContracts contracts) =>
-                {
-                    await contracts.RemoveHostAsync(id, hostId);
-                    return TypedResults.NoContent();
-                }
+                (TenantId id, TenantHostId hostId, ITenantContracts contracts) =>
+                    CrudEndpoints.Delete(() => contracts.RemoveHostAsync(id, hostId))
             )
             .RequirePermission(TenantsPermissions.ManageHosts);
 }

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/UpdateEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/UpdateEndpoint.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Endpoints;
+using SimpleModule.Core.Exceptions;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public class UpdateEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPut(
+                "/{id}",
+                (TenantId id, UpdateTenantRequest request, ITenantContracts contracts) =>
+                {
+                    var validation = UpdateRequestValidator.Validate(request);
+                    if (!validation.IsValid)
+                    {
+                        throw new ValidationException(validation.Errors);
+                    }
+
+                    return CrudEndpoints.Update(() => contracts.UpdateTenantAsync(id, request));
+                }
+            )
+            .RequirePermission(TenantsPermissions.Update);
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/UpdateRequestValidator.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/Tenants/UpdateRequestValidator.cs
@@ -1,0 +1,22 @@
+using SimpleModule.Core.Validation;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Endpoints.Tenants;
+
+public static class UpdateRequestValidator
+{
+    public static ValidationResult Validate(UpdateTenantRequest request) =>
+        new ValidationBuilder()
+            .AddErrorIf(
+                string.IsNullOrWhiteSpace(request.Name),
+                "Name",
+                "Tenant name is required."
+            )
+            .AddErrorIf(
+                !string.IsNullOrWhiteSpace(request.AdminEmail)
+                    && !request.AdminEmail.Contains('@', StringComparison.Ordinal),
+                "AdminEmail",
+                "Invalid email format."
+            )
+            .Build();
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Entities/TenantEntity.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Entities/TenantEntity.cs
@@ -1,0 +1,16 @@
+using SimpleModule.Core.Entities;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Entities;
+
+public sealed class TenantEntity : AuditableEntity<TenantId>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public TenantStatus Status { get; set; }
+    public string? AdminEmail { get; set; }
+    public string? EditionName { get; set; }
+    public string? ConnectionString { get; set; }
+    public DateTimeOffset? ValidUpTo { get; set; }
+    public ICollection<TenantHostEntity> Hosts { get; set; } = [];
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Entities/TenantHostEntity.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Entities/TenantHostEntity.cs
@@ -1,0 +1,12 @@
+using SimpleModule.Core.Entities;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Entities;
+
+public sealed class TenantHostEntity : Entity<TenantHostId>
+{
+    public TenantId TenantId { get; set; }
+    public string HostName { get; set; } = string.Empty;
+    public bool IsActive { get; set; } = true;
+    public TenantEntity Tenant { get; set; } = null!;
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
@@ -1,0 +1,73 @@
+using Bogus;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Entities;
+
+namespace SimpleModule.Tenants.EntityConfigurations;
+
+public sealed class TenantConfiguration : IEntityTypeConfiguration<TenantEntity>
+{
+    public void Configure(EntityTypeBuilder<TenantEntity> builder)
+    {
+        builder.HasKey(t => t.Id);
+        builder.Property(t => t.Id).ValueGeneratedOnAdd();
+        builder.Property(t => t.Name).IsRequired().HasMaxLength(256);
+        builder.Property(t => t.Slug).IsRequired().HasMaxLength(128);
+        builder.HasIndex(t => t.Slug).IsUnique();
+        builder.Property(t => t.AdminEmail).HasMaxLength(256);
+        builder.Property(t => t.EditionName).HasMaxLength(128);
+        builder.Property(t => t.ConnectionString).HasMaxLength(1024);
+
+        builder
+            .HasMany(t => t.Hosts)
+            .WithOne(h => h.Tenant)
+            .HasForeignKey(h => h.TenantId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasData(GenerateSeedTenants());
+    }
+
+    private static TenantEntity[] GenerateSeedTenants()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        return
+        [
+            new TenantEntity
+            {
+                Id = TenantId.From(1),
+                Name = "Acme Corporation",
+                Slug = "acme",
+                Status = TenantStatus.Active,
+                AdminEmail = "admin@acme.com",
+                EditionName = "Enterprise",
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-acme",
+            },
+            new TenantEntity
+            {
+                Id = TenantId.From(2),
+                Name = "Contoso Ltd",
+                Slug = "contoso",
+                Status = TenantStatus.Active,
+                AdminEmail = "admin@contoso.com",
+                EditionName = "Standard",
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-contoso",
+            },
+            new TenantEntity
+            {
+                Id = TenantId.From(3),
+                Name = "Suspended Corp",
+                Slug = "suspended-corp",
+                Status = TenantStatus.Suspended,
+                AdminEmail = "admin@suspended.com",
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-suspended",
+            },
+        ];
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
@@ -1,4 +1,3 @@
-using Bogus;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SimpleModule.Tenants.Contracts;

--- a/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantHostConfiguration.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantHostConfiguration.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Entities;
+
+namespace SimpleModule.Tenants.EntityConfigurations;
+
+public sealed class TenantHostConfiguration : IEntityTypeConfiguration<TenantHostEntity>
+{
+    public void Configure(EntityTypeBuilder<TenantHostEntity> builder)
+    {
+        builder.HasKey(h => h.Id);
+        builder.Property(h => h.Id).ValueGeneratedOnAdd();
+        builder.Property(h => h.HostName).IsRequired().HasMaxLength(512);
+        builder.HasIndex(h => h.HostName).IsUnique();
+
+        builder.HasData(GenerateSeedHosts());
+    }
+
+    private static TenantHostEntity[] GenerateSeedHosts()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        return
+        [
+            new TenantHostEntity
+            {
+                Id = TenantHostId.From(1),
+                TenantId = TenantId.From(1),
+                HostName = "acme.localhost",
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-host-1",
+            },
+            new TenantHostEntity
+            {
+                Id = TenantHostId.From(2),
+                TenantId = TenantId.From(1),
+                HostName = "acme.local",
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-host-2",
+            },
+            new TenantHostEntity
+            {
+                Id = TenantHostId.From(3),
+                TenantId = TenantId.From(2),
+                HostName = "contoso.localhost",
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ConcurrencyStamp = "seed-host-3",
+            },
+        ];
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Middleware/TenantResolutionMiddleware.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Middleware/TenantResolutionMiddleware.cs
@@ -1,0 +1,126 @@
+using System.Data.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Resolvers;
+
+namespace SimpleModule.Tenants.Middleware;
+
+public sealed partial class TenantResolutionMiddleware(
+    RequestDelegate next,
+    ILogger<TenantResolutionMiddleware> logger
+)
+{
+    private static readonly HashSet<string> SkipExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".css",
+        ".js",
+        ".mjs",
+        ".map",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".svg",
+        ".ico",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".eot",
+    };
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value;
+
+        if (ShouldSkip(path))
+        {
+            await next(context);
+            return;
+        }
+
+        var tenantContext = context.RequestServices.GetRequiredService<TenantContext>();
+
+        try
+        {
+            // Try hostname → header → claim
+            var hostResolver =
+                context.RequestServices.GetRequiredService<HostNameTenantResolver>();
+            var tenantId = await hostResolver.ResolveAsync(context);
+            tenantId ??= HeaderTenantResolver.Resolve(context);
+            tenantId ??= ClaimTenantResolver.Resolve(context);
+
+            if (tenantId is not null)
+            {
+                tenantContext.TenantId = tenantId;
+                LogTenantResolved(logger, tenantId, path);
+            }
+        }
+        catch (DbException ex)
+        {
+            LogResolutionFailed(logger, path, ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            LogResolutionFailed(logger, path, ex);
+        }
+
+        await next(context);
+    }
+
+    private static bool ShouldSkip(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        // Skip static assets
+        if (path.StartsWith("/_content/", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/js/", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Check file extensions
+        var lastDot = path.LastIndexOf('.');
+        if (lastDot >= 0)
+        {
+            var extension = path[lastDot..];
+            if (SkipExtensions.Contains(extension))
+            {
+                return true;
+            }
+        }
+
+        // Skip tenant management routes (host-admin, cross-tenant)
+        if (path.StartsWith("/api/tenants", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/tenants", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Tenant {TenantId} resolved for request {Path}"
+    )]
+    private static partial void LogTenantResolved(
+        ILogger logger,
+        string tenantId,
+        string? path
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Tenant resolution failed for request {Path}"
+    )]
+    private static partial void LogResolutionFailed(
+        ILogger logger,
+        string? path,
+        Exception exception
+    );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Middleware/TenantResolutionMiddleware.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Middleware/TenantResolutionMiddleware.cs
@@ -44,7 +44,6 @@ public sealed partial class TenantResolutionMiddleware(
 
         try
         {
-            // Try hostname → header → claim
             var hostResolver =
                 context.RequestServices.GetRequiredService<HostNameTenantResolver>();
             var tenantId = await hostResolver.ResolveAsync(context);
@@ -76,14 +75,12 @@ public sealed partial class TenantResolutionMiddleware(
             return false;
         }
 
-        // Skip static assets
         if (path.StartsWith("/_content/", StringComparison.OrdinalIgnoreCase)
             || path.StartsWith("/js/", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        // Check file extensions
         var lastDot = path.LastIndexOf('.');
         if (lastDot >= 0)
         {
@@ -94,7 +91,6 @@ public sealed partial class TenantResolutionMiddleware(
             }
         }
 
-        // Skip tenant management routes (host-admin, cross-tenant)
         if (path.StartsWith("/api/tenants", StringComparison.OrdinalIgnoreCase)
             || path.StartsWith("/tenants", StringComparison.OrdinalIgnoreCase))
         {

--- a/modules/Tenants/src/SimpleModule.Tenants/Pages/index.ts
+++ b/modules/Tenants/src/SimpleModule.Tenants/Pages/index.ts
@@ -1,0 +1,7 @@
+export const pages: Record<string, unknown> = {
+  'Tenants/Browse': () => import('../Views/Browse'),
+  'Tenants/Manage': () => import('../Views/Manage'),
+  'Tenants/Create': () => import('../Views/Create'),
+  'Tenants/Edit': () => import('../Views/Edit'),
+  'Tenants/Features': () => import('../Views/Features'),
+};

--- a/modules/Tenants/src/SimpleModule.Tenants/Resolvers/ClaimTenantResolver.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Resolvers/ClaimTenantResolver.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SimpleModule.Tenants.Resolvers;
+
+internal static class ClaimTenantResolver
+{
+    public static string? Resolve(HttpContext context)
+    {
+        var claim = context.User?.FindFirst(TenantsConstants.TenantClaimType);
+        return claim?.Value;
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HeaderTenantResolver.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HeaderTenantResolver.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SimpleModule.Tenants.Resolvers;
+
+internal static class HeaderTenantResolver
+{
+    public static string? Resolve(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(TenantsConstants.TenantIdHeader, out var values))
+        {
+            var value = values.ToString();
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        return null;
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HostNameTenantResolver.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HostNameTenantResolver.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace SimpleModule.Tenants.Resolvers;
+
+public sealed class HostNameTenantResolver(
+    TenantsDbContext db,
+    IMemoryCache cache
+)
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    public async Task<string?> ResolveAsync(HttpContext context)
+    {
+        var host = context.Request.Host.Host;
+        if (string.IsNullOrEmpty(host))
+        {
+            return null;
+        }
+
+        var cacheKey = $"tenant:host:{host}";
+        if (cache.TryGetValue(cacheKey, out string? cachedTenantId))
+        {
+            return cachedTenantId;
+        }
+
+        var tenantHost = await db
+            .TenantHosts.AsNoTracking()
+            .Where(h => h.HostName == host && h.IsActive)
+            .Select(h => (int?)h.TenantId.Value)
+            .FirstOrDefaultAsync();
+
+        if (tenantHost is null)
+        {
+            cache.Set(cacheKey, (string?)null, CacheDuration);
+            return null;
+        }
+
+        var tenantId = tenantHost.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        cache.Set(cacheKey, tenantId, CacheDuration);
+        return tenantId;
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HostNameTenantResolver.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Resolvers/HostNameTenantResolver.cs
@@ -9,7 +9,10 @@ public sealed class HostNameTenantResolver(
     IMemoryCache cache
 )
 {
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+    private static readonly MemoryCacheEntryOptions CacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+    };
 
     public async Task<string?> ResolveAsync(HttpContext context)
     {
@@ -20,25 +23,17 @@ public sealed class HostNameTenantResolver(
         }
 
         var cacheKey = $"tenant:host:{host}";
-        if (cache.TryGetValue(cacheKey, out string? cachedTenantId))
+        return await cache.GetOrCreateAsync(cacheKey, async entry =>
         {
-            return cachedTenantId;
-        }
+            entry.SetOptions(CacheOptions);
 
-        var tenantHost = await db
-            .TenantHosts.AsNoTracking()
-            .Where(h => h.HostName == host && h.IsActive)
-            .Select(h => (int?)h.TenantId.Value)
-            .FirstOrDefaultAsync();
+            var tenantHost = await db
+                .TenantHosts.AsNoTracking()
+                .Where(h => h.HostName == host && h.IsActive)
+                .Select(h => (int?)h.TenantId.Value)
+                .FirstOrDefaultAsync();
 
-        if (tenantHost is null)
-        {
-            cache.Set(cacheKey, (string?)null, CacheDuration);
-            return null;
-        }
-
-        var tenantId = tenantHost.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        cache.Set(cacheKey, tenantId, CacheDuration);
-        return tenantId;
+            return tenantHost?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        });
     }
 }

--- a/modules/Tenants/src/SimpleModule.Tenants/SimpleModule.Tenants.csproj
+++ b/modules/Tenants/src/SimpleModule.Tenants/SimpleModule.Tenants.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Bogus" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Database\SimpleModule.Database.csproj" />
     <ProjectReference Include="..\SimpleModule.Tenants.Contracts\SimpleModule.Tenants.Contracts.csproj" />

--- a/modules/Tenants/src/SimpleModule.Tenants/SimpleModule.Tenants.csproj
+++ b/modules/Tenants/src/SimpleModule.Tenants/SimpleModule.Tenants.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Bogus" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Database\SimpleModule.Database.csproj" />
+    <ProjectReference Include="..\SimpleModule.Tenants.Contracts\SimpleModule.Tenants.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\FeatureFlags\src\SimpleModule.FeatureFlags.Contracts\SimpleModule.FeatureFlags.Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Views\*.tsx">
+      <DependentUpon>%(Filename)Endpoint.cs</DependentUpon>
+    </None>
+  </ItemGroup>
+</Project>

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantContext.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantContext.cs
@@ -1,0 +1,8 @@
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Tenants;
+
+public class TenantContext : ITenantContext
+{
+    public string? TenantId { get; set; }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
@@ -1,0 +1,271 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SimpleModule.Core.Events;
+using SimpleModule.Core.Exceptions;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Contracts.Events;
+using SimpleModule.Tenants.Entities;
+
+namespace SimpleModule.Tenants;
+
+public sealed partial class TenantService(
+    TenantsDbContext db,
+    IEventBus eventBus,
+    ILogger<TenantService> logger
+) : ITenantContracts
+{
+    public async Task<IEnumerable<Tenant>> GetAllTenantsAsync() =>
+        await db
+            .Tenants.AsNoTracking()
+            .Include(t => t.Hosts)
+            .Select(t => MapToDto(t))
+            .ToListAsync();
+
+    public async Task<Tenant?> GetTenantByIdAsync(TenantId id)
+    {
+        var entity = await db
+            .Tenants.AsNoTracking()
+            .Include(t => t.Hosts)
+            .FirstOrDefaultAsync(t => t.Id == id);
+
+        if (entity is null)
+        {
+            LogTenantNotFound(logger, id);
+            return null;
+        }
+
+        return MapToDto(entity);
+    }
+
+    public async Task<Tenant?> GetTenantBySlugAsync(string slug)
+    {
+        var entity = await db
+            .Tenants.AsNoTracking()
+            .Include(t => t.Hosts)
+            .FirstOrDefaultAsync(t => t.Slug == slug);
+
+        return entity is null ? null : MapToDto(entity);
+    }
+
+    public async Task<Tenant?> GetTenantByHostNameAsync(string hostName)
+    {
+        var host = await db
+            .TenantHosts.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.HostName == hostName && h.IsActive);
+
+        if (host is null)
+        {
+            return null;
+        }
+
+        return await GetTenantByIdAsync(host.TenantId);
+    }
+
+    public async Task<Tenant> CreateTenantAsync(CreateTenantRequest request)
+    {
+        var entity = new TenantEntity
+        {
+            Name = request.Name,
+            Slug = request.Slug,
+            Status = TenantStatus.Active,
+            AdminEmail = request.AdminEmail,
+            EditionName = request.EditionName,
+            ConnectionString = request.ConnectionString,
+            ValidUpTo = request.ValidUpTo,
+        };
+
+        if (request.Hosts is { Count: > 0 })
+        {
+            foreach (var hostName in request.Hosts)
+            {
+                entity.Hosts.Add(new TenantHostEntity { HostName = hostName });
+            }
+        }
+
+        db.Tenants.Add(entity);
+        await db.SaveChangesAsync();
+
+        LogTenantCreated(logger, entity.Id, entity.Name);
+        await eventBus.PublishAsync(
+            new TenantCreatedEvent(entity.Id, entity.Name, entity.Slug)
+        );
+
+        return MapToDto(entity);
+    }
+
+    public async Task<Tenant> UpdateTenantAsync(TenantId id, UpdateTenantRequest request)
+    {
+        var entity = await db.Tenants.Include(t => t.Hosts).FirstOrDefaultAsync(t => t.Id == id);
+        if (entity is null)
+        {
+            throw new NotFoundException("Tenant", id);
+        }
+
+        entity.Name = request.Name;
+        entity.AdminEmail = request.AdminEmail;
+        entity.EditionName = request.EditionName;
+        entity.ConnectionString = request.ConnectionString;
+        entity.ValidUpTo = request.ValidUpTo;
+
+        await db.SaveChangesAsync();
+
+        LogTenantUpdated(logger, entity.Id, entity.Name);
+        await eventBus.PublishAsync(new TenantUpdatedEvent(entity.Id, entity.Name));
+
+        return MapToDto(entity);
+    }
+
+    public async Task DeleteTenantAsync(TenantId id)
+    {
+        var entity = await db.Tenants.FindAsync(id);
+        if (entity is null)
+        {
+            throw new NotFoundException("Tenant", id);
+        }
+
+        db.Tenants.Remove(entity);
+        await db.SaveChangesAsync();
+
+        LogTenantDeleted(logger, id);
+    }
+
+    public async Task<Tenant> ChangeStatusAsync(TenantId id, TenantStatus status)
+    {
+        var entity = await db.Tenants.Include(t => t.Hosts).FirstOrDefaultAsync(t => t.Id == id);
+        if (entity is null)
+        {
+            throw new NotFoundException("Tenant", id);
+        }
+
+        var oldStatus = entity.Status;
+        entity.Status = status;
+        await db.SaveChangesAsync();
+
+        LogTenantStatusChanged(logger, id, oldStatus, status);
+        await eventBus.PublishAsync(new TenantStatusChangedEvent(id, oldStatus, status));
+
+        return MapToDto(entity);
+    }
+
+    public async Task<TenantHost> AddHostAsync(TenantId tenantId, AddTenantHostRequest request)
+    {
+        var tenant = await db.Tenants.FindAsync(tenantId);
+        if (tenant is null)
+        {
+            throw new NotFoundException("Tenant", tenantId);
+        }
+
+        var hostEntity = new TenantHostEntity
+        {
+            TenantId = tenantId,
+            HostName = request.HostName,
+        };
+
+        db.TenantHosts.Add(hostEntity);
+        await db.SaveChangesAsync();
+
+        LogHostAdded(logger, tenantId, request.HostName);
+        await eventBus.PublishAsync(new TenantHostAddedEvent(tenantId, request.HostName));
+
+        return MapHostToDto(hostEntity);
+    }
+
+    public async Task RemoveHostAsync(TenantId tenantId, TenantHostId hostId)
+    {
+        var host = await db
+            .TenantHosts.FirstOrDefaultAsync(h => h.Id == hostId && h.TenantId == tenantId);
+        if (host is null)
+        {
+            throw new NotFoundException("TenantHost", hostId);
+        }
+
+        var hostName = host.HostName;
+        db.TenantHosts.Remove(host);
+        await db.SaveChangesAsync();
+
+        LogHostRemoved(logger, tenantId, hostName);
+        await eventBus.PublishAsync(new TenantHostRemovedEvent(tenantId, hostName));
+    }
+
+    private static Tenant MapToDto(TenantEntity entity) =>
+        new()
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            Slug = entity.Slug,
+            Status = entity.Status,
+            AdminEmail = entity.AdminEmail,
+            EditionName = entity.EditionName,
+            ConnectionString = entity.ConnectionString,
+            CreatedAt = entity.CreatedAt,
+            UpdatedAt = entity.UpdatedAt,
+            ValidUpTo = entity.ValidUpTo,
+            Hosts = entity.Hosts.Select(MapHostToDto).ToList(),
+        };
+
+    private static TenantHost MapHostToDto(TenantHostEntity entity) =>
+        new()
+        {
+            Id = entity.Id,
+            TenantId = entity.TenantId,
+            HostName = entity.HostName,
+            IsActive = entity.IsActive,
+        };
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Tenant with ID {TenantId} not found")]
+    private static partial void LogTenantNotFound(ILogger logger, TenantId tenantId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Tenant {TenantId} created: {TenantName}"
+    )]
+    private static partial void LogTenantCreated(
+        ILogger logger,
+        TenantId tenantId,
+        string tenantName
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Tenant {TenantId} updated: {TenantName}"
+    )]
+    private static partial void LogTenantUpdated(
+        ILogger logger,
+        TenantId tenantId,
+        string tenantName
+    );
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Tenant {TenantId} deleted")]
+    private static partial void LogTenantDeleted(ILogger logger, TenantId tenantId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Tenant {TenantId} status changed from {OldStatus} to {NewStatus}"
+    )]
+    private static partial void LogTenantStatusChanged(
+        ILogger logger,
+        TenantId tenantId,
+        TenantStatus oldStatus,
+        TenantStatus newStatus
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Host {HostName} added to tenant {TenantId}"
+    )]
+    private static partial void LogHostAdded(
+        ILogger logger,
+        TenantId tenantId,
+        string hostName
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Host {HostName} removed from tenant {TenantId}"
+    )]
+    private static partial void LogHostRemoved(
+        ILogger logger,
+        TenantId tenantId,
+        string hostName
+    );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
@@ -49,16 +49,13 @@ public sealed partial class TenantService(
 
     public async Task<Tenant?> GetTenantByHostNameAsync(string hostName)
     {
-        var host = await db
-            .TenantHosts.AsNoTracking()
-            .FirstOrDefaultAsync(h => h.HostName == hostName && h.IsActive);
+        var entity = await db
+            .Tenants.AsNoTracking()
+            .Include(t => t.Hosts)
+            .Where(t => t.Hosts.Any(h => h.HostName == hostName && h.IsActive))
+            .FirstOrDefaultAsync();
 
-        if (host is null)
-        {
-            return null;
-        }
-
-        return await GetTenantByIdAsync(host.TenantId);
+        return entity is null ? null : MapToDto(entity);
     }
 
     public async Task<Tenant> CreateTenantAsync(CreateTenantRequest request)
@@ -95,7 +92,7 @@ public sealed partial class TenantService(
 
     public async Task<Tenant> UpdateTenantAsync(TenantId id, UpdateTenantRequest request)
     {
-        var entity = await db.Tenants.Include(t => t.Hosts).FirstOrDefaultAsync(t => t.Id == id);
+        var entity = await db.Tenants.FindAsync(id);
         if (entity is null)
         {
             throw new NotFoundException("Tenant", id);
@@ -112,7 +109,7 @@ public sealed partial class TenantService(
         LogTenantUpdated(logger, entity.Id, entity.Name);
         await eventBus.PublishAsync(new TenantUpdatedEvent(entity.Id, entity.Name));
 
-        return MapToDto(entity);
+        return (await GetTenantByIdAsync(id))!;
     }
 
     public async Task DeleteTenantAsync(TenantId id)
@@ -131,7 +128,7 @@ public sealed partial class TenantService(
 
     public async Task<Tenant> ChangeStatusAsync(TenantId id, TenantStatus status)
     {
-        var entity = await db.Tenants.Include(t => t.Hosts).FirstOrDefaultAsync(t => t.Id == id);
+        var entity = await db.Tenants.FindAsync(id);
         if (entity is null)
         {
             throw new NotFoundException("Tenant", id);
@@ -144,7 +141,7 @@ public sealed partial class TenantService(
         LogTenantStatusChanged(logger, id, oldStatus, status);
         await eventBus.PublishAsync(new TenantStatusChangedEvent(id, oldStatus, status));
 
-        return MapToDto(entity);
+        return (await GetTenantByIdAsync(id))!;
     }
 
     public async Task<TenantHost> AddHostAsync(TenantId tenantId, AddTenantHostRequest request)

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantsConstants.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantsConstants.cs
@@ -1,0 +1,9 @@
+namespace SimpleModule.Tenants;
+
+public static class TenantsConstants
+{
+    public const string ModuleName = "Tenants";
+    public const string RoutePrefix = "/api/tenants";
+    public const string TenantIdHeader = "X-Tenant-Id";
+    public const string TenantClaimType = "tenant_id";
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantsDbContext.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantsDbContext.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SimpleModule.Database;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Entities;
+using SimpleModule.Tenants.EntityConfigurations;
+
+namespace SimpleModule.Tenants;
+
+public class TenantsDbContext(
+    DbContextOptions<TenantsDbContext> options,
+    IOptions<DatabaseOptions> dbOptions
+) : DbContext(options)
+{
+    public DbSet<TenantEntity> Tenants => Set<TenantEntity>();
+    public DbSet<TenantHostEntity> TenantHosts => Set<TenantHostEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new TenantConfiguration());
+        modelBuilder.ApplyConfiguration(new TenantHostConfiguration());
+        modelBuilder.ApplyModuleSchema("Tenants", dbOptions.Value);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<TenantId>()
+            .HaveConversion<TenantId.EfCoreValueConverter, TenantId.EfCoreValueComparer>();
+        configurationBuilder
+            .Properties<TenantHostId>()
+            .HaveConversion<TenantHostId.EfCoreValueConverter, TenantHostId.EfCoreValueComparer>();
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantsModule.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantsModule.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core;
+using SimpleModule.Core.Entities;
+using SimpleModule.Core.Menu;
+using SimpleModule.Database;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants;
+
+[Module(
+    TenantsConstants.ModuleName,
+    RoutePrefix = TenantsConstants.RoutePrefix,
+    ViewPrefix = "/tenants"
+)]
+public class TenantsModule : IModule
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMemoryCache();
+        services.AddModuleDbContext<TenantsDbContext>(configuration, TenantsConstants.ModuleName);
+        services.AddScoped<ITenantContracts, TenantService>();
+        services.AddScoped<TenantContext>();
+        services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
+        services.AddScoped<Resolvers.HostNameTenantResolver>();
+    }
+
+    public void ConfigureMenu(IMenuBuilder menus)
+    {
+        menus.Add(
+            new MenuItem
+            {
+                Label = "Tenants",
+                Url = "/tenants/manage",
+                Icon =
+                    """<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>""",
+                Order = 50,
+                Section = MenuSection.AdminSidebar,
+            }
+        );
+    }
+
+    public void ConfigureMiddleware(IApplicationBuilder app)
+    {
+        app.UseMiddleware<Middleware.TenantResolutionMiddleware>();
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, PageShell } from '@simplemodule/ui';
+import { statusColors, statusLabels } from './tenantStatus';
 
 interface BrowseTenant {
   id: number;
@@ -7,13 +8,6 @@ interface BrowseTenant {
   status: number;
   hostCount: number;
 }
-
-const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
-const statusColors: Record<number, string> = {
-  0: 'text-green-600',
-  1: 'text-yellow-600',
-  2: 'text-red-600',
-};
 
 export default function Browse({ tenants }: { tenants: BrowseTenant[] }) {
   return (

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
@@ -1,13 +1,11 @@
 import { Card, CardContent, PageShell } from '@simplemodule/ui';
 
-interface Tenant {
+interface BrowseTenant {
   id: number;
   name: string;
   slug: string;
   status: number;
-  adminEmail: string | null;
-  editionName: string | null;
-  hosts: { id: number; hostName: string; isActive: boolean }[];
+  hostCount: number;
 }
 
 const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
@@ -17,7 +15,7 @@ const statusColors: Record<number, string> = {
   2: 'text-red-600',
 };
 
-export default function Browse({ tenants }: { tenants: Tenant[] }) {
+export default function Browse({ tenants }: { tenants: BrowseTenant[] }) {
   return (
     <PageShell title="Tenants" description="Browse all tenants.">
       <div className="space-y-3">
@@ -30,7 +28,7 @@ export default function Browse({ tenants }: { tenants: Tenant[] }) {
               </div>
               <div className="flex items-center gap-4">
                 <span className="text-text-muted text-sm">
-                  {t.hosts.length} host{t.hosts.length !== 1 ? 's' : ''}
+                  {t.hostCount} host{t.hostCount !== 1 ? 's' : ''}
                 </span>
                 <span className={`text-sm font-medium ${statusColors[t.status]}`}>
                   {statusLabels[t.status]}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Browse.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, PageShell } from '@simplemodule/ui';
+
+interface Tenant {
+  id: number;
+  name: string;
+  slug: string;
+  status: number;
+  adminEmail: string | null;
+  editionName: string | null;
+  hosts: { id: number; hostName: string; isActive: boolean }[];
+}
+
+const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
+const statusColors: Record<number, string> = {
+  0: 'text-green-600',
+  1: 'text-yellow-600',
+  2: 'text-red-600',
+};
+
+export default function Browse({ tenants }: { tenants: Tenant[] }) {
+  return (
+    <PageShell title="Tenants" description="Browse all tenants.">
+      <div className="space-y-3">
+        {tenants.map((t) => (
+          <Card key={t.id} data-testid="tenant-card">
+            <CardContent className="flex justify-between items-center">
+              <div>
+                <span className="font-medium">{t.name}</span>
+                <span className="text-text-muted ml-2">({t.slug})</span>
+              </div>
+              <div className="flex items-center gap-4">
+                <span className="text-text-muted text-sm">
+                  {t.hosts.length} host{t.hosts.length !== 1 ? 's' : ''}
+                </span>
+                <span className={`text-sm font-medium ${statusColors[t.status]}`}>
+                  {statusLabels[t.status]}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/BrowseEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/BrowseEndpoint.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Views;
+
+[ViewPage("Tenants/Browse")]
+public class BrowseEndpoint : IViewEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/browse",
+                async (ITenantContracts contracts) =>
+                    Inertia.Render("Tenants/Browse", new { tenants = await contracts.GetAllTenantsAsync() })
+            )
+            .AllowAnonymous();
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/BrowseEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/BrowseEndpoint.cs
@@ -14,7 +14,18 @@ public class BrowseEndpoint : IViewEndpoint
         app.MapGet(
                 "/browse",
                 async (ITenantContracts contracts) =>
-                    Inertia.Render("Tenants/Browse", new { tenants = await contracts.GetAllTenantsAsync() })
+                {
+                    var tenants = (await contracts.GetAllTenantsAsync())
+                        .Select(t => new
+                        {
+                            t.Id,
+                            t.Name,
+                            t.Slug,
+                            t.Status,
+                            HostCount = t.Hosts.Count,
+                        });
+                    return Inertia.Render("Tenants/Browse", new { tenants });
+                }
             )
             .AllowAnonymous();
     }

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Create.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Create.tsx
@@ -1,0 +1,83 @@
+import { router } from '@inertiajs/react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+} from '@simplemodule/ui';
+
+export default function Create() {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    router.post('/api/tenants', formData);
+  }
+
+  return (
+    <Container className="space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/tenants/manage">Tenants</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Create Tenant</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <h1 className="text-2xl font-bold tracking-tight">Create Tenant</h1>
+
+      <Card>
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit}>
+            <FieldGroup>
+              <Field>
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" name="name" required placeholder="Tenant name" />
+              </Field>
+              <Field>
+                <Label htmlFor="slug">Slug</Label>
+                <Input
+                  id="slug"
+                  name="slug"
+                  required
+                  placeholder="tenant-slug"
+                  pattern="[a-z0-9][a-z0-9-]*[a-z0-9]|[a-z0-9]"
+                />
+              </Field>
+              <Field>
+                <Label htmlFor="adminEmail">Admin Email</Label>
+                <Input
+                  id="adminEmail"
+                  name="adminEmail"
+                  type="email"
+                  placeholder="admin@example.com"
+                />
+              </Field>
+              <Field>
+                <Label htmlFor="editionName">Edition</Label>
+                <Input id="editionName" name="editionName" placeholder="Standard" />
+              </Field>
+              <Field>
+                <Label htmlFor="validUpTo">Valid Until</Label>
+                <Input id="validUpTo" name="validUpTo" type="date" />
+              </Field>
+              <Button type="submit">Create</Button>
+            </FieldGroup>
+          </form>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/CreateEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/CreateEndpoint.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Views;
+
+[ViewPage("Tenants/Create")]
+public class CreateEndpoint : IViewEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/create", () => Inertia.Render("Tenants/Create"))
+            .RequirePermission(TenantsPermissions.Create);
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Edit.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Edit.tsx
@@ -1,0 +1,191 @@
+import { router } from '@inertiajs/react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@simplemodule/ui';
+import { useState } from 'react';
+
+interface TenantHost {
+  id: number;
+  tenantId: number;
+  hostName: string;
+  isActive: boolean;
+}
+
+interface Tenant {
+  id: number;
+  name: string;
+  slug: string;
+  status: number;
+  adminEmail: string | null;
+  editionName: string | null;
+  connectionString: string | null;
+  validUpTo: string | null;
+  hosts: TenantHost[];
+}
+
+const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
+
+export default function Edit({ tenant }: { tenant: Tenant }) {
+  const [newHost, setNewHost] = useState('');
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    router.put(`/api/tenants/${tenant.id}`, Object.fromEntries(formData));
+  }
+
+  function handleAddHost() {
+    if (!newHost.trim()) return;
+    router.post(
+      `/api/tenants/${tenant.id}/hosts`,
+      { hostName: newHost.trim() },
+      { preserveScroll: true },
+    );
+    setNewHost('');
+  }
+
+  function handleRemoveHost(hostId: number) {
+    router.delete(`/api/tenants/${tenant.id}/hosts/${hostId}`, { preserveScroll: true });
+  }
+
+  function handleStatusChange(status: number) {
+    router.put(`/api/tenants/${tenant.id}/status`, { status }, { preserveScroll: true });
+  }
+
+  return (
+    <Container className="space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/tenants/manage">Tenants</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Edit {tenant.name}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Edit Tenant</h1>
+        <Button variant="ghost" onClick={() => router.get(`/tenants/${tenant.id}/features`)}>
+          Manage Features
+        </Button>
+      </div>
+
+      <Card>
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit}>
+            <FieldGroup>
+              <Field>
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" name="name" required defaultValue={tenant.name} />
+              </Field>
+              <Field>
+                <Label htmlFor="adminEmail">Admin Email</Label>
+                <Input
+                  id="adminEmail"
+                  name="adminEmail"
+                  type="email"
+                  defaultValue={tenant.adminEmail ?? ''}
+                />
+              </Field>
+              <Field>
+                <Label htmlFor="editionName">Edition</Label>
+                <Input
+                  id="editionName"
+                  name="editionName"
+                  defaultValue={tenant.editionName ?? ''}
+                />
+              </Field>
+              <Field>
+                <Label htmlFor="validUpTo">Valid Until</Label>
+                <Input
+                  id="validUpTo"
+                  name="validUpTo"
+                  type="date"
+                  defaultValue={tenant.validUpTo?.split('T')[0] ?? ''}
+                />
+              </Field>
+              <Button type="submit">Save Changes</Button>
+            </FieldGroup>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold mb-4">Status</h2>
+          <div className="flex gap-2">
+            {[0, 1, 2].map((s) => (
+              <Button
+                key={s}
+                variant={tenant.status === s ? 'default' : 'secondary'}
+                size="sm"
+                onClick={() => handleStatusChange(s)}
+              >
+                {statusLabels[s]}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-6">
+          <h2 className="text-lg font-semibold mb-4">Hosts</h2>
+          {tenant.hosts.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Host Name</TableHead>
+                  <TableHead>Active</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tenant.hosts.map((host) => (
+                  <TableRow key={host.id}>
+                    <TableCell className="font-mono text-sm">{host.hostName}</TableCell>
+                    <TableCell>{host.isActive ? 'Yes' : 'No'}</TableCell>
+                    <TableCell>
+                      <Button variant="danger" size="sm" onClick={() => handleRemoveHost(host.id)}>
+                        Remove
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          <div className="flex gap-2 mt-4">
+            <Input
+              placeholder="new-host.example.com"
+              value={newHost}
+              onChange={(e) => setNewHost(e.target.value)}
+            />
+            <Button onClick={handleAddHost}>Add Host</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Edit.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Edit.tsx
@@ -22,27 +22,8 @@ import {
   TableRow,
 } from '@simplemodule/ui';
 import { useState } from 'react';
-
-interface TenantHost {
-  id: number;
-  tenantId: number;
-  hostName: string;
-  isActive: boolean;
-}
-
-interface Tenant {
-  id: number;
-  name: string;
-  slug: string;
-  status: number;
-  adminEmail: string | null;
-  editionName: string | null;
-  connectionString: string | null;
-  validUpTo: string | null;
-  hosts: TenantHost[];
-}
-
-const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
+import type { Tenant } from '../types';
+import { statusLabels } from './tenantStatus';
 
 export default function Edit({ tenant }: { tenant: Tenant }) {
   const [newHost, setNewHost] = useState('');

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/EditEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/EditEndpoint.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Views;
+
+[ViewPage("Tenants/Edit")]
+public class EditEndpoint : IViewEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/{id}/edit",
+                async (TenantId id, ITenantContracts contracts) =>
+                {
+                    var tenant = await contracts.GetTenantByIdAsync(id);
+                    if (tenant is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    return Inertia.Render("Tenants/Edit", new { tenant });
+                }
+            )
+            .RequirePermission(TenantsPermissions.Update);
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Features.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Features.tsx
@@ -1,0 +1,147 @@
+import { router } from '@inertiajs/react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@simplemodule/ui';
+
+interface FeatureFlag {
+  name: string;
+  description: string;
+  isEnabled: boolean;
+  defaultEnabled: boolean;
+  isDeprecated: boolean;
+}
+
+interface FeatureFlagOverride {
+  id: number;
+  flagName: string;
+  overrideType: number;
+  overrideValue: string;
+  isEnabled: boolean;
+}
+
+interface Tenant {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface Props {
+  tenant: Tenant;
+  flags: FeatureFlag[];
+  tenantOverrides: FeatureFlagOverride[];
+}
+
+export default function Features({ tenant, flags, tenantOverrides }: Props) {
+  const overrideMap = new Map(tenantOverrides.map((o) => [o.flagName, o]));
+
+  function handleToggle(flagName: string, currentlyEnabled: boolean) {
+    router.put(
+      `/api/tenants/${tenant.id}/features/${flagName}`,
+      { isEnabled: !currentlyEnabled },
+      { preserveScroll: true },
+    );
+  }
+
+  function handleReset(flagName: string) {
+    router.delete(`/api/tenants/${tenant.id}/features/${flagName}`, { preserveScroll: true });
+  }
+
+  if (flags.length === 0) {
+    return (
+      <Container className="space-y-6">
+        <h1 className="text-2xl font-bold tracking-tight">No Feature Flags Available</h1>
+        <p className="text-text-muted">
+          The Feature Flags module is not installed or has no flags.
+        </p>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/tenants/manage">Tenants</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href={`/tenants/${tenant.id}/edit`}>{tenant.name}</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Feature Flags</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <h1 className="text-2xl font-bold tracking-tight">Feature Flags for {tenant.name}</h1>
+
+      <Card>
+        <CardContent className="p-6">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Flag</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Global</TableHead>
+                <TableHead>Tenant Override</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {flags
+                .filter((f) => !f.isDeprecated)
+                .map((flag) => {
+                  const override = overrideMap.get(flag.name);
+                  const effectiveState = override ? override.isEnabled : flag.isEnabled;
+
+                  return (
+                    <TableRow key={flag.name}>
+                      <TableCell className="font-mono text-sm">{flag.name}</TableCell>
+                      <TableCell className="text-text-muted">{flag.description || '-'}</TableCell>
+                      <TableCell>
+                        <span className={flag.isEnabled ? 'text-green-600' : 'text-red-600'}>
+                          {flag.isEnabled ? 'On' : 'Off'}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          variant={effectiveState ? 'default' : 'secondary'}
+                          size="sm"
+                          onClick={() => handleToggle(flag.name, effectiveState)}
+                        >
+                          {effectiveState ? 'Enabled' : 'Disabled'}
+                        </Button>
+                      </TableCell>
+                      <TableCell>
+                        {override && (
+                          <Button variant="ghost" size="sm" onClick={() => handleReset(flag.name)}>
+                            Reset
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Inertia;
+using SimpleModule.FeatureFlags.Contracts;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Views;
+
+[ViewPage("Tenants/Features")]
+public class FeaturesEndpoint : IViewEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/{id}/features",
+                async (
+                    TenantId id,
+                    ITenantContracts contracts,
+                    IFeatureFlagContracts? featureFlags
+                ) =>
+                {
+                    var tenant = await contracts.GetTenantByIdAsync(id);
+                    if (tenant is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    if (featureFlags is null)
+                    {
+                        return Inertia.Render(
+                            "Tenants/Features",
+                            new { tenant, flags = Array.Empty<FeatureFlag>(), tenantOverrides = Array.Empty<FeatureFlagOverride>() }
+                        );
+                    }
+
+                    var flags = (await featureFlags.GetAllFlagsAsync()).ToList();
+                    var tenantIdStr = id.Value.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture
+                    );
+                    var tenantOverrides = new List<FeatureFlagOverride>();
+                    foreach (var flag in flags)
+                    {
+                        var overrides = await featureFlags.GetOverridesAsync(flag.Name);
+                        tenantOverrides.AddRange(
+                            overrides.Where(o =>
+                                o.OverrideType == OverrideType.Tenant
+                                && o.OverrideValue == tenantIdStr
+                            )
+                        );
+                    }
+
+                    return Inertia.Render(
+                        "Tenants/Features",
+                        new { tenant, flags, tenantOverrides }
+                    );
+                }
+            )
+            .RequirePermission(TenantsPermissions.View);
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
@@ -7,6 +7,7 @@ using SimpleModule.Core.Authorization;
 using SimpleModule.Core.Inertia;
 using SimpleModule.FeatureFlags.Contracts;
 using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Endpoints.TenantFeatures;
 
 namespace SimpleModule.Tenants.Views;
 
@@ -35,22 +36,8 @@ public class FeaturesEndpoint : IViewEndpoint
                     }
 
                     var flags = (await featureFlags.GetAllFlagsAsync()).ToList();
-                    var tenantIdStr = id.Value.ToString(
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
-
-                    var overrideTasks = flags
-                        .Where(f => !f.IsDeprecated)
-                        .Select(f => featureFlags.GetOverridesAsync(f.Name));
-                    var allOverrides = await Task.WhenAll(overrideTasks);
-
-                    var tenantOverrides = allOverrides
-                        .SelectMany(o => o)
-                        .Where(o =>
-                            o.OverrideType == OverrideType.Tenant
-                            && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
-                        )
-                        .ToList();
+                    var tenantOverrides = await TenantFeatureHelper.GetOverridesForTenantAsync(
+                        featureFlags, flags, id);
 
                     return Inertia.Render(
                         "Tenants/Features",

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/FeaturesEndpoint.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using SimpleModule.Core;
 using SimpleModule.Core.Authorization;
 using SimpleModule.Core.Inertia;
@@ -16,11 +17,7 @@ public class FeaturesEndpoint : IViewEndpoint
     {
         app.MapGet(
                 "/{id}/features",
-                async (
-                    TenantId id,
-                    ITenantContracts contracts,
-                    IFeatureFlagContracts? featureFlags
-                ) =>
+                async (TenantId id, ITenantContracts contracts, HttpContext context) =>
                 {
                     var tenant = await contracts.GetTenantByIdAsync(id);
                     if (tenant is null)
@@ -28,6 +25,7 @@ public class FeaturesEndpoint : IViewEndpoint
                         return Results.NotFound();
                     }
 
+                    var featureFlags = context.RequestServices.GetService<IFeatureFlagContracts>();
                     if (featureFlags is null)
                     {
                         return Inertia.Render(
@@ -40,17 +38,19 @@ public class FeaturesEndpoint : IViewEndpoint
                     var tenantIdStr = id.Value.ToString(
                         System.Globalization.CultureInfo.InvariantCulture
                     );
-                    var tenantOverrides = new List<FeatureFlagOverride>();
-                    foreach (var flag in flags)
-                    {
-                        var overrides = await featureFlags.GetOverridesAsync(flag.Name);
-                        tenantOverrides.AddRange(
-                            overrides.Where(o =>
-                                o.OverrideType == OverrideType.Tenant
-                                && o.OverrideValue == tenantIdStr
-                            )
-                        );
-                    }
+
+                    var overrideTasks = flags
+                        .Where(f => !f.IsDeprecated)
+                        .Select(f => featureFlags.GetOverridesAsync(f.Name));
+                    var allOverrides = await Task.WhenAll(overrideTasks);
+
+                    var tenantOverrides = allOverrides
+                        .SelectMany(o => o)
+                        .Where(o =>
+                            o.OverrideType == OverrideType.Tenant
+                            && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
+                        )
+                        .ToList();
 
                     return Inertia.Render(
                         "Tenants/Features",

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Manage.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Manage.tsx
@@ -16,23 +16,8 @@ import {
   TableRow,
 } from '@simplemodule/ui';
 import { useState } from 'react';
-
-interface Tenant {
-  id: number;
-  name: string;
-  slug: string;
-  status: number;
-  adminEmail: string | null;
-  editionName: string | null;
-  hosts: { id: number; hostName: string; isActive: boolean }[];
-}
-
-const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
-const statusColors: Record<number, string> = {
-  0: 'text-green-600',
-  1: 'text-yellow-600',
-  2: 'text-red-600',
-};
+import type { Tenant } from '../types';
+import { statusColors, statusLabels } from './tenantStatus';
 
 export default function Manage({ tenants }: { tenants: Tenant[] }) {
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/Manage.tsx
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/Manage.tsx
@@ -1,0 +1,135 @@
+import { router } from '@inertiajs/react';
+import {
+  Button,
+  DataGridPage,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@simplemodule/ui';
+import { useState } from 'react';
+
+interface Tenant {
+  id: number;
+  name: string;
+  slug: string;
+  status: number;
+  adminEmail: string | null;
+  editionName: string | null;
+  hosts: { id: number; hostName: string; isActive: boolean }[];
+}
+
+const statusLabels: Record<number, string> = { 0: 'Active', 1: 'Suspended', 2: 'Inactive' };
+const statusColors: Record<number, string> = {
+  0: 'text-green-600',
+  1: 'text-yellow-600',
+  2: 'text-red-600',
+};
+
+export default function Manage({ tenants }: { tenants: Tenant[] }) {
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+
+  function handleDelete() {
+    if (!deleteTarget) return;
+    router.delete(`/api/tenants/${deleteTarget.id}`);
+    setDeleteTarget(null);
+  }
+
+  return (
+    <>
+      <DataGridPage
+        title="Manage Tenants"
+        description={`${tenants.length} total tenants`}
+        actions={<Button onClick={() => router.get('/tenants/create')}>Create Tenant</Button>}
+        data={tenants}
+        emptyTitle="No tenants yet"
+        emptyDescription="Get started by creating your first tenant."
+      >
+        {(pageData) => (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Hosts</TableHead>
+                <TableHead>Edition</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pageData.map((tenant) => (
+                <TableRow key={tenant.id}>
+                  <TableCell className="text-text-muted">#{tenant.id}</TableCell>
+                  <TableCell className="font-medium text-text">{tenant.name}</TableCell>
+                  <TableCell className="text-text-muted">{tenant.slug}</TableCell>
+                  <TableCell>
+                    <span className={`font-medium ${statusColors[tenant.status]}`}>
+                      {statusLabels[tenant.status]}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-text-muted">{tenant.hosts.length}</TableCell>
+                  <TableCell className="text-text-muted">{tenant.editionName ?? '-'}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-3">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => router.get(`/tenants/${tenant.id}/edit`)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => router.get(`/tenants/${tenant.id}/features`)}
+                      >
+                        Features
+                      </Button>
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        onClick={() => setDeleteTarget({ id: tenant.id, name: tenant.name })}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DataGridPage>
+
+      <Dialog open={deleteTarget !== null} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Tenant</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &ldquo;{deleteTarget?.name}&rdquo;? This action cannot
+              be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="danger" onClick={handleDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/ManageEndpoint.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/ManageEndpoint.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Tenants.Contracts;
+
+namespace SimpleModule.Tenants.Views;
+
+[ViewPage("Tenants/Manage")]
+public class ManageEndpoint : IViewEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/manage",
+                async (ITenantContracts contracts) =>
+                    Inertia.Render(
+                        "Tenants/Manage",
+                        new { tenants = await contracts.GetAllTenantsAsync() }
+                    )
+            )
+            .RequirePermission(TenantsPermissions.View);
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Views/tenantStatus.ts
+++ b/modules/Tenants/src/SimpleModule.Tenants/Views/tenantStatus.ts
@@ -1,0 +1,11 @@
+export const statusLabels: Record<number, string> = {
+  0: 'Active',
+  1: 'Suspended',
+  2: 'Inactive',
+};
+
+export const statusColors: Record<number, string> = {
+  0: 'text-green-600',
+  1: 'text-yellow-600',
+  2: 'text-red-600',
+};

--- a/modules/Tenants/src/SimpleModule.Tenants/package.json
+++ b/modules/Tenants/src/SimpleModule.Tenants/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "@simplemodule/tenants",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "cross-env VITE_MODE=prod vite build",
+    "build:dev": "cross-env VITE_MODE=dev vite build",
+    "watch": "cross-env VITE_MODE=dev vite build --watch"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/types.ts
+++ b/modules/Tenants/src/SimpleModule.Tenants/types.ts
@@ -1,0 +1,47 @@
+// Auto-generated from [Dto] types — do not edit
+export interface Tenant {
+  id: number;
+  name: string;
+  slug: string;
+  status: any;
+  adminEmail: string;
+  editionName: string;
+  connectionString: string;
+  createdAt: string;
+  updatedAt: string;
+  validUpTo: string | null;
+  hosts: TenantHost[];
+}
+
+export interface TenantHost {
+  id: number;
+  tenantId: number;
+  hostName: string;
+  isActive: boolean;
+}
+
+export interface AddTenantHostRequest {
+  hostName: string;
+}
+
+export interface CreateTenantRequest {
+  name: string;
+  slug: string;
+  adminEmail: string;
+  editionName: string;
+  connectionString: string;
+  validUpTo: string | null;
+  hosts: string[];
+}
+
+export interface TenantsPermissions {
+}
+
+export interface UpdateTenantRequest {
+  name: string;
+  adminEmail: string;
+  editionName: string;
+  connectionString: string;
+  validUpTo: string | null;
+}
+

--- a/modules/Tenants/src/SimpleModule.Tenants/vite.config.ts
+++ b/modules/Tenants/src/SimpleModule.Tenants/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineModuleConfig } from '@simplemodule/client/module';
+
+export default defineModuleConfig(__dirname);

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/GlobalUsings.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/SimpleModule.Tenants.Tests.csproj
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/SimpleModule.Tenants.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SimpleModule.Tenants\SimpleModule.Tenants.csproj" />
+    <ProjectReference Include="..\..\src\SimpleModule.Tenants.Contracts\SimpleModule.Tenants.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\tests\SimpleModule.Tests.Shared\SimpleModule.Tests.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/CreateRequestValidatorTests.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/CreateRequestValidatorTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using SimpleModule.Tenants.Contracts;
+using SimpleModule.Tenants.Endpoints.Tenants;
+
+namespace Tenants.Tests.Unit;
+
+public class CreateRequestValidatorTests
+{
+    [Fact]
+    public void Validate_WithValidRequest_ReturnsSuccess()
+    {
+        var request = new CreateTenantRequest { Name = "Test", Slug = "test" };
+        var result = CreateRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyName_ReturnsError()
+    {
+        var request = new CreateTenantRequest { Name = "", Slug = "test" };
+        var result = CreateRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("Name");
+    }
+
+    [Fact]
+    public void Validate_WithEmptySlug_ReturnsError()
+    {
+        var request = new CreateTenantRequest { Name = "Test", Slug = "" };
+        var result = CreateRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("Slug");
+    }
+
+    [Fact]
+    public void Validate_WithInvalidSlug_ReturnsError()
+    {
+        var request = new CreateTenantRequest { Name = "Test", Slug = "INVALID SLUG!" };
+        var result = CreateRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("Slug");
+    }
+
+    [Fact]
+    public void Validate_WithInvalidEmail_ReturnsError()
+    {
+        var request = new CreateTenantRequest
+        {
+            Name = "Test",
+            Slug = "test",
+            AdminEmail = "not-an-email",
+        };
+        var result = CreateRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("AdminEmail");
+    }
+}

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantHostIdTests.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantHostIdTests.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using SimpleModule.Tenants.Contracts;
+
+namespace Tenants.Tests.Unit;
+
+public class TenantHostIdTests
+{
+    [Fact]
+    public void From_CreatesValueObject()
+    {
+        var id = TenantHostId.From(42);
+
+        id.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Equals_WithSameValue_ReturnsTrue()
+    {
+        var id1 = TenantHostId.From(1);
+        var id2 = TenantHostId.From(1);
+
+        id1.Should().Be(id2);
+    }
+}

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantIdTests.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantIdTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using SimpleModule.Tenants.Contracts;
+
+namespace Tenants.Tests.Unit;
+
+public class TenantIdTests
+{
+    [Fact]
+    public void From_CreatesValueObject()
+    {
+        var id = TenantId.From(42);
+
+        id.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Equals_WithSameValue_ReturnsTrue()
+    {
+        var id1 = TenantId.From(1);
+        var id2 = TenantId.From(1);
+
+        id1.Should().Be(id2);
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValue_ReturnsFalse()
+    {
+        var id1 = TenantId.From(1);
+        var id2 = TenantId.From(2);
+
+        id1.Should().NotBe(id2);
+    }
+}

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantServiceTests.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantServiceTests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SimpleModule.Core.Events;
+using SimpleModule.Core.Exceptions;
+using SimpleModule.Database;
+using SimpleModule.Tenants;
+using SimpleModule.Tenants.Contracts;
+
+namespace Tenants.Tests.Unit;
+
+public sealed class TenantServiceTests : IDisposable
+{
+    private readonly TenantsDbContext _db;
+    private readonly TenantService _sut;
+    private readonly TestEventBus _eventBus = new();
+
+    public TenantServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TenantsDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        var dbOptions = Options.Create(
+            new DatabaseOptions
+            {
+                ModuleConnections = new Dictionary<string, string>
+                {
+                    ["Tenants"] = "Data Source=:memory:",
+                },
+            }
+        );
+        _db = new TenantsDbContext(options, dbOptions);
+        _db.Database.OpenConnection();
+        _db.Database.EnsureCreated();
+        _sut = new TenantService(_db, _eventBus, NullLogger<TenantService>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task GetAllTenantsAsync_ReturnsSeedTenants()
+    {
+        var tenants = await _sut.GetAllTenantsAsync();
+
+        tenants.Should().NotBeEmpty();
+        tenants.Should().Contain(t => t.Slug == "acme");
+        tenants.Should().Contain(t => t.Slug == "contoso");
+    }
+
+    [Fact]
+    public async Task GetTenantByIdAsync_WithExistingId_ReturnsTenant()
+    {
+        var tenant = await _sut.GetTenantByIdAsync(TenantId.From(1));
+
+        tenant.Should().NotBeNull();
+        tenant!.Name.Should().Be("Acme Corporation");
+        tenant.Hosts.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetTenantByIdAsync_WithNonExistentId_ReturnsNull()
+    {
+        var tenant = await _sut.GetTenantByIdAsync(TenantId.From(99999));
+
+        tenant.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTenantAsync_CreatesAndReturnsTenant()
+    {
+        var request = new CreateTenantRequest
+        {
+            Name = "New Tenant",
+            Slug = "new-tenant",
+            AdminEmail = "admin@new.com",
+            Hosts = ["new.localhost"],
+        };
+
+        var tenant = await _sut.CreateTenantAsync(request);
+
+        tenant.Should().NotBeNull();
+        tenant.Name.Should().Be("New Tenant");
+        tenant.Slug.Should().Be("new-tenant");
+        tenant.Status.Should().Be(TenantStatus.Active);
+        tenant.Hosts.Should().HaveCount(1);
+        tenant.Hosts[0].HostName.Should().Be("new.localhost");
+        _eventBus.PublishedEvents.Should().ContainSingle(e => e is SimpleModule.Tenants.Contracts.Events.TenantCreatedEvent);
+    }
+
+    [Fact]
+    public async Task UpdateTenantAsync_WithValidData_UpdatesTenant()
+    {
+        var request = new UpdateTenantRequest { Name = "Updated Acme" };
+        var updated = await _sut.UpdateTenantAsync(TenantId.From(1), request);
+
+        updated.Name.Should().Be("Updated Acme");
+        _eventBus.PublishedEvents.Should().Contain(e => e is SimpleModule.Tenants.Contracts.Events.TenantUpdatedEvent);
+    }
+
+    [Fact]
+    public async Task UpdateTenantAsync_WithNonExistentId_ThrowsNotFoundException()
+    {
+        var request = new UpdateTenantRequest { Name = "Test" };
+        var act = () => _sut.UpdateTenantAsync(TenantId.From(99999), request);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task DeleteTenantAsync_WithExistingId_RemovesTenant()
+    {
+        var create = new CreateTenantRequest { Name = "ToDelete", Slug = "to-delete" };
+        var created = await _sut.CreateTenantAsync(create);
+
+        await _sut.DeleteTenantAsync(created.Id);
+
+        var found = await _sut.GetTenantByIdAsync(created.Id);
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ChangeStatusAsync_ChangesStatusAndPublishesEvent()
+    {
+        var result = await _sut.ChangeStatusAsync(TenantId.From(1), TenantStatus.Suspended);
+
+        result.Status.Should().Be(TenantStatus.Suspended);
+        _eventBus.PublishedEvents.Should()
+            .Contain(e => e is SimpleModule.Tenants.Contracts.Events.TenantStatusChangedEvent);
+    }
+
+    [Fact]
+    public async Task AddHostAsync_AddsHostToTenant()
+    {
+        var host = await _sut.AddHostAsync(
+            TenantId.From(2),
+            new AddTenantHostRequest { HostName = "new.contoso.com" }
+        );
+
+        host.HostName.Should().Be("new.contoso.com");
+        host.TenantId.Should().Be(TenantId.From(2));
+
+        var tenant = await _sut.GetTenantByIdAsync(TenantId.From(2));
+        tenant!.Hosts.Should().Contain(h => h.HostName == "new.contoso.com");
+    }
+
+    [Fact]
+    public async Task RemoveHostAsync_RemovesHostFromTenant()
+    {
+        var host = await _sut.AddHostAsync(
+            TenantId.From(2),
+            new AddTenantHostRequest { HostName = "temp.contoso.com" }
+        );
+
+        await _sut.RemoveHostAsync(TenantId.From(2), host.Id);
+
+        var tenant = await _sut.GetTenantByIdAsync(TenantId.From(2));
+        tenant!.Hosts.Should().NotContain(h => h.HostName == "temp.contoso.com");
+    }
+
+    [Fact]
+    public async Task GetTenantByHostNameAsync_ReturnsTenantForActiveHost()
+    {
+        var tenant = await _sut.GetTenantByHostNameAsync("acme.localhost");
+
+        tenant.Should().NotBeNull();
+        tenant!.Slug.Should().Be("acme");
+    }
+
+    [Fact]
+    public async Task GetTenantByHostNameAsync_ReturnsNullForUnknownHost()
+    {
+        var tenant = await _sut.GetTenantByHostNameAsync("unknown.example.com");
+
+        tenant.Should().BeNull();
+    }
+
+    private sealed class TestEventBus : IEventBus
+    {
+        public List<IEvent> PublishedEvents { get; } = [];
+
+        public Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+            where T : IEvent
+        {
+            PublishedEvents.Add(@event);
+            return Task.CompletedTask;
+        }
+
+        public void PublishInBackground<T>(T @event)
+            where T : IEvent
+        {
+            PublishedEvents.Add(@event);
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,6 +212,14 @@
         "react-dom": "^19.0.0"
       }
     },
+    "modules/Tenants/src/SimpleModule.Tenants": {
+      "name": "@simplemodule/tenants",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "modules/Users/src/SimpleModule.Users": {
       "name": "@simplemodule/users",
       "version": "0.0.0",
@@ -3534,6 +3542,10 @@
     },
     "node_modules/@simplemodule/settings": {
       "resolved": "modules/Settings/src/SimpleModule.Settings",
+      "link": true
+    },
+    "node_modules/@simplemodule/tenants": {
+      "resolved": "modules/Tenants/src/SimpleModule.Tenants",
       "link": true
     },
     "node_modules/@simplemodule/theme-default": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,7 +410,6 @@
       "integrity": "sha512-Jc360x4yqb3eEg4OY4KEIdGePBxZogivKI+OGIU8aLXgAYPTECvzeOBc90312yHA1hr3AeRlAFl0rIc8lQaIrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.50.0",
         "@algolia/requester-browser-xhr": "5.50.0",
@@ -533,7 +532,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1410,7 +1408,6 @@
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1462,7 +1459,6 @@
     "node_modules/@inertiajs/react": {
       "version": "2.3.18",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inertiajs/core": "2.3.18",
         "@types/lodash-es": "^4.17.12",
@@ -3912,7 +3908,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.5.tgz",
       "integrity": "sha512-Pkjd41UJ4F6Z8cPV+gEvqnt1VhY2g66xMjbpxREs0ECA5jRezCNKSZcc2pueQRTMtmn1SaSzGM9U/ifhVlVYOA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4190,7 +4185,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.5.tgz",
       "integrity": "sha512-yJhDa7Chx2EqJMX/jlewBv0za7slf1dKHWYve1XaApuVHEkxl0Ul3EDbwnx316vIITkuFW/pWSwkSsAplyBeCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4427,7 +4421,6 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4435,7 +4428,6 @@
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4772,7 +4764,6 @@
       "integrity": "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.16.0",
         "@algolia/client-abtesting": "5.50.0",
@@ -4881,7 +4872,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5447,7 +5437,6 @@
       "version": "0.25.12",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5566,7 +5555,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -5699,7 +5687,6 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.8.tgz",
       "integrity": "sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5806,7 +5793,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5895,7 +5881,6 @@
       "version": "1.31.1",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6501,7 +6486,6 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6723,7 +6707,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -6753,7 +6736,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -6802,7 +6784,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
       "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -6853,7 +6834,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6883,7 +6863,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6913,7 +6892,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7037,8 +7015,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7424,7 +7401,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7671,7 +7647,6 @@
     "node_modules/vite": {
       "version": "6.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8279,7 +8254,6 @@
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",

--- a/template/SimpleModule.Host/SimpleModule.Host.csproj
+++ b/template/SimpleModule.Host/SimpleModule.Host.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\modules\Marketplace\src\SimpleModule.Marketplace\SimpleModule.Marketplace.csproj" />
     <ProjectReference Include="..\..\modules\FileStorage\src\SimpleModule.FileStorage\SimpleModule.FileStorage.csproj" />
     <ProjectReference Include="..\..\modules\FeatureFlags\src\SimpleModule.FeatureFlags\SimpleModule.FeatureFlags.csproj" />
+    <ProjectReference Include="..\..\modules\Tenants\src\SimpleModule.Tenants\SimpleModule.Tenants.csproj" />
     <ProjectReference Include="..\..\framework\SimpleModule.Storage.Local\SimpleModule.Storage.Local.csproj" />
     <ProjectReference Include="..\..\SimpleModule.ServiceDefaults\SimpleModule.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
+++ b/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
@@ -22,6 +22,7 @@ using SimpleModule.Permissions;
 using SimpleModule.Products;
 using SimpleModule.Settings;
 using SimpleModule.FeatureFlags;
+using SimpleModule.Tenants;
 using SimpleModule.Users;
 
 namespace SimpleModule.Tests.Shared.Fixtures;
@@ -59,6 +60,7 @@ public class SimpleModuleWebApplicationFactory : WebApplicationFactory<Program>
             ReplaceDbContext<AuditLogsDbContext>(services);
             ReplaceDbContext<FileStorageDbContext>(services);
             ReplaceDbContext<FeatureFlagsDbContext>(services);
+            ReplaceDbContext<TenantsDbContext>(services);
             ReplaceDbContext<OpenIddictAppDbContext>(services, useOpenIddict: true);
 
             // Remove hosted seed services — they need real DB tables that
@@ -155,6 +157,7 @@ public class SimpleModuleWebApplicationFactory : WebApplicationFactory<Program>
         EnsureTablesCreated<AuditLogsDbContext>(sp);
         EnsureTablesCreated<FileStorageDbContext>(sp);
         EnsureTablesCreated<FeatureFlagsDbContext>(sp);
+        EnsureTablesCreated<TenantsDbContext>(sp);
         EnsureTablesCreated<OpenIddictAppDbContext>(sp);
     }
 


### PR DESCRIPTION
## Summary

- New **Tenants module** with full CRUD for tenants (name, slug, status, admin email, edition, connection string, validity period)
- **Multi-host support**: each tenant can have multiple hostnames, resolved via `TenantResolutionMiddleware` (hostname → header → claim priority chain)
- **Implements `ITenantContext`** from Core framework, enabling the built-in multi-tenant entity filtering (`IMultiTenant`, `ApplyMultiTenantFilters`) for all modules that opt in
- **Feature flags per tenant**: extends `OverrideType` enum with `Tenant = 2`, adds tenant-level feature flag management UI and API endpoints
- React pages: Browse, Manage, Create, Edit (with host management), Features (per-tenant flag toggles)
- Seed data: 3 tenants with hosts for local development
- 22 unit tests covering service CRUD, host management, and validators

## Test plan

- [x] `dotnet build` — zero errors/warnings
- [x] `dotnet test` (Tenants 22/22, FeatureFlags 14/14, Products 39/39) — all pass
- [x] `npm run build` — frontend builds
- [x] `npm run check` — Biome lint/format clean
- [x] `npm run validate-pages` — all view endpoints registered
- [ ] Manual: browse `/tenants/manage`, create/edit/delete tenants
- [ ] Manual: add/remove hosts on Edit page
- [ ] Manual: toggle feature flags per tenant on Features page
- [ ] Manual: verify hostname-based tenant resolution sets correct context