### PR TITLE
Add Tenants module to Dockerfile restore layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ COPY modules/FileStorage/src/SimpleModule.FileStorage.Contracts/*.csproj modules
 COPY modules/FileStorage/src/SimpleModule.FileStorage/*.csproj modules/FileStorage/src/SimpleModule.FileStorage/
 COPY modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/*.csproj modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/
 COPY modules/FeatureFlags/src/SimpleModule.FeatureFlags/*.csproj modules/FeatureFlags/src/SimpleModule.FeatureFlags/
+COPY modules/Tenants/src/SimpleModule.Tenants.Contracts/*.csproj modules/Tenants/src/SimpleModule.Tenants.Contracts/
+COPY modules/Tenants/src/SimpleModule.Tenants/*.csproj modules/Tenants/src/SimpleModule.Tenants/
 
 RUN dotnet restore template/SimpleModule.Host/SimpleModule.Host.csproj
 


### PR DESCRIPTION
## Summary
- Add missing COPY steps for `SimpleModule.Tenants.Contracts` and `SimpleModule.Tenants` csproj files to the Dockerfile restore stage
- The Tenants module (#32) landed after the Dockerfile rewrite (#36), so Docker builds fail with `MSB4025: Could not find a part of the path`

## Test plan
- [x] `docker build -t simplemodule-test .` succeeds locally