### PR TITLE
Fix Identity cookie redirect paths to match ViewPrefix

### DIFF
--- a/modules/Users/src/SimpleModule.Users/UsersModule.cs
+++ b/modules/Users/src/SimpleModule.Users/UsersModule.cs
@@ -24,6 +24,13 @@ public class UsersModule : IModule
             .AddEntityFrameworkStores<UsersDbContext>()
             .AddDefaultTokenProviders();
 
+        services.ConfigureApplicationCookie(options =>
+        {
+            options.LoginPath = "/Identity/Account/Login";
+            options.LogoutPath = "/Identity/Account/Logout";
+            options.AccessDeniedPath = "/Identity/Account/AccessDenied";
+        });
+
         // Bridge UsersModuleOptions into ASP.NET Identity options
         services.AddSingleton<IPostConfigureOptions<IdentityOptions>, ApplyUsersModuleOptions>();
 


### PR DESCRIPTION
## Summary

- ASP.NET Identity defaults `LoginPath` to `/Account/Login`, but the Users module uses `ViewPrefix = "/Identity/Account"`, placing the login route at `/Identity/Account/Login`
- Unauthenticated requests were redirected to `/Account/Login` which returned 404
- Explicitly configures `LoginPath`, `LogoutPath`, and `AccessDeniedPath` on the application cookie to match the ViewPrefix

## Test plan

- [ ] Deploy and verify unauthenticated API requests redirect to `/Identity/Account/Login` instead of `/Account/Login`
- [ ] Verify login page loads and form submission works
- [ ] Verify register page loads and form submission works
- [ ] Verify logout redirects correctly