### PR TITLE
fix: guarantee unique cache-buster per deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,9 +173,12 @@ COPY --from=build --chown=appuser:appgroup /app/publish .
 # Writable directory for SQLite database and local storage
 RUN mkdir -p /app/data /app/storage && chown appuser:appgroup /app/data /app/storage
 
-# Set deployment version for JS/CSS cache-busting and Inertia stale-version detection.
-# Override at runtime or build time: docker build --build-arg DEPLOY_VERSION=$(git rev-parse --short HEAD)
-ARG DEPLOY_VERSION=latest
+# Deployment version for JS/CSS cache-busting and Inertia stale-version detection.
+# Left empty by default so InertiaMiddleware.GetVersion() falls back to the entry
+# assembly's last-write timestamp (yyyyMMddHHmmss), which changes on every publish
+# and guarantees cache invalidation with zero configuration.
+# Override for deterministic versions: docker build --build-arg DEPLOY_VERSION=$(git rev-parse --short HEAD)
+ARG DEPLOY_VERSION=
 ENV DEPLOYMENT_VERSION=${DEPLOY_VERSION}
 
 USER appuser


### PR DESCRIPTION
## Summary

Two gaps were letting browsers cache stale JS/CSS across deploys, causing the exact symptoms from #94's original bug report to reappear after that PR shipped:

- `Dockerfile` hardcoded `ARG DEPLOY_VERSION=latest`, so every image set `DEPLOYMENT_VERSION=latest` and every asset URL ended in `?v=latest`. `InertiaMiddleware.GetVersion()`'s assembly-timestamp fallback was masked, the `X-Inertia-Version` header never changed between deploys, and browsers kept serving cached bundles that referenced chunk hashes no longer on disk — hard 404 on dynamic imports like `Home-MQTOkMvb.mjs`.
- The importmap in `index.html` referenced five vendor entries (`/js/vendor/react.js`, `react-dom`, `react-dom/client`, `react/jsx-runtime`, `@inertiajs/react`) with no `?v=` suffix at all, so fresh deploys kept using the browser's cached vendor chunks indefinitely.

## Changes

- **`Dockerfile`**: default `DEPLOY_VERSION` to empty. When unset, `InertiaMiddleware.GetVersion()` derives the version from the entry assembly's last-write timestamp (`yyyyMMddHHmmss`), which advances on every publish. Pass `--build-arg DEPLOY_VERSION=$(git rev-parse --short HEAD)` for deterministic versions if needed.
- **`template/SimpleModule.Host/wwwroot/index.html`**: add `?v=<!--DEPLOY_VERSION-->` to each importmap entry so they participate in the same replacement pass as `app.js` and `app.css`.

## Test plan

Verified locally with `dotnet run --project template/SimpleModule.Host`:

| Asset | Cache buster |
|---|---|
| `<meta name="cache-buster">` | `20260408111445` |
| `/css/app.css` | `?v=20260408111445` |
| `/_content/SimpleModule.PageBuilder/simplemodule.pagebuilder.css` | `?v=20260408111445` |
| `/js/vendor/react.js` (+ 4 other vendor entries) | `?v=20260408111445` |
| `/js/app.js` | `?v=20260408111445` |

Direct fetches all returned `200` with correct `Content-Type`:

- `/css/app.css` → `text/css`
- `/_content/SimpleModule.PageBuilder/simplemodule.pagebuilder.css` → `text/css`
- `/js/app.js` → `text/javascript`
- `/js/vendor/react.js` → `text/javascript`
- `/_content/SimpleModule.Users/SimpleModule.Users.pages.js` → `text/javascript`

Also verified via `docker build -t simplemodule:test . && docker run ...` that the rendered HTML emits a fresh timestamp instead of the literal `latest` string.

- [ ] Rebuild and deploy the image; confirm no stale-asset errors in production browser console after full refresh.
- [ ] Confirm subsequent deploys continue to get unique `?v=` values (no manual `--build-arg` needed).