### PR TITLE
Exclude load tests from default dotnet test run

### DIFF
--- a/tests/SimpleModule.LoadTests/SimpleModule.LoadTests.csproj
+++ b/tests/SimpleModule.LoadTests/SimpleModule.LoadTests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- Exclude from default 'dotnet test' — run explicitly with: dotnet test tests/SimpleModule.LoadTests -->
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
- Set `IsTestProject` to `false` in SimpleModule.LoadTests.csproj to prevent load tests from being discovered and executed during standard `dotnet test` runs
- Load tests must now be run explicitly with `dotnet test tests/SimpleModule.LoadTests`
- Prevents unintended performance impact on standard test execution