### PR TITLE
Fix Vite build failures in Docker by adding missing tsconfig files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,9 +116,11 @@ COPY modules/Email/src/SimpleModule.Email/package.json modules/Email/src/SimpleM
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting/package.json modules/RateLimiting/src/SimpleModule.RateLimiting/
 COPY packages/SimpleModule.Client/package.json packages/SimpleModule.Client/
 COPY packages/SimpleModule.Theme.Default/package.json packages/SimpleModule.Theme.Default/
+COPY packages/SimpleModule.TsConfig/package.json packages/SimpleModule.TsConfig/
 COPY packages/SimpleModule.UI/package.json packages/SimpleModule.UI/
 COPY template/SimpleModule.Host/ClientApp/package.json template/SimpleModule.Host/ClientApp/
 COPY tests/e2e/package.json tests/e2e/
+COPY tests/k6/package.json tests/k6/
 COPY docs/site/package.json docs/site/
 COPY website/package.json website/
 

--- a/modules/Email/src/SimpleModule.Email/tsconfig.json
+++ b/modules/Email/src/SimpleModule.Email/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@simplemodule/tsconfig/base",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/tsconfig.json
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@simplemodule/tsconfig/base",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
The Docker build failed because the npm-restore stage was missing the
@simplemodule/tsconfig workspace package.json, so npm ci never created
the node_modules symlink. Also added missing tsconfig.json for Email
and RateLimiting modules, and the tests/k6 workspace package.json.