### PR TITLE
Regenerate DTO types and fix e2e smoke tests

### DIFF
--- a/modules/Admin/src/SimpleModule.Admin/types.ts
+++ b/modules/Admin/src/SimpleModule.Admin/types.ts
@@ -1,2 +1,4 @@
 // Auto-generated from [Dto] types — do not edit
-export type AdminPermissions = {};
+export interface AdminPermissions {
+}
+

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/types.ts
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/types.ts
@@ -1,4 +1,12 @@
 // Auto-generated from [Dto] types — do not edit
+export interface UserSessionDto {
+  tokenId: string;
+  type: string;
+  applicationName: string;
+  creationDate: string | null;
+  expirationDate: string | null;
+}
+
 export interface OpenIddictPermissions {
 }
 

--- a/modules/Users/src/SimpleModule.Users/types.ts
+++ b/modules/Users/src/SimpleModule.Users/types.ts
@@ -4,10 +4,13 @@ export interface AdminUserDto {
   displayName: string;
   email: string;
   emailConfirmed: boolean;
+  twoFactorEnabled: boolean;
   roles: string[];
   isLockedOut: boolean;
   isDeactivated: boolean;
+  accessFailedCount: number;
   createdAt: string;
+  lastLoginAt: string;
 }
 
 export interface RoleDto {

--- a/package-lock.json
+++ b/package-lock.json
@@ -402,6 +402,7 @@
       "integrity": "sha512-Jc360x4yqb3eEg4OY4KEIdGePBxZogivKI+OGIU8aLXgAYPTECvzeOBc90312yHA1hr3AeRlAFl0rIc8lQaIrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.50.0",
         "@algolia/requester-browser-xhr": "5.50.0",
@@ -524,6 +525,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1400,6 +1402,7 @@
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1451,6 +1454,7 @@
     "node_modules/@inertiajs/react": {
       "version": "2.3.18",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inertiajs/core": "2.3.18",
         "@types/lodash-es": "^4.17.12",
@@ -3896,6 +3900,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.5.tgz",
       "integrity": "sha512-Pkjd41UJ4F6Z8cPV+gEvqnt1VhY2g66xMjbpxREs0ECA5jRezCNKSZcc2pueQRTMtmn1SaSzGM9U/ifhVlVYOA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4173,6 +4178,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.5.tgz",
       "integrity": "sha512-yJhDa7Chx2EqJMX/jlewBv0za7slf1dKHWYve1XaApuVHEkxl0Ul3EDbwnx316vIITkuFW/pWSwkSsAplyBeCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4409,6 +4415,7 @@
     "node_modules/@types/react": {
       "version": "19.2.14",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4416,6 +4423,7 @@
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4752,6 +4760,7 @@
       "integrity": "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.16.0",
         "@algolia/client-abtesting": "5.50.0",
@@ -4860,6 +4869,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5425,6 +5435,7 @@
       "version": "0.25.12",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5543,6 +5554,7 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -5675,6 +5687,7 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.8.tgz",
       "integrity": "sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5781,6 +5794,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5869,6 +5883,7 @@
       "version": "1.31.1",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6474,6 +6489,7 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6695,6 +6711,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -6724,6 +6741,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -6772,6 +6790,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
       "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -6822,6 +6841,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6851,6 +6871,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6880,6 +6901,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7003,7 +7025,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7389,6 +7412,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7635,6 +7659,7 @@
     "node_modules/vite": {
       "version": "6.4.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8242,6 +8267,7 @@
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",

--- a/tests/e2e/pages/pagebuilder/manage.page.ts
+++ b/tests/e2e/pages/pagebuilder/manage.page.ts
@@ -13,7 +13,7 @@ export class PageBuilderManagePage {
   }
 
   get heading() {
-    return this.page.getByRole('heading', { name: /pages/i });
+    return this.page.getByRole('heading', { name: 'Pages', exact: true });
   }
 
   get newPageButton() {

--- a/tests/e2e/pages/pagebuilder/pages-list.page.ts
+++ b/tests/e2e/pages/pagebuilder/pages-list.page.ts
@@ -8,7 +8,7 @@ export class PageBuilderPagesListPage {
   }
 
   get heading() {
-    return this.page.getByRole('heading', { name: /pages/i });
+    return this.page.getByRole('heading', { name: 'Pages', exact: true });
   }
 
   get emptyMessage() {

--- a/tests/e2e/tests/smoke/filestorage.spec.ts
+++ b/tests/e2e/tests/smoke/filestorage.spec.ts
@@ -40,7 +40,7 @@ test.describe('FileStorage smoke', () => {
 
     test('browse page redirects to login', async ({ page }) => {
       const response = await page.goto('/files/browse');
-      expect(response?.url()).toContain('/Identity/Account/Login');
+      expect(response?.url()).toContain('/Account/Login');
     });
 
     test('API endpoint returns 302', async ({ request }) => {


### PR DESCRIPTION
## Changes

### TypeScript DTO Types
- **Admin module**: Convert `AdminPermissions` type to interface format
- **OpenIddict module**: Add new `UserSessionDto` interface with token and session properties
- **Users module**: Add missing fields to `AdminUserDto`:
  - `twoFactorEnabled`
  - `accessFailedCount`
  - `lastLoginAt`

### E2E Test Fixes
- Fix page heading selectors in PageBuilder tests to use exact matching instead of regex patterns
- Update FileStorage redirect test to match new login URL path (`/Account/Login` instead of `/Identity/Account/Login`)

### Dependencies
- Update `package-lock.json` to mark peer dependencies correctly