### PR TITLE
Fix login/signup in Docker deployments behind reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       Database__DefaultConnection: "Host=postgres;Port=5432;Database=simplemodule;Username=simplemodule;Password=${POSTGRES_PASSWORD:-simplemodule}"
       Database__Provider: PostgreSQL
+      # Set to your public URL so OpenIddict registers correct redirect URIs.
+      # Examples: https://app.simplemodule.dev, http://localhost:8080
+      OpenIddict__BaseUrl: ${APP_BASE_URL:-http://localhost:8080}
     depends_on:
       postgres:
         condition: service_healthy

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -139,8 +139,8 @@ public static class SimpleModuleHostExtensions
             }
         }
 
-        app.UseExceptionHandler();
         app.UseForwardedHeaders();
+        app.UseExceptionHandler();
 
         var options = app.Services.GetRequiredService<SimpleModuleOptions>();
         if (options.EnableSwagger && app.Environment.IsDevelopment())

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -47,6 +48,15 @@ public static class SimpleModuleHostExtensions
 
         BridgeAspireConnectionString(builder.Configuration);
         options.DatabaseProvider = ValidateDatabaseConfiguration(builder.Configuration);
+
+        builder.Services.Configure<ForwardedHeadersOptions>(fhOptions =>
+        {
+            fhOptions.ForwardedHeaders =
+                ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            // Allow any proxy in containerized/cloud environments
+            fhOptions.KnownIPNetworks.Clear();
+            fhOptions.KnownProxies.Clear();
+        });
 
         builder.Services.AddProblemDetails();
         builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
@@ -130,6 +140,7 @@ public static class SimpleModuleHostExtensions
         }
 
         app.UseExceptionHandler();
+        app.UseForwardedHeaders();
 
         var options = app.Services.GetRequiredService<SimpleModuleOptions>();
         if (options.EnableSwagger && app.Environment.IsDevelopment())

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
@@ -110,7 +110,7 @@ public partial class OpenIddictSeedService(
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "Updating OpenIddict client application redirect URIs..."
+        Message = "Updating OpenIddict client application..."
     )]
     private static partial void LogUpdatingClient(ILogger logger);
 

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
@@ -38,16 +38,6 @@ public partial class OpenIddictSeedService(
     {
         var manager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
 
-        if (
-            await manager.FindByClientIdAsync(ClientConstants.ClientId, cancellationToken)
-            is not null
-        )
-        {
-            return;
-        }
-
-        LogSeedingClient(logger);
-
         var baseUrl = configuration[ConfigKeys.OpenIddictBaseUrl] ?? ClientConstants.DefaultBaseUrl;
 
         var descriptor = new OpenIddictApplicationDescriptor
@@ -97,6 +87,18 @@ public partial class OpenIddictSeedService(
             }
         }
 
+        var existing = await manager.FindByClientIdAsync(
+            ClientConstants.ClientId,
+            cancellationToken
+        );
+        if (existing is not null)
+        {
+            LogUpdatingClient(logger);
+            await manager.UpdateAsync(existing, descriptor, cancellationToken);
+            return;
+        }
+
+        LogSeedingClient(logger);
         await manager.CreateAsync(descriptor, cancellationToken);
     }
 
@@ -105,6 +107,12 @@ public partial class OpenIddictSeedService(
         Message = "Seeding OpenIddict client application..."
     )]
     private static partial void LogSeedingClient(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Updating OpenIddict client application redirect URIs..."
+    )]
+    private static partial void LogUpdatingClient(ILogger logger);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/template/SimpleModule.Host/appsettings.Production.json
+++ b/template/SimpleModule.Host/appsettings.Production.json
@@ -3,6 +3,9 @@
     "DefaultConnection": "Data Source=/app/data/app.db",
     "Provider": "Sqlite"
   },
+  "OpenIddict": {
+    "BaseUrl": "https://app.simplemodule.dev"
+  },
   "Storage": {
     "Local": {
       "BasePath": "/app/storage"


### PR DESCRIPTION
Three issues prevented auth from working at app.simplemodule.dev:

1. No ForwardedHeaders middleware — the app behind a reverse proxy saw
   Request.Scheme as "http" and Request.Host as "localhost:8080" instead
   of the real values, breaking cookie security, redirects, and email
   confirmation links.

2. OpenIddict client redirect URIs were seeded with https://localhost:5001
   because OpenIddict:BaseUrl was never configured in docker-compose.yml.
   Added APP_BASE_URL env var support (defaults to http://localhost:8080).

3. The seed service skipped updating an existing OAuth client, so changing
   BaseUrl after initial seeding had no effect. Now it updates redirect
   URIs on every startup to match the current configuration.