### PR TITLE
Fix Docker build by allowing workspace package.json files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@
 
 # Tests (not needed for Host build)
 tests/
+!tests/e2e/package.json
 modules/*/tests/
 
 # Development artifacts
@@ -28,7 +29,9 @@ modules/*/tests/
 SimpleModule.AppHost/
 cli/
 docs/
+!docs/site/package.json
 website/
+!website/package.json
 
 # CI/CD and tooling
 .github/


### PR DESCRIPTION
## Changes

Updates `.dockerignore` to allow specific `package.json` files through the ignore filter:

- `tests/e2e/package.json`
- `docs/site/package.json`
- `website/package.json`

These files are needed for the Docker build process and should not be excluded by the blanket directory ignores.