### PR TITLE
Apply base entity inheritance consistently across all modules

### DIFF
--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -82,10 +82,19 @@ public class BrowseEndpoint(IOptions<ProductsModuleOptions> options) : IViewEndp
 - Options classes may live in the module assembly or its Contracts assembly.
 ### What a Module Must Never Expose
 
-- Entity classes
 - DbContext or DbSet types
 - Internal services
-- EF Core configurations
+- EF Core configurations (`IEntityTypeConfiguration<T>`)
+
+### What a Module Must Always Expose
+
+- **Entity classes** — every class used as `DbSet<T>` in a module's `DbContext`
+  must live in that module's `.Contracts` assembly (SM0055, error). This keeps
+  EF Core entities addressable from cross-module code without leaking the
+  implementation assembly, and it puts the entity alongside the DTOs and
+  contract interfaces that already describe the module's public surface.
+  Mark non-DTO entities with `[NoDtoGeneration]` so the source generator
+  doesn't emit TypeScript interfaces for them.
 
 ### Structural Rules
 
@@ -133,15 +142,20 @@ Dependencies flow one way: **implementation --> contracts --> core**. Never side
 
 ### Each Module Owns Its Data Exclusively
 
-- Entities live in the implementation assembly, never in Contracts.
-- Only the owning module's service layer may read or write its entities.
-- Other modules access data through the contract interface.
+- **Entity classes live in the module's `.Contracts` assembly** (enforced by
+  SM0055). Mark non-DTO entities with `[NoDtoGeneration]` so the source
+  generator doesn't emit TypeScript interfaces for them.
+- `IEntityTypeConfiguration<T>` mappings, the `DbContext`, and the service
+  layer all live in the implementation assembly. They are the only code
+  allowed to read or write the entities.
+- Other modules access data through the contract interface — they never
+  touch a `DbContext` or `IQueryable<T>` directly.
 
 ### DbContext Rules
 
 - Register with `AddModuleDbContext<TContext>(configuration, ModuleName)`.
 - Call `ApplyModuleSchema()` in `OnModelCreating`.
-- Use entity configurations via `IEntityTypeConfiguration<T>`.
+- Use entity configurations via `IEntityTypeConfiguration<T>` (implementation-only).
 - Register Vogen value object converters in `ConfigureConventions`.
 - One DbContext per module, maximum.
 
@@ -392,6 +406,7 @@ All SM diagnostics are emitted by the Roslyn source generator at compile time. `
 | SM0005 | Error | IdentityDbContext must use three type arguments |
 | SM0006 | Warning | Orphaned entity configuration (not referenced by any DbSet) |
 | SM0007 | Error | No duplicate entity configurations |
+| SM0055 | Error | Entity class must live in a `.Contracts` assembly |
 
 ### Module Structure
 

--- a/framework/SimpleModule.Database/DatabaseOptionsExtensions.cs
+++ b/framework/SimpleModule.Database/DatabaseOptionsExtensions.cs
@@ -1,0 +1,30 @@
+namespace SimpleModule.Database;
+
+/// <summary>
+/// Convenience helpers for resolving a <see cref="DatabaseProvider"/> from a
+/// <see cref="DatabaseOptions"/> instance, tolerating missing defaults by
+/// falling back to module-specific connections or explicit provider names.
+/// </summary>
+public static class DatabaseOptionsExtensions
+{
+    /// <summary>
+    /// Detects the database provider for <paramref name="moduleName"/>, honoring
+    /// module-specific connection strings and explicit <see cref="DatabaseOptions.Provider"/>.
+    /// Returns <c>null</c> when neither a connection string nor an explicit provider is configured.
+    /// </summary>
+    public static DatabaseProvider? DetectProvider(this DatabaseOptions options, string moduleName)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var cs = options.ModuleConnections.TryGetValue(moduleName, out var module)
+            ? module
+            : options.DefaultConnection;
+
+        if (string.IsNullOrWhiteSpace(cs) && string.IsNullOrWhiteSpace(options.Provider))
+        {
+            return null;
+        }
+
+        return DatabaseProviderDetector.Detect(cs ?? string.Empty, options.Provider);
+    }
+}

--- a/framework/SimpleModule.Generator/AnalyzerReleases.Unshipped.md
+++ b/framework/SimpleModule.Generator/AnalyzerReleases.Unshipped.md
@@ -39,3 +39,4 @@ SM0049 | SimpleModule.Generator | Error | Multiple endpoints in a single file
 SM0052 | SimpleModule.Generator | Error | Module assembly name does not follow naming convention
 SM0053 | SimpleModule.Generator | Error | Module has no matching Contracts assembly
 SM0054 | SimpleModule.Generator | Info | Endpoint missing Route const field
+SM0055 | SimpleModule.Generator | Error | Entity class must live in a Contracts assembly

--- a/framework/SimpleModule.Generator/Discovery/DiscoveryData.cs
+++ b/framework/SimpleModule.Generator/Discovery/DiscoveryData.cs
@@ -304,7 +304,12 @@ internal readonly record struct DbContextInfoRecord(
     }
 }
 
-internal readonly record struct DbSetInfoRecord(string PropertyName, string EntityFqn);
+internal readonly record struct DbSetInfoRecord(
+    string PropertyName,
+    string EntityFqn,
+    string EntityAssemblyName,
+    SourceLocationRecord? EntityLocation
+);
 
 internal readonly record struct EntityConfigInfoRecord(
     string ConfigFqn,
@@ -557,6 +562,8 @@ internal sealed class DbSetInfo
 {
     public string PropertyName { get; set; } = "";
     public string EntityFqn { get; set; } = "";
+    public string EntityAssemblyName { get; set; } = "";
+    public SourceLocationRecord? EntityLocation { get; set; }
 }
 
 internal sealed class EntityConfigInfo

--- a/framework/SimpleModule.Generator/Discovery/SymbolDiscovery.cs
+++ b/framework/SimpleModule.Generator/Discovery/SymbolDiscovery.cs
@@ -735,7 +735,12 @@ internal static class SymbolDiscovery
                     c.IdentityUserTypeFqn,
                     c.IdentityRoleTypeFqn,
                     c.IdentityKeyTypeFqn,
-                    c.DbSets.Select(d => new DbSetInfoRecord(d.PropertyName, d.EntityFqn))
+                    c.DbSets.Select(d => new DbSetInfoRecord(
+                            d.PropertyName,
+                            d.EntityFqn,
+                            d.EntityAssemblyName,
+                            d.EntityLocation
+                        ))
                         .ToImmutableArray(),
                     c.Location
                 ))
@@ -1380,11 +1385,20 @@ internal static class SymbolDiscovery
                         ) == "global::Microsoft.EntityFrameworkCore.DbSet<TEntity>"
                     )
                     {
-                        var entityFqn = propType
-                            .TypeArguments[0]
-                            .ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                        var entityType = propType.TypeArguments[0];
+                        var entityFqn = entityType.ToDisplayString(
+                            SymbolDisplayFormat.FullyQualifiedFormat
+                        );
+                        var entityAssemblyName =
+                            entityType.ContainingAssembly?.Name ?? string.Empty;
                         info.DbSets.Add(
-                            new DbSetInfo { PropertyName = prop.Name, EntityFqn = entityFqn }
+                            new DbSetInfo
+                            {
+                                PropertyName = prop.Name,
+                                EntityFqn = entityFqn,
+                                EntityAssemblyName = entityAssemblyName,
+                                EntityLocation = GetSourceLocation(entityType),
+                            }
                         );
                     }
                 }

--- a/framework/SimpleModule.Generator/Emitters/DiagnosticEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/DiagnosticEmitter.cs
@@ -7,6 +7,35 @@ using Microsoft.CodeAnalysis;
 
 namespace SimpleModule.Generator;
 
+/// <summary>
+/// Naming conventions for SimpleModule assemblies. Centralised so the same
+/// string literals don't drift between discovery code and diagnostic emission.
+/// </summary>
+internal static class AssemblyConventions
+{
+    internal const string FrameworkPrefix = "SimpleModule.";
+    internal const string ContractsSuffix = ".Contracts";
+    internal const string ModuleSuffix = ".Module";
+
+    /// <summary>
+    /// Derives the `.Contracts` sibling assembly name for a SimpleModule
+    /// implementation assembly. Strips a trailing <c>.Module</c> suffix first
+    /// so <c>SimpleModule.Agents.Module</c> maps to
+    /// <c>SimpleModule.Agents.Contracts</c> instead of
+    /// <c>SimpleModule.Agents.Module.Contracts</c>.
+    /// </summary>
+    internal static string GetExpectedContractsAssemblyName(string implementationAssemblyName)
+    {
+        var baseName = implementationAssemblyName.EndsWith(ModuleSuffix, StringComparison.Ordinal)
+            ? implementationAssemblyName.Substring(
+                0,
+                implementationAssemblyName.Length - ModuleSuffix.Length
+            )
+            : implementationAssemblyName;
+        return baseName + ContractsSuffix;
+    }
+}
+
 internal sealed class DiagnosticEmitter : IEmitter
 {
     internal static readonly DiagnosticDescriptor DuplicateDbSetPropertyName = new(
@@ -471,42 +500,39 @@ internal sealed class DiagnosticEmitter : IEmitter
         }
 
         // SM0055: Entity classes must live in a .Contracts assembly.
-        // Reported once per (entity, DbContext) pair so the author sees the
-        // offending DbSet in their editor. Only warns for entities the author
-        // can actually move — source-declared, inside a SimpleModule.* module,
-        // and NOT an Identity/OpenIddict external type.
+        // Walks every DbSet in the same pass that also collects EntityFqns
+        // for SM0006 below, so we only iterate data.DbContexts once.
+        var allEntityFqns = new HashSet<string>();
         foreach (var ctx in data.DbContexts)
         {
-            // IdentityDbContext uses external Identity entity types we can't move.
-            if (ctx.IsIdentityDbContext)
-                continue;
-
             foreach (var dbSet in ctx.DbSets)
             {
-                if (string.IsNullOrEmpty(dbSet.EntityAssemblyName))
-                    continue;
+                allEntityFqns.Add(dbSet.EntityFqn);
 
-                // Skip entities that aren't source-declared in a SimpleModule.* project.
-                // External libraries (OpenIddict, etc.) have no source location and shouldn't
-                // be reported even if the user can't physically move them.
+                // Skip entities we can't flag: IdentityDbContext external types,
+                // metadata-only symbols (no source location), and anything that
+                // lives outside the SimpleModule.* assembly family.
+                if (ctx.IsIdentityDbContext)
+                    continue;
                 if (dbSet.EntityLocation is null)
                     continue;
-
-                if (!dbSet.EntityAssemblyName.StartsWith("SimpleModule.", StringComparison.Ordinal))
-                    continue;
-
-                if (dbSet.EntityAssemblyName.EndsWith(".Contracts", StringComparison.Ordinal))
-                    continue;
-
-                var expectedContractsAssembly = dbSet.EntityAssemblyName.EndsWith(
-                    ".Module",
-                    StringComparison.Ordinal
+                if (
+                    !dbSet.EntityAssemblyName.StartsWith(
+                        AssemblyConventions.FrameworkPrefix,
+                        StringComparison.Ordinal
+                    )
                 )
-                    ? dbSet.EntityAssemblyName.Substring(
-                        0,
-                        dbSet.EntityAssemblyName.Length - ".Module".Length
-                    ) + ".Contracts"
-                    : dbSet.EntityAssemblyName + ".Contracts";
+                    continue;
+                if (
+                    dbSet.EntityAssemblyName.EndsWith(
+                        AssemblyConventions.ContractsSuffix,
+                        StringComparison.Ordinal
+                    )
+                )
+                    continue;
+
+                var expectedContractsAssembly =
+                    AssemblyConventions.GetExpectedContractsAssemblyName(dbSet.EntityAssemblyName);
 
                 context.ReportDiagnostic(
                     Diagnostic.Create(
@@ -523,13 +549,7 @@ internal sealed class DiagnosticEmitter : IEmitter
         }
 
         // SM0006: Entity config for entity not in any DbSet
-        var allEntityFqns = new HashSet<string>();
-        foreach (var ctx in data.DbContexts)
-        {
-            foreach (var dbSet in ctx.DbSets)
-                allEntityFqns.Add(dbSet.EntityFqn);
-        }
-
+        // (allEntityFqns was populated above during the SM0055 pass)
         foreach (var config in data.EntityConfigs)
         {
             if (!allEntityFqns.Contains(config.EntityFqn))

--- a/framework/SimpleModule.Generator/Emitters/DiagnosticEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/DiagnosticEmitter.cs
@@ -342,6 +342,15 @@ internal sealed class DiagnosticEmitter : IEmitter
         isEnabledByDefault: true
     );
 
+    internal static readonly DiagnosticDescriptor EntityNotInContractsAssembly = new(
+        id: "SM0055",
+        title: "Entity class must live in a Contracts assembly",
+        messageFormat: "Entity '{0}' is exposed as DbSet '{1}' on '{2}' but is declared in assembly '{3}'. Entity classes must be declared in a '.Contracts' assembly so other modules can reference them type-safely through contracts. Move '{0}' to assembly '{4}' (or another '.Contracts' assembly that the module references).",
+        category: "SimpleModule.Generator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true
+    );
+
     public void Emit(SourceProductionContext context, DiscoveryData data)
     {
         // SM0002: Empty module name
@@ -456,6 +465,58 @@ internal sealed class DiagnosticEmitter : IEmitter
                         Strip(ctx.FullyQualifiedName),
                         ctx.ModuleName,
                         0
+                    )
+                );
+            }
+        }
+
+        // SM0055: Entity classes must live in a .Contracts assembly.
+        // Reported once per (entity, DbContext) pair so the author sees the
+        // offending DbSet in their editor. Only warns for entities the author
+        // can actually move — source-declared, inside a SimpleModule.* module,
+        // and NOT an Identity/OpenIddict external type.
+        foreach (var ctx in data.DbContexts)
+        {
+            // IdentityDbContext uses external Identity entity types we can't move.
+            if (ctx.IsIdentityDbContext)
+                continue;
+
+            foreach (var dbSet in ctx.DbSets)
+            {
+                if (string.IsNullOrEmpty(dbSet.EntityAssemblyName))
+                    continue;
+
+                // Skip entities that aren't source-declared in a SimpleModule.* project.
+                // External libraries (OpenIddict, etc.) have no source location and shouldn't
+                // be reported even if the user can't physically move them.
+                if (dbSet.EntityLocation is null)
+                    continue;
+
+                if (!dbSet.EntityAssemblyName.StartsWith("SimpleModule.", StringComparison.Ordinal))
+                    continue;
+
+                if (dbSet.EntityAssemblyName.EndsWith(".Contracts", StringComparison.Ordinal))
+                    continue;
+
+                var expectedContractsAssembly = dbSet.EntityAssemblyName.EndsWith(
+                    ".Module",
+                    StringComparison.Ordinal
+                )
+                    ? dbSet.EntityAssemblyName.Substring(
+                        0,
+                        dbSet.EntityAssemblyName.Length - ".Module".Length
+                    ) + ".Contracts"
+                    : dbSet.EntityAssemblyName + ".Contracts";
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        EntityNotInContractsAssembly,
+                        LocationHelper.ToLocation(dbSet.EntityLocation),
+                        Strip(dbSet.EntityFqn),
+                        dbSet.PropertyName,
+                        Strip(ctx.FullyQualifiedName),
+                        dbSet.EntityAssemblyName,
+                        expectedContractsAssembly
                     )
                 );
             }

--- a/modules/Agents/src/SimpleModule.Agents.Contracts/AgentMessage.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Contracts/AgentMessage.cs
@@ -1,7 +1,8 @@
-using SimpleModule.Agents.Contracts;
+using SimpleModule.Core;
 
-namespace SimpleModule.Agents.Module;
+namespace SimpleModule.Agents.Contracts;
 
+[NoDtoGeneration]
 public sealed class AgentMessage
 {
     public AgentMessageId Id { get; set; } = AgentMessageId.From(Guid.NewGuid().ToString());

--- a/modules/Agents/src/SimpleModule.Agents.Contracts/AgentMessageId.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Contracts/AgentMessageId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Agents.Contracts;
+
+[ValueObject<string>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct AgentMessageId;

--- a/modules/Agents/src/SimpleModule.Agents.Contracts/AgentSession.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Contracts/AgentSession.cs
@@ -1,7 +1,6 @@
-using SimpleModule.Agents.Contracts;
 using SimpleModule.Core.Entities;
 
-namespace SimpleModule.Agents.Module;
+namespace SimpleModule.Agents.Contracts;
 
 public sealed class AgentSession : Entity<AgentSessionId>
 {

--- a/modules/Agents/src/SimpleModule.Agents.Contracts/AgentSessionId.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Contracts/AgentSessionId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Agents.Contracts;
+
+[ValueObject<string>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct AgentSessionId;

--- a/modules/Agents/src/SimpleModule.Agents.Contracts/SimpleModule.Agents.Contracts.csproj
+++ b/modules/Agents/src/SimpleModule.Agents.Contracts/SimpleModule.Agents.Contracts.csproj
@@ -3,8 +3,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Description>Contracts for the SimpleModule Agents module. Events and shared types for cross-module use.</Description>
+    <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Vogen" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/modules/Agents/src/SimpleModule.Agents.Module/AgentsDbContext.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/AgentsDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
+using SimpleModule.Agents.Contracts;
 using SimpleModule.Database;
 
 namespace SimpleModule.Agents.Module;
@@ -22,6 +23,19 @@ public sealed class AgentsDbContext(
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
+        configurationBuilder
+            .Properties<AgentSessionId>()
+            .HaveConversion<
+                AgentSessionId.EfCoreValueConverter,
+                AgentSessionId.EfCoreValueComparer
+            >();
+        configurationBuilder
+            .Properties<AgentMessageId>()
+            .HaveConversion<
+                AgentMessageId.EfCoreValueConverter,
+                AgentMessageId.EfCoreValueComparer
+            >();
+
         // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
         // Store as long (binary ticks) only when running against SQLite.
         if (dbOptions.Value.DetectProvider(AgentsConstants.ModuleName) == DatabaseProvider.Sqlite)

--- a/modules/Agents/src/SimpleModule.Agents.Module/AgentsDbContext.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/AgentsDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 
@@ -17,5 +18,20 @@ public sealed class AgentsDbContext(
         modelBuilder.ApplyConfiguration(new EntityConfigurations.AgentSessionConfiguration());
         modelBuilder.ApplyConfiguration(new EntityConfigurations.AgentMessageConfiguration());
         modelBuilder.ApplyModuleSchema(AgentsConstants.ModuleName, dbOptions.Value);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider(AgentsConstants.ModuleName) == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/Agents/src/SimpleModule.Agents.Module/AgentsService.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/AgentsService.cs
@@ -42,7 +42,7 @@ public sealed class AgentsService(IAgentSessionStore sessionStore) : IAgentsCont
     private static AgentSessionDto ToDto(AgentSession session) =>
         new()
         {
-            Id = session.Id,
+            Id = session.Id.Value,
             AgentName = session.AgentName,
             UserId = session.UserId,
             CreatedAt = session.CreatedAt,
@@ -52,8 +52,8 @@ public sealed class AgentsService(IAgentSessionStore sessionStore) : IAgentsCont
     private static AgentMessageDto ToDto(AgentMessage message) =>
         new()
         {
-            Id = message.Id,
-            SessionId = message.SessionId,
+            Id = message.Id.Value,
+            SessionId = message.SessionId.Value,
             Role = message.Role,
             Content = message.Content,
             Timestamp = message.Timestamp,

--- a/modules/Agents/src/SimpleModule.Agents.Module/EfAgentSessionStore.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/EfAgentSessionStore.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SimpleModule.Agents.Contracts;
 
 namespace SimpleModule.Agents.Module;
 
@@ -9,7 +10,8 @@ public sealed class EfAgentSessionStore(AgentsDbContext db) : IAgentSessionStore
         CancellationToken cancellationToken = default
     )
     {
-        return await db.Sessions.FindAsync([sessionId], cancellationToken);
+        var id = AgentSessionId.From(sessionId);
+        return await db.Sessions.FindAsync([id], cancellationToken);
     }
 
     public async Task<AgentSession> CreateSessionAsync(
@@ -30,10 +32,11 @@ public sealed class EfAgentSessionStore(AgentsDbContext db) : IAgentSessionStore
         CancellationToken cancellationToken = default
     )
     {
-        message.SessionId = sessionId;
+        var id = AgentSessionId.From(sessionId);
+        message.SessionId = id;
         db.Messages.Add(message);
 
-        var session = await db.Sessions.FindAsync([sessionId], cancellationToken);
+        var session = await db.Sessions.FindAsync([id], cancellationToken);
         if (session is not null)
         {
             session.LastMessageAt = DateTimeOffset.UtcNow;
@@ -48,7 +51,8 @@ public sealed class EfAgentSessionStore(AgentsDbContext db) : IAgentSessionStore
         CancellationToken cancellationToken = default
     )
     {
-        var query = db.Messages.Where(m => m.SessionId == sessionId);
+        var id = AgentSessionId.From(sessionId);
+        var query = db.Messages.Where(m => m.SessionId == id);
 
         if (maxMessages.HasValue)
         {

--- a/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentMessageConfiguration.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentMessageConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.Agents.Contracts;
 
 namespace SimpleModule.Agents.Module.EntityConfigurations;
 

--- a/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentSessionConfiguration.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentSessionConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.Agents.Contracts;
 
 namespace SimpleModule.Agents.Module.EntityConfigurations;
 

--- a/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentSessionConfiguration.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/EntityConfigurations/AgentSessionConfiguration.cs
@@ -12,6 +12,8 @@ public sealed class AgentSessionConfiguration : IEntityTypeConfiguration<AgentSe
         builder.Property(e => e.AgentName).IsRequired().HasMaxLength(256);
         builder.Property(e => e.UserId).HasMaxLength(256);
         builder.Property(e => e.CreatedAt).IsRequired();
+        builder.Property(e => e.UpdatedAt).IsRequired();
+        builder.Property(e => e.ConcurrencyStamp).HasMaxLength(64);
         builder.Property(e => e.LastMessageAt).IsRequired();
 
         builder.HasIndex(e => e.AgentName);

--- a/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentMessage.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentMessage.cs
@@ -1,9 +1,11 @@
+using SimpleModule.Agents.Contracts;
+
 namespace SimpleModule.Agents.Module;
 
 public sealed class AgentMessage
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string SessionId { get; set; } = "";
+    public AgentMessageId Id { get; set; } = AgentMessageId.From(Guid.NewGuid().ToString());
+    public AgentSessionId SessionId { get; set; } = AgentSessionId.From(string.Empty);
     public string Role { get; set; } = "";
     public string Content { get; set; } = "";
     public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;

--- a/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentSession.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentSession.cs
@@ -1,12 +1,13 @@
+using SimpleModule.Agents.Contracts;
 using SimpleModule.Core.Entities;
 
 namespace SimpleModule.Agents.Module;
 
-public sealed class AgentSession : Entity<string>
+public sealed class AgentSession : Entity<AgentSessionId>
 {
     public AgentSession()
     {
-        Id = Guid.NewGuid().ToString();
+        Id = AgentSessionId.From(Guid.NewGuid().ToString());
     }
 
     public string AgentName { get; set; } = "";

--- a/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentSession.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/Sessions/AgentSession.cs
@@ -1,10 +1,15 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Agents.Module;
 
-public sealed class AgentSession
+public sealed class AgentSession : Entity<string>
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public AgentSession()
+    {
+        Id = Guid.NewGuid().ToString();
+    }
+
     public string AgentName { get; set; } = "";
     public string? UserId { get; set; }
-    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset LastMessageAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/modules/Agents/src/SimpleModule.Agents.Module/Sessions/IAgentSessionStore.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/Sessions/IAgentSessionStore.cs
@@ -1,3 +1,5 @@
+using SimpleModule.Agents.Contracts;
+
 namespace SimpleModule.Agents.Module;
 
 public interface IAgentSessionStore

--- a/modules/Agents/src/SimpleModule.Agents.Module/Sessions/InMemoryAgentSessionStore.cs
+++ b/modules/Agents/src/SimpleModule.Agents.Module/Sessions/InMemoryAgentSessionStore.cs
@@ -1,18 +1,19 @@
 using System.Collections.Concurrent;
+using SimpleModule.Agents.Contracts;
 
 namespace SimpleModule.Agents.Module;
 
 public sealed class InMemoryAgentSessionStore : IAgentSessionStore
 {
-    private readonly ConcurrentDictionary<string, AgentSession> _sessions = new();
-    private readonly ConcurrentDictionary<string, List<AgentMessage>> _messages = new();
+    private readonly ConcurrentDictionary<AgentSessionId, AgentSession> _sessions = new();
+    private readonly ConcurrentDictionary<AgentSessionId, List<AgentMessage>> _messages = new();
 
     public Task<AgentSession?> GetSessionAsync(
         string sessionId,
         CancellationToken cancellationToken = default
     )
     {
-        _sessions.TryGetValue(sessionId, out var session);
+        _sessions.TryGetValue(AgentSessionId.From(sessionId), out var session);
         return Task.FromResult(session);
     }
 
@@ -34,12 +35,13 @@ public sealed class InMemoryAgentSessionStore : IAgentSessionStore
         CancellationToken cancellationToken = default
     )
     {
-        message.SessionId = sessionId;
-        var messages = _messages.GetOrAdd(sessionId, _ => []);
+        var id = AgentSessionId.From(sessionId);
+        message.SessionId = id;
+        var messages = _messages.GetOrAdd(id, _ => []);
         lock (messages)
         {
             messages.Add(message);
-            if (_sessions.TryGetValue(sessionId, out var session))
+            if (_sessions.TryGetValue(id, out var session))
             {
                 session.LastMessageAt = DateTimeOffset.UtcNow;
             }
@@ -54,7 +56,7 @@ public sealed class InMemoryAgentSessionStore : IAgentSessionStore
         CancellationToken cancellationToken = default
     )
     {
-        if (!_messages.TryGetValue(sessionId, out var messages))
+        if (!_messages.TryGetValue(AgentSessionId.From(sessionId), out var messages))
             return Task.FromResult<IReadOnlyList<AgentMessage>>([]);
 
         lock (messages)

--- a/modules/Agents/src/SimpleModule.Agents/types.ts
+++ b/modules/Agents/src/SimpleModule.Agents/types.ts
@@ -16,3 +16,13 @@ export interface AgentSessionDto {
   lastMessageAt: string;
 }
 
+export interface AgentSession {
+  agentName: string;
+  userId: string;
+  lastMessageAt: string;
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
+}
+

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs.Contracts/JobProgress.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs.Contracts/JobProgress.cs
@@ -1,7 +1,6 @@
-using SimpleModule.BackgroundJobs.Contracts;
 using SimpleModule.Core.Entities;
 
-namespace SimpleModule.BackgroundJobs.Entities;
+namespace SimpleModule.BackgroundJobs.Contracts;
 
 public class JobProgress : Entity<JobId>
 {

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs.Contracts/JobQueueEntryEntity.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs.Contracts/JobQueueEntryEntity.cs
@@ -1,8 +1,9 @@
-using SimpleModule.BackgroundJobs.Contracts;
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
 
-namespace SimpleModule.BackgroundJobs.Entities;
+namespace SimpleModule.BackgroundJobs.Contracts;
 
+[NoDtoGeneration]
 public class JobQueueEntryEntity : Entity<JobId>
 {
     public string JobTypeName { get; set; } = string.Empty;

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/BackgroundJobsDbContext.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/BackgroundJobsDbContext.cs
@@ -25,9 +25,14 @@ public class BackgroundJobsDbContext(
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
-        var connectionString = dbOptions.Value.DefaultConnection;
-        var provider = DatabaseProviderDetector.Detect(connectionString, dbOptions.Value.Provider);
-        if (provider == DatabaseProvider.Sqlite)
+        configurationBuilder
+            .Properties<JobId>()
+            .HaveConversion<JobId.EfCoreValueConverter, JobId.EfCoreValueComparer>();
+
+        if (
+            dbOptions.Value.DetectProvider(BackgroundJobsConstants.ModuleName)
+            == DatabaseProvider.Sqlite
+        )
         {
             configurationBuilder
                 .Properties<DateTimeOffset>()

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/BackgroundJobsDbContext.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/BackgroundJobsDbContext.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using SimpleModule.BackgroundJobs.EntityConfigurations;
 using SimpleModule.Database;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobProgress.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobProgress.cs
@@ -1,8 +1,9 @@
+using SimpleModule.BackgroundJobs.Contracts;
 using SimpleModule.Core.Entities;
 
 namespace SimpleModule.BackgroundJobs.Entities;
 
-public class JobProgress : Entity<Guid>
+public class JobProgress : Entity<JobId>
 {
     public string JobTypeName { get; set; } = string.Empty;
     public string ModuleName { get; set; } = string.Empty;

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobProgress.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobProgress.cs
@@ -1,13 +1,13 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.BackgroundJobs.Entities;
 
-public class JobProgress
+public class JobProgress : Entity<Guid>
 {
-    public Guid Id { get; set; }
     public string JobTypeName { get; set; } = string.Empty;
     public string ModuleName { get; set; } = string.Empty;
     public int ProgressPercentage { get; set; }
     public string? ProgressMessage { get; set; }
     public string? Data { get; set; }
     public string? Logs { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobQueueEntryEntity.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobQueueEntryEntity.cs
@@ -3,7 +3,7 @@ using SimpleModule.Core.Entities;
 
 namespace SimpleModule.BackgroundJobs.Entities;
 
-public class JobQueueEntryEntity : Entity<Guid>
+public class JobQueueEntryEntity : Entity<JobId>
 {
     public string JobTypeName { get; set; } = string.Empty;
     public string? SerializedData { get; set; }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobQueueEntryEntity.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Entities/JobQueueEntryEntity.cs
@@ -1,10 +1,10 @@
 using SimpleModule.BackgroundJobs.Contracts;
+using SimpleModule.Core.Entities;
 
 namespace SimpleModule.BackgroundJobs.Entities;
 
-public class JobQueueEntryEntity
+public class JobQueueEntryEntity : Entity<Guid>
 {
-    public Guid Id { get; set; }
     public string JobTypeName { get; set; } = string.Empty;
     public string? SerializedData { get; set; }
     public DateTimeOffset ScheduledAt { get; set; }
@@ -13,7 +13,6 @@ public class JobQueueEntryEntity
     public DateTimeOffset? ClaimedAt { get; set; }
     public int AttemptCount { get; set; }
     public string? Error { get; set; }
-    public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? CompletedAt { get; set; }
     public string? CronExpression { get; set; }
     public string? RecurringName { get; set; }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobProgressConfiguration.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobProgressConfiguration.cs
@@ -13,6 +13,7 @@ public class JobProgressConfiguration : IEntityTypeConfiguration<JobProgress>
         builder.Property(j => j.JobTypeName).IsRequired().HasMaxLength(500);
         builder.Property(j => j.ModuleName).IsRequired().HasMaxLength(100);
         builder.Property(j => j.ProgressMessage).HasMaxLength(1000);
+        builder.Property(j => j.ConcurrencyStamp).HasMaxLength(64);
         builder.HasIndex(j => j.ModuleName);
     }
 }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobProgressConfiguration.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobProgressConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.BackgroundJobs.Entities;
+using SimpleModule.BackgroundJobs.Contracts;
 
 namespace SimpleModule.BackgroundJobs.EntityConfigurations;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobQueueEntryConfiguration.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobQueueEntryConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.BackgroundJobs.Entities;
+using SimpleModule.BackgroundJobs.Contracts;
 
 namespace SimpleModule.BackgroundJobs.EntityConfigurations;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobQueueEntryConfiguration.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/EntityConfigurations/JobQueueEntryConfiguration.cs
@@ -20,11 +20,15 @@ public class JobQueueEntryConfiguration : IEntityTypeConfiguration<JobQueueEntry
         builder.Property(e => e.AttemptCount).IsRequired();
         builder.Property(e => e.Error);
         builder.Property(e => e.CreatedAt).IsRequired();
+        builder.Property(e => e.UpdatedAt).IsRequired();
+        builder.Property(e => e.ConcurrencyStamp).HasMaxLength(64);
         builder.Property(e => e.CompletedAt);
         builder.Property(e => e.CronExpression).HasMaxLength(100);
         builder.Property(e => e.RecurringName).HasMaxLength(200);
 
-        builder.HasIndex(e => new { e.State, e.ScheduledAt }).HasDatabaseName("IX_JobQueueEntries_State_ScheduledAt");
+        builder
+            .HasIndex(e => new { e.State, e.ScheduledAt })
+            .HasDatabaseName("IX_JobQueueEntries_State_ScheduledAt");
         builder.HasIndex(e => e.RecurringName).HasDatabaseName("IX_JobQueueEntries_RecurringName");
     }
 }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Queue/DatabaseJobQueue.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Queue/DatabaseJobQueue.cs
@@ -15,7 +15,7 @@ public sealed partial class DatabaseJobQueue(
     {
         var row = new JobQueueEntryEntity
         {
-            Id = entry.Id == Guid.Empty ? Guid.NewGuid() : entry.Id,
+            Id = JobId.From(entry.Id == Guid.Empty ? Guid.NewGuid() : entry.Id),
             JobTypeName = entry.JobTypeName,
             SerializedData = entry.SerializedData,
             ScheduledAt = entry.ScheduledAt,
@@ -28,12 +28,14 @@ public sealed partial class DatabaseJobQueue(
 
         db.JobQueueEntries.Add(row);
         await db.SaveChangesAsync(ct);
-        LogEnqueued(logger, row.Id, row.JobTypeName);
+        LogEnqueued(logger, row.Id.Value, row.JobTypeName);
     }
 
     public async Task<JobQueueEntry?> DequeueAsync(string workerId, CancellationToken ct = default)
     {
-        var isPostgres = db.Database.ProviderName?.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) == true;
+        var isPostgres =
+            db.Database.ProviderName?.Contains("Npgsql", StringComparison.OrdinalIgnoreCase)
+            == true;
         var now = DateTimeOffset.UtcNow;
 
         await using var tx = await db.Database.BeginTransactionAsync(ct);
@@ -49,15 +51,17 @@ public sealed partial class DatabaseJobQueue(
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED
                 """;
-            candidate = await db.JobQueueEntries
-                .FromSqlRaw(sql, now)
+            candidate = await db
+                .JobQueueEntries.FromSqlRaw(sql, now)
                 .AsTracking()
                 .FirstOrDefaultAsync(ct);
         }
         else
         {
-            candidate = await db.JobQueueEntries
-                .Where(e => e.State == JobQueueEntryState.Pending && e.ScheduledAt <= now)
+            candidate = await db
+                .JobQueueEntries.Where(e =>
+                    e.State == JobQueueEntryState.Pending && e.ScheduledAt <= now
+                )
                 .OrderBy(e => e.ScheduledAt)
                 .FirstOrDefaultAsync(ct);
         }
@@ -75,10 +79,10 @@ public sealed partial class DatabaseJobQueue(
         await db.SaveChangesAsync(ct);
         await tx.CommitAsync(ct);
 
-        LogClaimed(logger, candidate.Id, workerId);
+        LogClaimed(logger, candidate.Id.Value, workerId);
 
         return new JobQueueEntry(
-            candidate.Id,
+            candidate.Id.Value,
             candidate.JobTypeName,
             candidate.SerializedData,
             candidate.ScheduledAt,
@@ -92,8 +96,10 @@ public sealed partial class DatabaseJobQueue(
 
     public async Task CompleteAsync(Guid entryId, CancellationToken ct = default)
     {
-        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == entryId, ct);
-        if (row is null) return;
+        var id = JobId.From(entryId);
+        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (row is null)
+            return;
         row.State = JobQueueEntryState.Completed;
         row.CompletedAt = DateTimeOffset.UtcNow;
         row.Error = null;
@@ -103,8 +109,10 @@ public sealed partial class DatabaseJobQueue(
 
     public async Task FailAsync(Guid entryId, string error, CancellationToken ct = default)
     {
-        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == entryId, ct);
-        if (row is null) return;
+        var id = JobId.From(entryId);
+        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (row is null)
+            return;
         row.State = JobQueueEntryState.Failed;
         row.CompletedAt = DateTimeOffset.UtcNow;
         row.Error = error;
@@ -115,8 +123,10 @@ public sealed partial class DatabaseJobQueue(
     public async Task<int> RequeueStalledAsync(TimeSpan timeout, CancellationToken ct = default)
     {
         var cutoff = DateTimeOffset.UtcNow - timeout;
-        var stalled = await db.JobQueueEntries
-            .Where(e => e.State == JobQueueEntryState.Claimed && e.ClaimedAt != null && e.ClaimedAt < cutoff)
+        var stalled = await db
+            .JobQueueEntries.Where(e =>
+                e.State == JobQueueEntryState.Claimed && e.ClaimedAt != null && e.ClaimedAt < cutoff
+            )
             .ToListAsync(ct);
 
         foreach (var row in stalled)

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Queue/DatabaseJobQueue.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Queue/DatabaseJobQueue.cs
@@ -2,7 +2,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 
 namespace SimpleModule.BackgroundJobs.Queue;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsContractsService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsContractsService.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Cronos;
 using Microsoft.EntityFrameworkCore;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using SimpleModule.Core;
 using static SimpleModule.BackgroundJobs.BackgroundJobsInternalConstants;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsContractsService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsContractsService.cs
@@ -9,12 +9,13 @@ using static SimpleModule.BackgroundJobs.BackgroundJobsInternalConstants;
 
 namespace SimpleModule.BackgroundJobs.Services;
 
-public sealed class BackgroundJobsContractsService(
-    IJobQueue queue,
-    BackgroundJobsDbContext db
-) : IBackgroundJobsContracts
+public sealed class BackgroundJobsContractsService(IJobQueue queue, BackgroundJobsDbContext db)
+    : IBackgroundJobsContracts
 {
-    public async Task<PagedResult<JobSummaryDto>> GetJobsAsync(JobFilter filter, CancellationToken ct)
+    public async Task<PagedResult<JobSummaryDto>> GetJobsAsync(
+        JobFilter filter,
+        CancellationToken ct
+    )
     {
         var query = db.JobQueueEntries.AsNoTracking().Where(e => e.RecurringName == null);
         if (filter.State.HasValue)
@@ -31,24 +32,28 @@ public sealed class BackgroundJobsContractsService(
             .ToListAsync(ct);
 
         var ids = rows.Select(r => r.Id).ToList();
-        var progressMap = await db.JobProgress.AsNoTracking()
+        var progressMap = await db
+            .JobProgress.AsNoTracking()
             .Where(j => ids.Contains(j.Id))
             .ToDictionaryAsync(j => j.Id, ct);
 
         var items = rows.Select(r =>
-        {
-            progressMap.TryGetValue(r.Id, out var p);
-            return new JobSummaryDto
             {
-                Id = JobId.From(r.Id),
-                JobType = GetShortTypeName(r.JobTypeName),
-                State = BackgroundJobsService.MapQueueState(r.State),
-                ProgressPercentage = p?.ProgressPercentage ?? (r.State == JobQueueEntryState.Completed ? 100 : 0),
-                ProgressMessage = p?.ProgressMessage,
-                CreatedAt = r.CreatedAt,
-                CompletedAt = r.CompletedAt,
-            };
-        }).ToList();
+                progressMap.TryGetValue(r.Id, out var p);
+                return new JobSummaryDto
+                {
+                    Id = r.Id,
+                    JobType = GetShortTypeName(r.JobTypeName),
+                    State = BackgroundJobsService.MapQueueState(r.State),
+                    ProgressPercentage =
+                        p?.ProgressPercentage
+                        ?? (r.State == JobQueueEntryState.Completed ? 100 : 0),
+                    ProgressMessage = p?.ProgressMessage,
+                    CreatedAt = r.CreatedAt,
+                    CompletedAt = r.CompletedAt,
+                };
+            })
+            .ToList();
 
         return new PagedResult<JobSummaryDto>
         {
@@ -61,10 +66,11 @@ public sealed class BackgroundJobsContractsService(
 
     public async Task<JobDetailDto?> GetJobDetailAsync(JobId id, CancellationToken ct)
     {
-        var row = await db.JobQueueEntries.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id.Value, ct);
-        if (row is null) return null;
+        var row = await db.JobQueueEntries.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (row is null)
+            return null;
 
-        var progress = await db.JobProgress.AsNoTracking().FirstOrDefaultAsync(j => j.Id == id.Value, ct);
+        var progress = await db.JobProgress.AsNoTracking().FirstOrDefaultAsync(j => j.Id == id, ct);
         var logs = !string.IsNullOrEmpty(progress?.Logs)
             ? JsonSerializer.Deserialize<List<JobLogEntry>>(progress.Logs) ?? []
             : [];
@@ -75,7 +81,9 @@ public sealed class BackgroundJobsContractsService(
             JobType = GetShortTypeName(row.JobTypeName),
             ModuleName = GetModuleName(row.JobTypeName),
             State = BackgroundJobsService.MapQueueState(row.State),
-            ProgressPercentage = progress?.ProgressPercentage ?? (row.State == JobQueueEntryState.Completed ? 100 : 0),
+            ProgressPercentage =
+                progress?.ProgressPercentage
+                ?? (row.State == JobQueueEntryState.Completed ? 100 : 0),
             ProgressMessage = progress?.ProgressMessage,
             Error = row.Error,
             Data = progress?.Data,
@@ -89,7 +97,8 @@ public sealed class BackgroundJobsContractsService(
 
     public async Task<IReadOnlyList<RecurringJobDto>> GetRecurringJobsAsync(CancellationToken ct)
     {
-        var rows = await db.JobQueueEntries.AsNoTracking()
+        var rows = await db
+            .JobQueueEntries.AsNoTracking()
             .Where(e => e.RecurringName != null)
             .OrderByDescending(e => e.CreatedAt)
             .ToListAsync(ct);
@@ -98,66 +107,86 @@ public sealed class BackgroundJobsContractsService(
         var disabledSentinel = DateTimeOffset.MaxValue.AddYears(-1);
 
         return rows.Select(r =>
-        {
-            DateTimeOffset? next = null;
-            var isEnabled = r.ScheduledAt < disabledSentinel;
-            if (isEnabled && r.CronExpression is not null)
             {
-                try
+                DateTimeOffset? next = null;
+                var isEnabled = r.ScheduledAt < disabledSentinel;
+                if (isEnabled && r.CronExpression is not null)
                 {
-                    var format = r.CronExpression.Split(' ').Length > 5 ? CronFormat.IncludeSeconds : CronFormat.Standard;
-                    var cron = CronExpression.Parse(r.CronExpression, format);
-                    var n = cron.GetNextOccurrence(now, inclusive: false);
-                    if (n.HasValue) next = new DateTimeOffset(n.Value, TimeSpan.Zero);
+                    try
+                    {
+                        var format =
+                            r.CronExpression.Split(' ').Length > 5
+                                ? CronFormat.IncludeSeconds
+                                : CronFormat.Standard;
+                        var cron = CronExpression.Parse(r.CronExpression, format);
+                        var n = cron.GetNextOccurrence(now, inclusive: false);
+                        if (n.HasValue)
+                            next = new DateTimeOffset(n.Value, TimeSpan.Zero);
+                    }
+                    catch (CronFormatException) { }
                 }
-                catch (CronFormatException) { }
-            }
 
-            return new RecurringJobDto
-            {
-                Id = RecurringJobId.From(r.Id),
-                Name = r.RecurringName ?? UnknownValue,
-                JobType = GetShortTypeName(r.JobTypeName),
-                CronExpression = r.CronExpression ?? string.Empty,
-                IsEnabled = isEnabled,
-                LastRunAt = null,
-                NextRunAt = isEnabled ? next : null,
-                CreatedAt = r.CreatedAt,
-            };
-        }).ToList();
+                return new RecurringJobDto
+                {
+                    Id = RecurringJobId.From(r.Id.Value),
+                    Name = r.RecurringName ?? UnknownValue,
+                    JobType = GetShortTypeName(r.JobTypeName),
+                    CronExpression = r.CronExpression ?? string.Empty,
+                    IsEnabled = isEnabled,
+                    LastRunAt = null,
+                    NextRunAt = isEnabled ? next : null,
+                    CreatedAt = r.CreatedAt,
+                };
+            })
+            .ToList();
     }
 
-    public async Task<int> GetRecurringCountAsync(CancellationToken ct)
-        => await db.JobQueueEntries.AsNoTracking().CountAsync(e => e.RecurringName != null, ct);
+    public async Task<int> GetRecurringCountAsync(CancellationToken ct) =>
+        await db.JobQueueEntries.AsNoTracking().CountAsync(e => e.RecurringName != null, ct);
 
     public async Task RetryAsync(JobId id, CancellationToken ct)
     {
-        var row = await db.JobQueueEntries.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id.Value, ct)
+        var row =
+            await db.JobQueueEntries.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id, ct)
             ?? throw new InvalidOperationException($"Job {id} not found.");
 
         var newId = Guid.NewGuid();
-        await queue.EnqueueAsync(new JobQueueEntry(
-            newId, row.JobTypeName, row.SerializedData, DateTimeOffset.UtcNow,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow), ct);
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                newId,
+                row.JobTypeName,
+                row.SerializedData,
+                DateTimeOffset.UtcNow,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            ),
+            ct
+        );
 
-        db.JobProgress.Add(new JobProgress
-        {
-            Id = newId,
-            JobTypeName = row.JobTypeName,
-            ModuleName = GetModuleName(row.JobTypeName),
-            ProgressPercentage = 0,
-            Data = row.SerializedData,
-            UpdatedAt = DateTimeOffset.UtcNow,
-        });
+        db.JobProgress.Add(
+            new JobProgress
+            {
+                Id = JobId.From(newId),
+                JobTypeName = row.JobTypeName,
+                ModuleName = GetModuleName(row.JobTypeName),
+                ProgressPercentage = 0,
+                Data = row.SerializedData,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            }
+        );
         await db.SaveChangesAsync(ct);
     }
 
-    private static JobQueueEntryState[] MapJobStateToQueueStates(JobState state) => state switch
-    {
-        JobState.Pending => [JobQueueEntryState.Pending],
-        JobState.Running => [JobQueueEntryState.Claimed],
-        JobState.Completed => [JobQueueEntryState.Completed],
-        JobState.Failed => [JobQueueEntryState.Failed],
-        _ => [],
-    };
+    private static JobQueueEntryState[] MapJobStateToQueueStates(JobState state) =>
+        state switch
+        {
+            JobState.Pending => [JobQueueEntryState.Pending],
+            JobState.Running => [JobQueueEntryState.Claimed],
+            JobState.Completed => [JobQueueEntryState.Completed],
+            JobState.Failed => [JobQueueEntryState.Failed],
+            _ => [],
+        };
 }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsService.cs
@@ -4,7 +4,6 @@ using Cronos;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using static SimpleModule.BackgroundJobs.BackgroundJobsInternalConstants;
 
 namespace SimpleModule.BackgroundJobs.Services;

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/BackgroundJobsService.cs
@@ -23,25 +23,51 @@ public sealed partial class BackgroundJobsService(
         var serialized = data is not null ? JsonSerializer.Serialize(data) : null;
         var now = DateTimeOffset.UtcNow;
 
-        await queue.EnqueueAsync(new JobQueueEntry(
-            id, jobType.AssemblyQualifiedName!, serialized, now,
-            JobQueueEntryState.Pending, 0, null, null, now), ct);
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                jobType.AssemblyQualifiedName!,
+                serialized,
+                now,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                now
+            ),
+            ct
+        );
 
         await CreateJobProgressAsync(id, jobType, serialized, ct);
         LogJobEnqueued(logger, jobType.Name, id);
         return JobId.From(id);
     }
 
-    public async Task<JobId> ScheduleAsync<TJob>(DateTimeOffset executeAt, object? data, CancellationToken ct)
+    public async Task<JobId> ScheduleAsync<TJob>(
+        DateTimeOffset executeAt,
+        object? data,
+        CancellationToken ct
+    )
         where TJob : IModuleJob
     {
         var jobType = typeof(TJob);
         var id = Guid.NewGuid();
         var serialized = data is not null ? JsonSerializer.Serialize(data) : null;
 
-        await queue.EnqueueAsync(new JobQueueEntry(
-            id, jobType.AssemblyQualifiedName!, serialized, executeAt,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow), ct);
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                jobType.AssemblyQualifiedName!,
+                serialized,
+                executeAt,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            ),
+            ct
+        );
 
         await CreateJobProgressAsync(id, jobType, serialized, ct);
         LogJobScheduled(logger, jobType.Name, id, executeAt);
@@ -49,30 +75,51 @@ public sealed partial class BackgroundJobsService(
     }
 
     public async Task<RecurringJobId> AddRecurringAsync<TJob>(
-        string name, string cronExpression, object? data, CancellationToken ct)
+        string name,
+        string cronExpression,
+        object? data,
+        CancellationToken ct
+    )
         where TJob : IModuleJob
     {
         // Validate cron expression
-        var format = cronExpression.Split(' ').Length > 5 ? CronFormat.IncludeSeconds : CronFormat.Standard;
+        var format =
+            cronExpression.Split(' ').Length > 5 ? CronFormat.IncludeSeconds : CronFormat.Standard;
         var cron = CronExpression.Parse(cronExpression, format);
-        var next = cron.GetNextOccurrence(DateTime.UtcNow, inclusive: false)
-            ?? throw new InvalidOperationException($"Cron '{cronExpression}' has no next occurrence.");
+        var next =
+            cron.GetNextOccurrence(DateTime.UtcNow, inclusive: false)
+            ?? throw new InvalidOperationException(
+                $"Cron '{cronExpression}' has no next occurrence."
+            );
 
         // Remove any existing recurring with the same name to keep it unique
-        var existing = await db.JobQueueEntries
-            .Where(e => e.RecurringName == name && e.State == JobQueueEntryState.Pending)
+        var existing = await db
+            .JobQueueEntries.Where(e =>
+                e.RecurringName == name && e.State == JobQueueEntryState.Pending
+            )
             .ToListAsync(ct);
         db.JobQueueEntries.RemoveRange(existing);
-        if (existing.Count > 0) await db.SaveChangesAsync(ct);
+        if (existing.Count > 0)
+            await db.SaveChangesAsync(ct);
 
         var jobType = typeof(TJob);
         var id = Guid.NewGuid();
         var serialized = data is not null ? JsonSerializer.Serialize(data) : null;
 
-        await queue.EnqueueAsync(new JobQueueEntry(
-            id, jobType.AssemblyQualifiedName!, serialized,
-            new DateTimeOffset(next, TimeSpan.Zero),
-            JobQueueEntryState.Pending, 0, cronExpression, name, DateTimeOffset.UtcNow), ct);
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                jobType.AssemblyQualifiedName!,
+                serialized,
+                new DateTimeOffset(next, TimeSpan.Zero),
+                JobQueueEntryState.Pending,
+                0,
+                cronExpression,
+                name,
+                DateTimeOffset.UtcNow
+            ),
+            ct
+        );
 
         LogRecurringJobAdded(logger, name, cronExpression);
         return RecurringJobId.From(id);
@@ -80,8 +127,10 @@ public sealed partial class BackgroundJobsService(
 
     public async Task RemoveRecurringAsync(RecurringJobId id, CancellationToken ct)
     {
-        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == id.Value, ct);
-        if (row is null) return;
+        var jobId = JobId.From(id.Value);
+        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == jobId, ct);
+        if (row is null)
+            return;
         var name = row.RecurringName;
         if (name is not null)
         {
@@ -93,8 +142,10 @@ public sealed partial class BackgroundJobsService(
 
     public async Task<bool> ToggleRecurringAsync(RecurringJobId id, CancellationToken ct)
     {
+        var jobId = JobId.From(id.Value);
         // Toggle: if Pending → set ScheduledAt far future (disabled). If "disabled" → reset to next cron occurrence.
-        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == id.Value, ct)
+        var row =
+            await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == jobId, ct)
             ?? throw new InvalidOperationException($"Recurring job {id} not found.");
 
         var disabledSentinel = DateTimeOffset.MaxValue.AddDays(-1);
@@ -102,10 +153,15 @@ public sealed partial class BackgroundJobsService(
 
         if (isDisabled && row.CronExpression is not null)
         {
-            var format = row.CronExpression.Split(' ').Length > 5 ? CronFormat.IncludeSeconds : CronFormat.Standard;
+            var format =
+                row.CronExpression.Split(' ').Length > 5
+                    ? CronFormat.IncludeSeconds
+                    : CronFormat.Standard;
             var cron = CronExpression.Parse(row.CronExpression, format);
             var next = cron.GetNextOccurrence(DateTime.UtcNow, inclusive: false);
-            row.ScheduledAt = next.HasValue ? new DateTimeOffset(next.Value, TimeSpan.Zero) : DateTimeOffset.UtcNow;
+            row.ScheduledAt = next.HasValue
+                ? new DateTimeOffset(next.Value, TimeSpan.Zero)
+                : DateTimeOffset.UtcNow;
         }
         else
         {
@@ -117,27 +173,33 @@ public sealed partial class BackgroundJobsService(
 
     public async Task CancelAsync(JobId jobId, CancellationToken ct)
     {
-        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == jobId.Value, ct);
-        if (row is null || row.State != JobQueueEntryState.Pending) return;
+        var row = await db.JobQueueEntries.FirstOrDefaultAsync(e => e.Id == jobId, ct);
+        if (row is null || row.State != JobQueueEntryState.Pending)
+            return;
         db.JobQueueEntries.Remove(row);
         await db.SaveChangesAsync(ct);
     }
 
     public async Task<JobStatusDto?> GetStatusAsync(JobId jobId, CancellationToken ct)
     {
-        var row = await db.JobQueueEntries.AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Id == jobId.Value, ct);
-        if (row is null) return null;
+        var row = await db
+            .JobQueueEntries.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == jobId, ct);
+        if (row is null)
+            return null;
 
-        var progress = await db.JobProgress.AsNoTracking()
-            .FirstOrDefaultAsync(j => j.Id == jobId.Value, ct);
+        var progress = await db
+            .JobProgress.AsNoTracking()
+            .FirstOrDefaultAsync(j => j.Id == jobId, ct);
 
         return new JobStatusDto
         {
             Id = jobId,
             JobType = GetShortTypeName(row.JobTypeName),
             State = MapQueueState(row.State),
-            ProgressPercentage = progress?.ProgressPercentage ?? (row.State == JobQueueEntryState.Completed ? 100 : 0),
+            ProgressPercentage =
+                progress?.ProgressPercentage
+                ?? (row.State == JobQueueEntryState.Completed ? 100 : 0),
             ProgressMessage = progress?.ProgressMessage,
             Error = row.Error,
             CreatedAt = row.CreatedAt,
@@ -147,37 +209,61 @@ public sealed partial class BackgroundJobsService(
         };
     }
 
-    public static JobState MapQueueState(JobQueueEntryState state) => state switch
-    {
-        JobQueueEntryState.Pending => JobState.Pending,
-        JobQueueEntryState.Claimed => JobState.Running,
-        JobQueueEntryState.Completed => JobState.Completed,
-        JobQueueEntryState.Failed => JobState.Failed,
-        _ => JobState.Pending,
-    };
-
-    private async Task CreateJobProgressAsync(Guid id, Type jobType, string? data, CancellationToken ct)
-    {
-        var moduleName = jobType.Assembly.GetName().Name?
-            .Replace("SimpleModule.", "", StringComparison.Ordinal) ?? UnknownValue;
-        db.JobProgress.Add(new JobProgress
+    public static JobState MapQueueState(JobQueueEntryState state) =>
+        state switch
         {
-            Id = id,
-            JobTypeName = jobType.AssemblyQualifiedName!,
-            ModuleName = moduleName,
-            ProgressPercentage = 0,
-            Data = data,
-            UpdatedAt = DateTimeOffset.UtcNow,
-        });
+            JobQueueEntryState.Pending => JobState.Pending,
+            JobQueueEntryState.Claimed => JobState.Running,
+            JobQueueEntryState.Completed => JobState.Completed,
+            JobQueueEntryState.Failed => JobState.Failed,
+            _ => JobState.Pending,
+        };
+
+    private async Task CreateJobProgressAsync(
+        Guid id,
+        Type jobType,
+        string? data,
+        CancellationToken ct
+    )
+    {
+        var moduleName =
+            jobType.Assembly.GetName().Name?.Replace("SimpleModule.", "", StringComparison.Ordinal)
+            ?? UnknownValue;
+        db.JobProgress.Add(
+            new JobProgress
+            {
+                Id = JobId.From(id),
+                JobTypeName = jobType.AssemblyQualifiedName!,
+                ModuleName = moduleName,
+                ProgressPercentage = 0,
+                Data = data,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            }
+        );
         await db.SaveChangesAsync(ct);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Job {JobType} enqueued ({JobId})")]
     private static partial void LogJobEnqueued(ILogger logger, string jobType, Guid jobId);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Job {JobType} scheduled ({JobId}) for {ExecuteAt}")]
-    private static partial void LogJobScheduled(ILogger logger, string jobType, Guid jobId, DateTimeOffset executeAt);
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Job {JobType} scheduled ({JobId}) for {ExecuteAt}"
+    )]
+    private static partial void LogJobScheduled(
+        ILogger logger,
+        string jobType,
+        Guid jobId,
+        DateTimeOffset executeAt
+    );
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Recurring job '{Name}' added with cron '{CronExpression}'")]
-    private static partial void LogRecurringJobAdded(ILogger logger, string name, string cronExpression);
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Recurring job '{Name}' added with cron '{CronExpression}'"
+    )]
+    private static partial void LogRecurringJobAdded(
+        ILogger logger,
+        string name,
+        string cronExpression
+    );
 }

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 
 namespace SimpleModule.BackgroundJobs.Services;
 

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
@@ -136,8 +136,6 @@ public sealed partial class ProgressFlushService(
 
                 existing.Logs = JsonSerializer.Serialize(logs);
             }
-
-            existing.UpdatedAt = DateTimeOffset.UtcNow;
         }
 
         await db.SaveChangesAsync(ct);

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/Services/ProgressFlushService.cs
@@ -87,7 +87,7 @@ public sealed partial class ProgressFlushService(
 
         // Group by JobId — take latest progress per job
         var grouped = batch
-            .GroupBy(e => e.JobId)
+            .GroupBy(e => JobId.From(e.JobId))
             .Select(g => new
             {
                 JobId = g.Key,

--- a/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/types.ts
+++ b/modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/types.ts
@@ -31,6 +31,19 @@ export interface JobFilter {
   pageSize: number;
 }
 
+export interface JobProgress {
+  jobTypeName: string;
+  moduleName: string;
+  progressPercentage: number;
+  progressMessage: string;
+  data: string;
+  logs: string;
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
+}
+
 export interface JobStatusDto {
   id: string;
   jobType: string;

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Queue/DatabaseJobQueueTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Queue/DatabaseJobQueueTests.cs
@@ -23,8 +23,16 @@ public sealed class DatabaseJobQueueTests : IDisposable
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
         var entry = new JobQueueEntry(
-            Guid.NewGuid(), "My.Job, Asm", """{"x":1}""",
-            DateTimeOffset.UtcNow, JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow);
+            Guid.NewGuid(),
+            "My.Job, Asm",
+            """{"x":1}""",
+            DateTimeOffset.UtcNow,
+            JobQueueEntryState.Pending,
+            0,
+            null,
+            null,
+            DateTimeOffset.UtcNow
+        );
 
         await queue.EnqueueAsync(entry);
 
@@ -37,10 +45,28 @@ public sealed class DatabaseJobQueueTests : IDisposable
     public async Task DequeueAsync_ReturnsAndClaimsOldestPending()
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
-        var older = new JobQueueEntry(Guid.NewGuid(), "A", null, DateTimeOffset.UtcNow.AddMinutes(-5),
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow.AddMinutes(-5));
-        var newer = new JobQueueEntry(Guid.NewGuid(), "B", null, DateTimeOffset.UtcNow,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow);
+        var older = new JobQueueEntry(
+            Guid.NewGuid(),
+            "A",
+            null,
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            JobQueueEntryState.Pending,
+            0,
+            null,
+            null,
+            DateTimeOffset.UtcNow.AddMinutes(-5)
+        );
+        var newer = new JobQueueEntry(
+            Guid.NewGuid(),
+            "B",
+            null,
+            DateTimeOffset.UtcNow,
+            JobQueueEntryState.Pending,
+            0,
+            null,
+            null,
+            DateTimeOffset.UtcNow
+        );
         await queue.EnqueueAsync(older);
         await queue.EnqueueAsync(newer);
 
@@ -48,7 +74,8 @@ public sealed class DatabaseJobQueueTests : IDisposable
 
         claimed.Should().NotBeNull();
         claimed!.JobTypeName.Should().Be("A");
-        var row = await _db.JobQueueEntries.SingleAsync(e => e.Id == claimed.Id);
+        var claimedId = JobId.From(claimed.Id);
+        var row = await _db.JobQueueEntries.SingleAsync(e => e.Id == claimedId);
         row.State.Should().Be(JobQueueEntryState.Claimed);
         row.ClaimedBy.Should().Be("worker-1");
         row.AttemptCount.Should().Be(1);
@@ -66,9 +93,19 @@ public sealed class DatabaseJobQueueTests : IDisposable
     public async Task DequeueAsync_IgnoresFutureScheduledEntries()
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
-        await queue.EnqueueAsync(new JobQueueEntry(
-            Guid.NewGuid(), "Future", null, DateTimeOffset.UtcNow.AddHours(1),
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow));
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                Guid.NewGuid(),
+                "Future",
+                null,
+                DateTimeOffset.UtcNow.AddHours(1),
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            )
+        );
 
         var result = await queue.DequeueAsync("worker-1");
         result.Should().BeNull();
@@ -79,8 +116,19 @@ public sealed class DatabaseJobQueueTests : IDisposable
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
         var id = Guid.NewGuid();
-        await queue.EnqueueAsync(new JobQueueEntry(id, "X", null, DateTimeOffset.UtcNow,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow));
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                "X",
+                null,
+                DateTimeOffset.UtcNow,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            )
+        );
         await queue.DequeueAsync("worker-1");
 
         await queue.CompleteAsync(id);
@@ -95,8 +143,19 @@ public sealed class DatabaseJobQueueTests : IDisposable
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
         var id = Guid.NewGuid();
-        await queue.EnqueueAsync(new JobQueueEntry(id, "X", null, DateTimeOffset.UtcNow,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow));
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                "X",
+                null,
+                DateTimeOffset.UtcNow,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            )
+        );
         await queue.DequeueAsync("worker-1");
 
         await queue.FailAsync(id, "boom");
@@ -111,8 +170,19 @@ public sealed class DatabaseJobQueueTests : IDisposable
     {
         var queue = new DatabaseJobQueue(_db, NullLogger<DatabaseJobQueue>.Instance);
         var id = Guid.NewGuid();
-        await queue.EnqueueAsync(new JobQueueEntry(id, "X", null, DateTimeOffset.UtcNow,
-            JobQueueEntryState.Pending, 0, null, null, DateTimeOffset.UtcNow));
+        await queue.EnqueueAsync(
+            new JobQueueEntry(
+                id,
+                "X",
+                null,
+                DateTimeOffset.UtcNow,
+                JobQueueEntryState.Pending,
+                0,
+                null,
+                null,
+                DateTimeOffset.UtcNow
+            )
+        );
         await queue.DequeueAsync("worker-1");
 
         // Manually backdate ClaimedAt to simulate a stall

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsContractsServiceTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsContractsServiceTests.cs
@@ -52,24 +52,28 @@ public sealed class BackgroundJobsContractsServiceTests : IDisposable
     [Fact]
     public async Task GetJobsAsync_ExcludesRecurringJobs()
     {
-        _db.JobQueueEntries.Add(new JobQueueEntryEntity
-        {
-            Id = Guid.NewGuid(),
-            JobTypeName = "TestJob",
-            ScheduledAt = DateTimeOffset.UtcNow,
-            State = JobQueueEntryState.Pending,
-            RecurringName = "my-recurring",
-            CreatedAt = DateTimeOffset.UtcNow,
-        });
-        _db.JobQueueEntries.Add(new JobQueueEntryEntity
-        {
-            Id = Guid.NewGuid(),
-            JobTypeName = "TestJob",
-            ScheduledAt = DateTimeOffset.UtcNow,
-            State = JobQueueEntryState.Pending,
-            RecurringName = null,
-            CreatedAt = DateTimeOffset.UtcNow,
-        });
+        _db.JobQueueEntries.Add(
+            new JobQueueEntryEntity
+            {
+                Id = JobId.From(Guid.NewGuid()),
+                JobTypeName = "TestJob",
+                ScheduledAt = DateTimeOffset.UtcNow,
+                State = JobQueueEntryState.Pending,
+                RecurringName = "my-recurring",
+                CreatedAt = DateTimeOffset.UtcNow,
+            }
+        );
+        _db.JobQueueEntries.Add(
+            new JobQueueEntryEntity
+            {
+                Id = JobId.From(Guid.NewGuid()),
+                JobTypeName = "TestJob",
+                ScheduledAt = DateTimeOffset.UtcNow,
+                State = JobQueueEntryState.Pending,
+                RecurringName = null,
+                CreatedAt = DateTimeOffset.UtcNow,
+            }
+        );
         await _db.SaveChangesAsync();
 
         var result = await _sut.GetJobsAsync(new JobFilter(), CancellationToken.None);
@@ -82,7 +86,10 @@ public sealed class BackgroundJobsContractsServiceTests : IDisposable
     [Fact]
     public async Task GetJobDetailAsync_NonExistentId_ReturnsNull()
     {
-        var result = await _sut.GetJobDetailAsync(JobId.From(Guid.NewGuid()), CancellationToken.None);
+        var result = await _sut.GetJobDetailAsync(
+            JobId.From(Guid.NewGuid()),
+            CancellationToken.None
+        );
 
         result.Should().BeNull();
     }
@@ -117,7 +124,7 @@ public sealed class BackgroundJobsContractsServiceTests : IDisposable
     {
         return new JobProgress
         {
-            Id = id,
+            Id = JobId.From(id),
             JobTypeName = jobType,
             ModuleName = module,
             ProgressPercentage = 0,

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsContractsServiceTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsContractsServiceTests.cs
@@ -2,7 +2,6 @@ using BackgroundJobs.Tests.Helpers;
 using FluentAssertions;
 using NSubstitute;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using SimpleModule.BackgroundJobs.Services;
 
 namespace BackgroundJobs.Tests.Unit;

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsServiceTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/BackgroundJobsServiceTests.cs
@@ -17,11 +17,7 @@ public sealed class BackgroundJobsServiceTests : IDisposable
     public BackgroundJobsServiceTests()
     {
         _db = _factory.Create();
-        _sut = new BackgroundJobsService(
-            _queue,
-            _db,
-            NullLogger<BackgroundJobsService>.Instance
-        );
+        _sut = new BackgroundJobsService(_queue, _db, NullLogger<BackgroundJobsService>.Instance);
     }
 
     public void Dispose()
@@ -35,12 +31,17 @@ public sealed class BackgroundJobsServiceTests : IDisposable
     [Fact]
     public async Task EnqueueAsync_EnqueuesViaQueueAndCreatesProgress()
     {
-        var jobId = await _sut.EnqueueAsync<TestJob>(new TestData("import", 100), CancellationToken.None);
+        var jobId = await _sut.EnqueueAsync<TestJob>(
+            new TestData("import", 100),
+            CancellationToken.None
+        );
 
         jobId.Value.Should().NotBeEmpty();
-        await _queue.Received(1).EnqueueAsync(Arg.Any<JobQueueEntry>(), Arg.Any<CancellationToken>());
+        await _queue
+            .Received(1)
+            .EnqueueAsync(Arg.Any<JobQueueEntry>(), Arg.Any<CancellationToken>());
 
-        var progress = await _db.JobProgress.FindAsync(jobId.Value);
+        var progress = await _db.JobProgress.FindAsync(jobId);
         progress.Should().NotBeNull();
         progress!.ProgressPercentage.Should().Be(0);
         progress.JobTypeName.Should().Contain("TestJob");
@@ -50,7 +51,10 @@ public sealed class BackgroundJobsServiceTests : IDisposable
     public async Task EnqueueAsync_WithNullData_SerializesNullPayloadData()
     {
         JobQueueEntry? capturedEntry = null;
-        _ = _queue.EnqueueAsync(Arg.Do<JobQueueEntry>(e => capturedEntry = e), Arg.Any<CancellationToken>());
+        _ = _queue.EnqueueAsync(
+            Arg.Do<JobQueueEntry>(e => capturedEntry = e),
+            Arg.Any<CancellationToken>()
+        );
 
         await _sut.EnqueueAsync<TestJob>(null, CancellationToken.None);
 
@@ -65,7 +69,7 @@ public sealed class BackgroundJobsServiceTests : IDisposable
 
         var jobId = await _sut.EnqueueAsync<TestJob>(data, CancellationToken.None);
 
-        var progress = await _db.JobProgress.FindAsync(jobId.Value);
+        var progress = await _db.JobProgress.FindAsync(jobId);
         progress!.Data.Should().NotBeNull();
         progress.Data.Should().Contain("import-csv");
     }
@@ -77,13 +81,20 @@ public sealed class BackgroundJobsServiceTests : IDisposable
     {
         var executeAt = DateTimeOffset.UtcNow.AddHours(2);
         JobQueueEntry? capturedEntry = null;
-        _ = _queue.EnqueueAsync(Arg.Do<JobQueueEntry>(e => capturedEntry = e), Arg.Any<CancellationToken>());
+        _ = _queue.EnqueueAsync(
+            Arg.Do<JobQueueEntry>(e => capturedEntry = e),
+            Arg.Any<CancellationToken>()
+        );
 
-        var jobId = await _sut.ScheduleAsync<TestJob>(executeAt, new TestData("scheduled", 1), CancellationToken.None);
+        var jobId = await _sut.ScheduleAsync<TestJob>(
+            executeAt,
+            new TestData("scheduled", 1),
+            CancellationToken.None
+        );
 
         jobId.Value.Should().NotBeEmpty();
         capturedEntry!.ScheduledAt.Should().BeCloseTo(executeAt, TimeSpan.FromSeconds(1));
-        var progress = await _db.JobProgress.FindAsync(jobId.Value);
+        var progress = await _db.JobProgress.FindAsync(jobId);
         progress.Should().NotBeNull();
     }
 
@@ -95,7 +106,9 @@ public sealed class BackgroundJobsServiceTests : IDisposable
         var jobId = await _sut.ScheduleAsync<TestJob>(executeAt, null, CancellationToken.None);
 
         jobId.Value.Should().NotBeEmpty();
-        await _queue.Received(1).EnqueueAsync(Arg.Any<JobQueueEntry>(), Arg.Any<CancellationToken>());
+        await _queue
+            .Received(1)
+            .EnqueueAsync(Arg.Any<JobQueueEntry>(), Arg.Any<CancellationToken>());
     }
 
     // --- AddRecurringAsync ---
@@ -104,9 +117,17 @@ public sealed class BackgroundJobsServiceTests : IDisposable
     public async Task AddRecurringAsync_EnqueuesWithCronFields()
     {
         JobQueueEntry? capturedEntry = null;
-        _ = _queue.EnqueueAsync(Arg.Do<JobQueueEntry>(e => capturedEntry = e), Arg.Any<CancellationToken>());
+        _ = _queue.EnqueueAsync(
+            Arg.Do<JobQueueEntry>(e => capturedEntry = e),
+            Arg.Any<CancellationToken>()
+        );
 
-        var id = await _sut.AddRecurringAsync<TestJob>("cleanup", "0 2 * * *", null, CancellationToken.None);
+        var id = await _sut.AddRecurringAsync<TestJob>(
+            "cleanup",
+            "0 2 * * *",
+            null,
+            CancellationToken.None
+        );
 
         id.Value.Should().NotBeEmpty();
         capturedEntry.Should().NotBeNull();

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceLifecycleTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceLifecycleTests.cs
@@ -35,7 +35,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(40);
         updated.ProgressMessage.Should().Be("Pre-queued");
     }
@@ -57,7 +57,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(60);
         updated.ProgressMessage.Should().Be("Post-start");
     }
@@ -104,7 +104,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await service.StopAsync(CancellationToken.None);
 
         // The drain-on-shutdown path should have flushed
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(90);
     }
 
@@ -130,9 +130,15 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await service.StopAsync(CancellationToken.None);
 
         var verifyDb = _factory.Create();
-        (await verifyDb.JobProgress.FindAsync(job1))!.ProgressPercentage.Should().Be(10);
-        (await verifyDb.JobProgress.FindAsync(job2))!.ProgressPercentage.Should().Be(20);
-        (await verifyDb.JobProgress.FindAsync(job3))!.ProgressPercentage.Should().Be(30);
+        (await verifyDb.JobProgress.FindAsync(JobId.From(job1)))!
+            .ProgressPercentage.Should()
+            .Be(10);
+        (await verifyDb.JobProgress.FindAsync(JobId.From(job2)))!
+            .ProgressPercentage.Should()
+            .Be(20);
+        (await verifyDb.JobProgress.FindAsync(JobId.From(job3)))!
+            .ProgressPercentage.Should()
+            .Be(30);
     }
 
     [Fact]
@@ -167,7 +173,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(200);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.Logs.Should().NotBeNull();
         var logs = JsonSerializer.Deserialize<List<JobLogEntry>>(updated.Logs!);
         logs.Should().ContainSingle().Which.Message.Should().Be("Log before shutdown");
@@ -192,7 +198,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service.StopAsync(CancellationToken.None);
 
-        var afterFirst = await _factory.Create().JobProgress.FindAsync(jobId);
+        var afterFirst = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         afterFirst!.ProgressPercentage.Should().Be(25);
 
         // Restart with a new service instance (same channel)
@@ -202,7 +208,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service2.StopAsync(CancellationToken.None);
 
-        var afterRestart = await _factory.Create().JobProgress.FindAsync(jobId);
+        var afterRestart = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         afterRestart!.ProgressPercentage.Should().Be(80);
         afterRestart.ProgressMessage.Should().Be("After restart");
     }
@@ -234,7 +240,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service2.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(50);
         updated.ProgressMessage.Should().Be("Enqueued while stopped");
     }
@@ -267,7 +273,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
         await Task.Delay(1500);
         await service2.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         var logs = JsonSerializer.Deserialize<List<JobLogEntry>>(updated!.Logs!);
         logs.Should().HaveCount(2);
         logs![0].Message.Should().Be("Log from run 1");
@@ -301,7 +307,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
             await service.StopAsync(CancellationToken.None);
         }
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(90);
         updated.ProgressMessage.Should().Be("Cycle 3");
 
@@ -315,7 +321,7 @@ public sealed class ProgressFlushServiceLifecycleTests : IDisposable
     {
         return new JobProgress
         {
-            Id = id,
+            Id = JobId.From(id),
             JobTypeName = "TestJob",
             ModuleName = "Test",
             ProgressPercentage = 0,

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceLifecycleTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceLifecycleTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using SimpleModule.BackgroundJobs.Services;
 
 namespace BackgroundJobs.Tests.Unit;

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using SimpleModule.BackgroundJobs.Contracts;
-using SimpleModule.BackgroundJobs.Entities;
 using SimpleModule.BackgroundJobs.Services;
 
 namespace BackgroundJobs.Tests.Unit;

--- a/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceTests.cs
+++ b/modules/BackgroundJobs/tests/SimpleModule.BackgroundJobs.Tests/Unit/ProgressFlushServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class ProgressFlushServiceTests : IDisposable
         await Task.Delay(3000);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(75);
         updated.ProgressMessage.Should().Be("Processing");
     }
@@ -61,7 +61,7 @@ public sealed class ProgressFlushServiceTests : IDisposable
         await Task.Delay(3000);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.Logs.Should().NotBeNull();
         var logs = JsonSerializer.Deserialize<List<JobLogEntry>>(updated.Logs!);
         logs.Should().HaveCount(2);
@@ -105,7 +105,7 @@ public sealed class ProgressFlushServiceTests : IDisposable
         await Task.Delay(3000);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         var logs = JsonSerializer.Deserialize<List<JobLogEntry>>(updated!.Logs!);
         logs.Should().HaveCount(1000);
         // Oldest entries should be dropped
@@ -144,7 +144,7 @@ public sealed class ProgressFlushServiceTests : IDisposable
         await Task.Delay(3000);
         await service.StopAsync(CancellationToken.None);
 
-        var updated = await _factory.Create().JobProgress.FindAsync(jobId);
+        var updated = await _factory.Create().JobProgress.FindAsync(JobId.From(jobId));
         updated!.ProgressPercentage.Should().Be(75);
         updated.ProgressMessage.Should().Be("Three quarters");
     }
@@ -192,8 +192,8 @@ public sealed class ProgressFlushServiceTests : IDisposable
         await service.StopAsync(CancellationToken.None);
 
         var verifyDb = _factory.Create();
-        var p1 = await verifyDb.JobProgress.FindAsync(job1);
-        var p2 = await verifyDb.JobProgress.FindAsync(job2);
+        var p1 = await verifyDb.JobProgress.FindAsync(JobId.From(job1));
+        var p2 = await verifyDb.JobProgress.FindAsync(JobId.From(job2));
         p1!.ProgressPercentage.Should().Be(30);
         p2!.ProgressPercentage.Should().Be(60);
     }
@@ -204,7 +204,7 @@ public sealed class ProgressFlushServiceTests : IDisposable
     {
         return new JobProgress
         {
-            Id = id,
+            Id = JobId.From(id),
             JobTypeName = "TestJob",
             ModuleName = "Test",
             ProgressPercentage = 0,

--- a/modules/Chat/src/SimpleModule.Chat.Contracts/ChatMessage.cs
+++ b/modules/Chat/src/SimpleModule.Chat.Contracts/ChatMessage.cs
@@ -1,12 +1,12 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Chat.Contracts;
 
-public class ChatMessage
+public class ChatMessage : Entity<ChatMessageId>
 {
-    public ChatMessageId Id { get; set; }
     public ConversationId ConversationId { get; set; }
     public ChatRole Role { get; set; }
     public string Content { get; set; } = string.Empty;
-    public DateTimeOffset CreatedAt { get; set; }
 }
 
 public enum ChatRole

--- a/modules/Chat/src/SimpleModule.Chat.Contracts/Conversation.cs
+++ b/modules/Chat/src/SimpleModule.Chat.Contracts/Conversation.cs
@@ -1,14 +1,13 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Chat.Contracts;
 
-public class Conversation
+public class Conversation : Entity<ConversationId>
 {
-    public ConversationId Id { get; set; }
     public string UserId { get; set; } = string.Empty;
     public string Title { get; set; } = "New conversation";
     public string AgentName { get; set; } = string.Empty;
     public bool Pinned { get; set; }
-    public DateTimeOffset CreatedAt { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; }
 
     public List<ChatMessage> Messages { get; set; } = [];
 }

--- a/modules/Chat/src/SimpleModule.Chat/ChatService.cs
+++ b/modules/Chat/src/SimpleModule.Chat/ChatService.cs
@@ -98,13 +98,15 @@ public partial class ChatService(ChatDbContext db, ILogger<ChatService> logger) 
         CancellationToken cancellationToken = default
     )
     {
+        var now = DateTimeOffset.UtcNow;
         var message = new ChatMessage
         {
             Id = ChatMessageId.From(Guid.NewGuid()),
             ConversationId = conversationId,
             Role = role,
             Content = content,
-            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedAt = now,
+            UpdatedAt = now,
         };
         db.ChatMessages.Add(message);
 
@@ -114,7 +116,7 @@ public partial class ChatService(ChatDbContext db, ILogger<ChatService> logger) 
         );
         if (conversation is not null)
         {
-            conversation.UpdatedAt = message.CreatedAt;
+            conversation.UpdatedAt = now;
         }
 
         await db.SaveChangesAsync(cancellationToken);

--- a/modules/Chat/src/SimpleModule.Chat/EntityConfigurations/ConversationConfiguration.cs
+++ b/modules/Chat/src/SimpleModule.Chat/EntityConfigurations/ConversationConfiguration.cs
@@ -17,6 +17,7 @@ public class ConversationConfiguration : IEntityTypeConfiguration<Conversation>
         // SQLite cannot ORDER BY DateTimeOffset natively; convert to binary long.
         builder.Property(c => c.CreatedAt).HasConversion<DateTimeOffsetToBinaryConverter>();
         builder.Property(c => c.UpdatedAt).HasConversion<DateTimeOffsetToBinaryConverter>();
+        builder.Property(c => c.ConcurrencyStamp).HasMaxLength(64);
         builder.HasIndex(c => new { c.UserId, c.UpdatedAt });
 
         builder
@@ -36,6 +37,8 @@ public class ChatMessageConfiguration : IEntityTypeConfiguration<ChatMessage>
         builder.Property(m => m.Content).IsRequired();
         builder.Property(m => m.Role).HasConversion<int>();
         builder.Property(m => m.CreatedAt).HasConversion<DateTimeOffsetToBinaryConverter>();
+        builder.Property(m => m.UpdatedAt).HasConversion<DateTimeOffsetToBinaryConverter>();
+        builder.Property(m => m.ConcurrencyStamp).HasMaxLength(64);
         builder.HasIndex(m => new { m.ConversationId, m.CreatedAt });
     }
 }

--- a/modules/Chat/src/SimpleModule.Chat/types.ts
+++ b/modules/Chat/src/SimpleModule.Chat/types.ts
@@ -1,21 +1,24 @@
 // Auto-generated from [Dto] types — do not edit
 export interface ChatMessage {
-  id: string;
   conversationId: string;
   role: any;
   content: string;
+  id: string;
   createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface Conversation {
-  id: string;
   userId: string;
   title: string;
   agentName: string;
   pinned: boolean;
+  messages: ChatMessage[];
+  id: string;
   createdAt: string;
   updatedAt: string;
-  messages: ChatMessage[];
+  concurrencyStamp: string;
 }
 
 export interface CreateConversationRequest {

--- a/modules/Datasets/src/SimpleModule.Datasets.Contracts/Dataset.cs
+++ b/modules/Datasets/src/SimpleModule.Datasets.Contracts/Dataset.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.Datasets.Contracts;
 
-namespace SimpleModule.Datasets.Entities;
+namespace SimpleModule.Datasets.Contracts;
 
+[NoDtoGeneration]
 public sealed class Dataset : FullAuditableEntity<DatasetId>
 {
     public string Name { get; set; } = string.Empty;

--- a/modules/Datasets/src/SimpleModule.Datasets/DatasetsContractsService.cs
+++ b/modules/Datasets/src/SimpleModule.Datasets/DatasetsContractsService.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using SimpleModule.BackgroundJobs.Contracts;
 using SimpleModule.Core.Settings;
 using SimpleModule.Datasets.Contracts;
-using SimpleModule.Datasets.Entities;
 using SimpleModule.Datasets.Jobs;
 using SimpleModule.Settings.Contracts;
 using SimpleModule.Storage;

--- a/modules/Datasets/src/SimpleModule.Datasets/DatasetsDbContext.cs
+++ b/modules/Datasets/src/SimpleModule.Datasets/DatasetsDbContext.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Datasets.Contracts;
-using SimpleModule.Datasets.Entities;
 using SimpleModule.Datasets.EntityConfigurations;
 
 namespace SimpleModule.Datasets;

--- a/modules/Datasets/src/SimpleModule.Datasets/EntityConfigurations/DatasetConfiguration.cs
+++ b/modules/Datasets/src/SimpleModule.Datasets/EntityConfigurations/DatasetConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.Datasets.Entities;
+using SimpleModule.Datasets.Contracts;
 
 namespace SimpleModule.Datasets.EntityConfigurations;
 

--- a/modules/Datasets/src/SimpleModule.Datasets/Jobs/ProcessDatasetJob.cs
+++ b/modules/Datasets/src/SimpleModule.Datasets/Jobs/ProcessDatasetJob.cs
@@ -7,7 +7,6 @@ using SimpleModule.Core.Events;
 using SimpleModule.Core.Settings;
 using SimpleModule.Datasets.Contracts;
 using SimpleModule.Datasets.Contracts.Events;
-using SimpleModule.Datasets.Entities;
 using SimpleModule.Datasets.Processing;
 using SimpleModule.Settings.Contracts;
 using SimpleModule.Storage;

--- a/modules/Email/src/SimpleModule.Email.Contracts/EmailMessage.cs
+++ b/modules/Email/src/SimpleModule.Email.Contracts/EmailMessage.cs
@@ -1,11 +1,11 @@
 using SimpleModule.Core;
+using SimpleModule.Core.Entities;
 
 namespace SimpleModule.Email.Contracts;
 
 [Dto]
-public class EmailMessage
+public class EmailMessage : Entity<EmailMessageId>
 {
-    public EmailMessageId Id { get; set; }
     public string To { get; set; } = string.Empty;
     public string? Cc { get; set; }
     public string? Bcc { get; set; }
@@ -18,6 +18,5 @@ public class EmailMessage
     public int RetryCount { get; set; }
     public string? TemplateSlug { get; set; }
     public string? Provider { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime? SentAt { get; set; }
+    public DateTimeOffset? SentAt { get; set; }
 }

--- a/modules/Email/src/SimpleModule.Email.Contracts/EmailTemplate.cs
+++ b/modules/Email/src/SimpleModule.Email.Contracts/EmailTemplate.cs
@@ -1,17 +1,15 @@
 using SimpleModule.Core;
+using SimpleModule.Core.Entities;
 
 namespace SimpleModule.Email.Contracts;
 
 [Dto]
-public class EmailTemplate
+public class EmailTemplate : Entity<EmailTemplateId>
 {
-    public EmailTemplateId Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Slug { get; set; } = string.Empty;
     public string Subject { get; set; } = string.Empty;
     public string Body { get; set; } = string.Empty;
     public bool IsHtml { get; set; } = true;
     public string? DefaultReplyTo { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime? UpdatedAt { get; set; }
 }

--- a/modules/Email/src/SimpleModule.Email.Contracts/QueryEmailMessagesRequest.cs
+++ b/modules/Email/src/SimpleModule.Email.Contracts/QueryEmailMessagesRequest.cs
@@ -10,8 +10,8 @@ public class QueryEmailMessagesRequest
     public EmailStatus? Status { get; set; }
     public string? To { get; set; }
     public string? Subject { get; set; }
-    public DateTime? DateFrom { get; set; }
-    public DateTime? DateTo { get; set; }
+    public DateTimeOffset? DateFrom { get; set; }
+    public DateTimeOffset? DateTo { get; set; }
     public string? SortBy { get; set; }
     public bool? SortDescending { get; set; }
 

--- a/modules/Email/src/SimpleModule.Email/EmailDbContext.cs
+++ b/modules/Email/src/SimpleModule.Email/EmailDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Email.Contracts;
@@ -35,5 +36,17 @@ public class EmailDbContext(
                 EmailTemplateId.EfCoreValueConverter,
                 EmailTemplateId.EfCoreValueComparer
             >();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("Email") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/Email/src/SimpleModule.Email/EmailService.cs
+++ b/modules/Email/src/SimpleModule.Email/EmailService.cs
@@ -32,7 +32,6 @@ public partial class EmailService(
             IsHtml = request.IsHtml,
             Status = EmailStatus.Queued,
             Provider = emailProvider.Name,
-            CreatedAt = DateTime.UtcNow,
         };
 
         db.EmailMessages.Add(message);
@@ -197,7 +196,6 @@ public partial class EmailService(
             Body = request.Body,
             IsHtml = request.IsHtml,
             DefaultReplyTo = request.DefaultReplyTo,
-            CreatedAt = DateTime.UtcNow,
         };
 
         db.EmailTemplates.Add(template);
@@ -237,7 +235,6 @@ public partial class EmailService(
         template.Body = request.Body;
         template.IsHtml = request.IsHtml;
         template.DefaultReplyTo = request.DefaultReplyTo;
-        template.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 
@@ -265,7 +262,7 @@ public partial class EmailService(
 
     public async Task<EmailStats> GetEmailStatsAsync()
     {
-        var now = DateTime.UtcNow;
+        var now = DateTimeOffset.UtcNow;
         var last24Hours = now.AddHours(-24);
         var last7Days = now.AddDays(-7);
         var last30Days = now.AddDays(-30);
@@ -308,7 +305,7 @@ public partial class EmailService(
         var failureRate = total7d > 0 ? (double)failed7d / total7d * 100 : 0;
 
         var dailyVolume = recentMessages
-            .GroupBy(m => m.CreatedAt.Date)
+            .GroupBy(m => m.CreatedAt.UtcDateTime.Date)
             .Select(g => new DailyCount
             {
                 Date = g.Key,

--- a/modules/Email/src/SimpleModule.Email/EntityConfigurations/EmailMessageConfiguration.cs
+++ b/modules/Email/src/SimpleModule.Email/EntityConfigurations/EmailMessageConfiguration.cs
@@ -20,6 +20,7 @@ public class EmailMessageConfiguration : IEntityTypeConfiguration<EmailMessage>
         builder.Property(e => e.Provider).HasMaxLength(100);
         builder.Property(e => e.ReplyTo).HasMaxLength(500);
         builder.Property(e => e.Status).HasConversion<string>().HasMaxLength(50);
+        builder.Property(e => e.ConcurrencyStamp).HasMaxLength(64);
 
         builder.HasIndex(e => e.Status);
         builder.HasIndex(e => e.CreatedAt);

--- a/modules/Email/src/SimpleModule.Email/EntityConfigurations/EmailTemplateConfiguration.cs
+++ b/modules/Email/src/SimpleModule.Email/EntityConfigurations/EmailTemplateConfiguration.cs
@@ -15,6 +15,7 @@ public class EmailTemplateConfiguration : IEntityTypeConfiguration<EmailTemplate
         builder.Property(e => e.Subject).IsRequired().HasMaxLength(500);
         builder.Property(e => e.Body).IsRequired();
         builder.Property(e => e.DefaultReplyTo).HasMaxLength(500);
+        builder.Property(e => e.ConcurrencyStamp).HasMaxLength(64);
 
         builder.HasIndex(e => e.Slug).IsUnique();
     }

--- a/modules/Email/src/SimpleModule.Email/Jobs/SendEmailJob.cs
+++ b/modules/Email/src/SimpleModule.Email/Jobs/SendEmailJob.cs
@@ -47,7 +47,7 @@ public partial class SendEmailJob(
             context.Log($"Sending email {message.Id} to {message.To}");
             await emailProvider.SendAsync(envelope, cancellationToken);
             message.Status = EmailStatus.Sent;
-            message.SentAt = DateTime.UtcNow;
+            message.SentAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync(cancellationToken);
 
             LogEmailSent(logger, message.Id, message.To);

--- a/modules/Email/src/SimpleModule.Email/types.ts
+++ b/modules/Email/src/SimpleModule.Email/types.ts
@@ -9,7 +9,6 @@ export interface CreateEmailTemplateRequest {
 }
 
 export interface EmailMessage {
-  id: number;
   to: string;
   cc: string;
   bcc: string;
@@ -22,8 +21,11 @@ export interface EmailMessage {
   retryCount: number;
   templateSlug: string;
   provider: string;
-  createdAt: string;
   sentAt: string | null;
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface EmailStats {
@@ -50,15 +52,16 @@ export interface DailyCount {
 }
 
 export interface EmailTemplate {
-  id: number;
   name: string;
   slug: string;
   subject: string;
   body: string;
   isHtml: boolean;
   defaultReplyTo: string;
+  id: number;
   createdAt: string;
-  updatedAt: string | null;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface QueryEmailMessagesRequest {

--- a/modules/Email/tests/SimpleModule.Email.Tests/Unit/EmailServiceTests.cs
+++ b/modules/Email/tests/SimpleModule.Email.Tests/Unit/EmailServiceTests.cs
@@ -202,7 +202,6 @@ public sealed class EmailServiceTests : IDisposable
 
         updated.Name.Should().Be("Updated");
         updated.Subject.Should().Be("Updated Subject");
-        updated.UpdatedAt.Should().NotBeNull();
     }
 
     [Fact]
@@ -424,8 +423,8 @@ public sealed class EmailServiceTests : IDisposable
                 Subject = "A",
                 Body = "B",
                 Status = EmailStatus.Sent,
-                CreatedAt = DateTime.UtcNow,
-                SentAt = DateTime.UtcNow,
+                CreatedAt = DateTimeOffset.UtcNow,
+                SentAt = DateTimeOffset.UtcNow,
             },
             new EmailMessage
             {
@@ -433,8 +432,8 @@ public sealed class EmailServiceTests : IDisposable
                 Subject = "B",
                 Body = "B",
                 Status = EmailStatus.Sent,
-                CreatedAt = DateTime.UtcNow,
-                SentAt = DateTime.UtcNow,
+                CreatedAt = DateTimeOffset.UtcNow,
+                SentAt = DateTimeOffset.UtcNow,
             },
             new EmailMessage
             {
@@ -443,7 +442,7 @@ public sealed class EmailServiceTests : IDisposable
                 Body = "B",
                 Status = EmailStatus.Failed,
                 ErrorMessage = "Timeout",
-                CreatedAt = DateTime.UtcNow,
+                CreatedAt = DateTimeOffset.UtcNow,
             }
         );
         await _db.SaveChangesAsync();

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagEntity.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.FeatureFlags.Contracts;
 
-namespace SimpleModule.FeatureFlags.Entities;
+namespace SimpleModule.FeatureFlags.Contracts;
 
+[NoDtoGeneration]
 public class FeatureFlagEntity : Entity<FeatureFlagId>
 {
     public string Name { get; set; } = string.Empty;

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagId.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.FeatureFlags.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct FeatureFlagId;

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverride.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverride.cs
@@ -2,7 +2,7 @@ namespace SimpleModule.FeatureFlags.Contracts;
 
 public class FeatureFlagOverride
 {
-    public int Id { get; set; }
+    public FeatureFlagOverrideId Id { get; set; }
     public string FlagName { get; set; } = string.Empty;
     public OverrideType OverrideType { get; set; }
     public string OverrideValue { get; set; } = string.Empty;

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverrideEntity.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverrideEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.FeatureFlags.Contracts;
 
-namespace SimpleModule.FeatureFlags.Entities;
+namespace SimpleModule.FeatureFlags.Contracts;
 
+[NoDtoGeneration]
 public class FeatureFlagOverrideEntity : Entity<FeatureFlagOverrideId>
 {
     public string FlagName { get; set; } = string.Empty;

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverrideId.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagOverrideId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.FeatureFlags.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct FeatureFlagOverrideId;

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/IFeatureFlagContracts.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/IFeatureFlagContracts.cs
@@ -18,5 +18,5 @@ public interface IFeatureFlagContracts
     Task<FeatureFlag> UpdateFlagAsync(string flagName, UpdateFeatureFlagRequest request);
     Task<IEnumerable<FeatureFlagOverride>> GetOverridesAsync(string flagName);
     Task<FeatureFlagOverride> SetOverrideAsync(string flagName, SetOverrideRequest request);
-    Task DeleteOverrideAsync(int overrideId);
+    Task DeleteOverrideAsync(FeatureFlagOverrideId overrideId);
 }

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/SimpleModule.FeatureFlags.Contracts.csproj
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/SimpleModule.FeatureFlags.Contracts.csproj
@@ -2,8 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Vogen" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Endpoints/FeatureFlags/DeleteOverrideEndpoint.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Endpoints/FeatureFlags/DeleteOverrideEndpoint.cs
@@ -17,7 +17,7 @@ public class DeleteOverrideEndpoint : IEndpoint
                 Route,
                 async (int id, IFeatureFlagContracts featureFlags) =>
                 {
-                    await featureFlags.DeleteOverrideAsync(id);
+                    await featureFlags.DeleteOverrideAsync(FeatureFlagOverrideId.From(id));
                     return TypedResults.NoContent();
                 }
             )

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Entities/FeatureFlagEntity.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Entities/FeatureFlagEntity.cs
@@ -1,8 +1,9 @@
 using SimpleModule.Core.Entities;
+using SimpleModule.FeatureFlags.Contracts;
 
 namespace SimpleModule.FeatureFlags.Entities;
 
-public class FeatureFlagEntity : Entity<int>
+public class FeatureFlagEntity : Entity<FeatureFlagId>
 {
     public string Name { get; set; } = string.Empty;
     public bool IsEnabled { get; set; }

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Entities/FeatureFlagOverrideEntity.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/Entities/FeatureFlagOverrideEntity.cs
@@ -3,7 +3,7 @@ using SimpleModule.FeatureFlags.Contracts;
 
 namespace SimpleModule.FeatureFlags.Entities;
 
-public class FeatureFlagOverrideEntity : Entity<int>
+public class FeatureFlagOverrideEntity : Entity<FeatureFlagOverrideId>
 {
     public string FlagName { get; set; } = string.Empty;
     public OverrideType OverrideType { get; set; }

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/EntityConfigurations/FeatureFlagConfiguration.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/EntityConfigurations/FeatureFlagConfiguration.cs
@@ -1,7 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.FeatureFlags.Contracts;
 
-namespace SimpleModule.FeatureFlags.Entities;
+namespace SimpleModule.FeatureFlags.EntityConfigurations;
 
 public class FeatureFlagConfiguration : IEntityTypeConfiguration<FeatureFlagEntity>
 {

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/EntityConfigurations/FeatureFlagOverrideConfiguration.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/EntityConfigurations/FeatureFlagOverrideConfiguration.cs
@@ -1,7 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.FeatureFlags.Contracts;
 
-namespace SimpleModule.FeatureFlags.Entities;
+namespace SimpleModule.FeatureFlags.EntityConfigurations;
 
 public class FeatureFlagOverrideConfiguration : IEntityTypeConfiguration<FeatureFlagOverrideEntity>
 {

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
@@ -192,7 +192,7 @@ public sealed partial class FeatureFlagService(
         };
     }
 
-    public async Task DeleteOverrideAsync(int overrideId)
+    public async Task DeleteOverrideAsync(FeatureFlagOverrideId overrideId)
     {
         var entity = await db.FeatureFlagOverrides.FindAsync(overrideId);
         if (entity is not null)

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagService.cs
@@ -5,7 +5,6 @@ using SimpleModule.Core.Caching;
 using SimpleModule.Core.Entities;
 using SimpleModule.Core.FeatureFlags;
 using SimpleModule.FeatureFlags.Contracts;
-using SimpleModule.FeatureFlags.Entities;
 
 namespace SimpleModule.FeatureFlags;
 

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagSyncService.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagSyncService.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using SimpleModule.Core.FeatureFlags;
-using SimpleModule.FeatureFlags.Entities;
+using SimpleModule.FeatureFlags.Contracts;
 
 namespace SimpleModule.FeatureFlags;
 

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagsDbContext.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagsDbContext.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.FeatureFlags.Contracts;
-using SimpleModule.FeatureFlags.Entities;
 
 namespace SimpleModule.FeatureFlags;
 

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagsDbContext.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/FeatureFlagsDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
+using SimpleModule.FeatureFlags.Contracts;
 using SimpleModule.FeatureFlags.Entities;
 
 namespace SimpleModule.FeatureFlags;
@@ -19,5 +20,21 @@ public class FeatureFlagsDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(FeatureFlagsDbContext).Assembly);
         modelBuilder.ApplyModuleSchema("FeatureFlags", dbOptions.Value);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<FeatureFlagId>()
+            .HaveConversion<
+                FeatureFlagId.EfCoreValueConverter,
+                FeatureFlagId.EfCoreValueComparer
+            >();
+        configurationBuilder
+            .Properties<FeatureFlagOverrideId>()
+            .HaveConversion<
+                FeatureFlagOverrideId.EfCoreValueConverter,
+                FeatureFlagOverrideId.EfCoreValueComparer
+            >();
     }
 }

--- a/modules/FeatureFlags/tests/SimpleModule.FeatureFlags.Tests/Unit/FeatureFlagServiceTests.cs
+++ b/modules/FeatureFlags/tests/SimpleModule.FeatureFlags.Tests/Unit/FeatureFlagServiceTests.cs
@@ -9,7 +9,6 @@ using SimpleModule.Core.FeatureFlags;
 using SimpleModule.Database;
 using SimpleModule.FeatureFlags;
 using SimpleModule.FeatureFlags.Contracts;
-using SimpleModule.FeatureFlags.Entities;
 
 namespace FeatureFlags.Tests.Unit;
 

--- a/modules/FileStorage/src/SimpleModule.FileStorage.Contracts/StoredFile.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage.Contracts/StoredFile.cs
@@ -1,16 +1,15 @@
 using SimpleModule.Core;
+using SimpleModule.Core.Entities;
 
 namespace SimpleModule.FileStorage.Contracts;
 
 [Dto]
-public class StoredFile
+public class StoredFile : Entity<FileStorageId>
 {
-    public FileStorageId Id { get; set; }
     public string FileName { get; set; } = string.Empty;
     public string StoragePath { get; set; } = string.Empty;
     public string ContentType { get; set; } = string.Empty;
     public long Size { get; set; }
     public string? Folder { get; set; }
     public string? CreatedByUserId { get; set; }
-    public DateTimeOffset CreatedAt { get; set; }
 }

--- a/modules/FileStorage/src/SimpleModule.FileStorage/EntityConfigurations/StoredFileConfiguration.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/EntityConfigurations/StoredFileConfiguration.cs
@@ -15,6 +15,7 @@ public class StoredFileConfiguration : IEntityTypeConfiguration<StoredFile>
         builder.Property(f => f.ContentType).IsRequired().HasMaxLength(256);
         builder.Property(f => f.Folder).HasMaxLength(1024);
         builder.Property(f => f.CreatedByUserId).HasMaxLength(450);
+        builder.Property(f => f.ConcurrencyStamp).HasMaxLength(64);
         builder.HasIndex(f => f.Folder);
         builder.HasIndex(f => f.CreatedByUserId);
         builder.HasIndex(f => new { f.Folder, f.FileName }).IsUnique();

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageDbContext.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.FileStorage.Contracts;
@@ -27,5 +28,17 @@ public class FileStorageDbContext(
                 FileStorageId.EfCoreValueConverter,
                 FileStorageId.EfCoreValueComparer
             >();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("FileStorage") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/FileStorage/src/SimpleModule.FileStorage/types.ts
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/types.ts
@@ -1,12 +1,14 @@
 // Auto-generated from [Dto] types — do not edit
 export interface StoredFile {
-  id: number;
   fileName: string;
   storagePath: string;
   contentType: string;
   size: number;
   folder: string;
   createdByUserId: string;
+  id: number;
   createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 

--- a/modules/Orders/src/SimpleModule.Orders.Contracts/Order.cs
+++ b/modules/Orders/src/SimpleModule.Orders.Contracts/Order.cs
@@ -1,10 +1,10 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Orders.Contracts;
 
-public class Order
+public class Order : AuditableEntity<OrderId>
 {
-    public OrderId Id { get; set; }
     public string UserId { get; set; } = string.Empty;
     public List<OrderItem> Items { get; set; } = new();
     public decimal Total { get; set; }
-    public DateTime CreatedAt { get; set; }
 }

--- a/modules/Orders/src/SimpleModule.Orders/EntityConfigurations/OrderConfiguration.cs
+++ b/modules/Orders/src/SimpleModule.Orders/EntityConfigurations/OrderConfiguration.cs
@@ -11,6 +11,7 @@ public class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.HasKey(o => o.Id);
         builder.Property(o => o.Id).ValueGeneratedOnAdd();
         builder.Property(o => o.Total).HasColumnType("decimal(18,2)");
+        builder.Property(o => o.ConcurrencyStamp).HasMaxLength(64);
         builder.HasMany(o => o.Items).WithOne().HasForeignKey("OrderId");
     }
 }

--- a/modules/Orders/src/SimpleModule.Orders/OrderService.cs
+++ b/modules/Orders/src/SimpleModule.Orders/OrderService.cs
@@ -63,7 +63,6 @@ public sealed partial class OrderService(
             UserId = request.UserId,
             Items = request.Items,
             Total = total,
-            CreatedAt = DateTime.UtcNow,
         };
 
         db.Orders.Add(order);

--- a/modules/Orders/src/SimpleModule.Orders/OrdersDbContext.cs
+++ b/modules/Orders/src/SimpleModule.Orders/OrdersDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Orders.Contracts;
@@ -26,5 +27,17 @@ public class OrdersDbContext(
         configurationBuilder
             .Properties<OrderId>()
             .HaveConversion<OrderId.EfCoreValueConverter, OrderId.EfCoreValueComparer>();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("Orders") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/Orders/src/SimpleModule.Orders/Services/OrderSeedService.cs
+++ b/modules/Orders/src/SimpleModule.Orders/Services/OrderSeedService.cs
@@ -76,9 +76,12 @@ public partial class OrderSeedService(
                     {
                         UserId = userId,
                         Total = Math.Round(total, 2),
-                        CreatedAt = faker.Date.Between(
-                            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-                            new DateTime(2026, 1, 31, 23, 59, 59, DateTimeKind.Utc)
+                        CreatedAt = new DateTimeOffset(
+                            faker.Date.Between(
+                                new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                                new DateTime(2026, 1, 31, 23, 59, 59, DateTimeKind.Utc)
+                            ),
+                            TimeSpan.Zero
                         ),
                         Items = items,
                     }

--- a/modules/Orders/src/SimpleModule.Orders/types.ts
+++ b/modules/Orders/src/SimpleModule.Orders/types.ts
@@ -5,11 +5,15 @@ export interface CreateOrderRequest {
 }
 
 export interface Order {
-  id: number;
   userId: string;
   items: OrderItem[];
   total: number;
+  createdBy: string;
+  updatedBy: string;
+  id: number;
   createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface OrderItem {

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/Page.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/Page.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.PageBuilder.Contracts;
 
-public class Page
+public class Page : FullAuditableEntity<PageId>
 {
-    public PageId Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Slug { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
@@ -12,8 +13,5 @@ public class Page
     public string? OgImage { get; set; }
     public bool IsPublished { get; set; }
     public int Order { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
     public List<PageTag> Tags { get; set; } = [];
-    public DateTime? DeletedAt { get; set; }
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/PageSummary.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/PageSummary.cs
@@ -8,8 +8,8 @@ public class PageSummary
     public bool IsPublished { get; set; }
     public bool HasDraft { get; set; }
     public int Order { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
     public List<string> Tags { get; set; } = [];
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/PageTemplate.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder.Contracts/PageTemplate.cs
@@ -1,9 +1,9 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.PageBuilder.Contracts;
 
-public class PageTemplate
+public class PageTemplate : Entity<PageTemplateId>
 {
-    public PageTemplateId Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder/EntityConfigurations/PageConfiguration.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder/EntityConfigurations/PageConfiguration.cs
@@ -20,13 +20,14 @@ public class PageConfiguration : IEntityTypeConfiguration<Page>
         builder.Property(p => p.OgImage).IsRequired(false).HasMaxLength(500);
         builder.Property(p => p.IsPublished).HasDefaultValue(false);
         builder.Property(p => p.Order).HasDefaultValue(0);
-        builder.Property(p => p.DeletedAt).IsRequired(false);
+        builder.Property(p => p.ConcurrencyStamp).HasMaxLength(64);
 
         builder.HasMany(p => p.Tags).WithOne().HasForeignKey("PageId");
 
         builder.HasIndex(p => p.IsPublished);
-        builder.HasIndex(p => p.DeletedAt);
-
-        builder.HasQueryFilter(p => p.DeletedAt == null);
+        builder.HasIndex(p => new { p.IsDeleted, p.DeletedAt });
+        // Soft-delete query filter is applied by ApplyEntityConventions via the
+        // named filter key; do not add a local anonymous filter which would
+        // conflict with it (EF Core disallows mixing anonymous and named filters).
     }
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder/EntityConfigurations/PageTemplateConfiguration.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder/EntityConfigurations/PageTemplateConfiguration.cs
@@ -13,5 +13,6 @@ public class PageTemplateConfiguration : IEntityTypeConfiguration<PageTemplate>
         builder.Property(t => t.Name).IsRequired().HasMaxLength(200);
         builder.HasIndex(t => t.Name).IsUnique();
         builder.Property(t => t.Content).IsRequired();
+        builder.Property(t => t.ConcurrencyStamp).HasMaxLength(64);
     }
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder/PageBuilderDbContext.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder/PageBuilderDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.PageBuilder.Contracts;
@@ -37,5 +38,18 @@ public class PageBuilderDbContext(
         configurationBuilder
             .Properties<PageTagId>()
             .HaveConversion<PageTagId.EfCoreValueConverter, PageTagId.EfCoreValueComparer>();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite; leave
+        // other providers to their native timestamptz/datetimeoffset types.
+        if (dbOptions.Value.DetectProvider("PageBuilder") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder/PageBuilderService.cs
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder/PageBuilderService.cs
@@ -84,14 +84,11 @@ public sealed partial class PageBuilderService(
 
         slug = await EnsureUniqueSlugAsync(slug);
 
-        var now = DateTime.UtcNow;
         var page = new Page
         {
             Title = request.Title,
             Slug = slug,
             Content = "{}",
-            CreatedAt = now,
-            UpdatedAt = now,
         };
 
         db.Pages.Add(page);
@@ -124,7 +121,6 @@ public sealed partial class PageBuilderService(
         page.MetaDescription = request.MetaDescription;
         page.MetaKeywords = request.MetaKeywords;
         page.OgImage = request.OgImage;
-        page.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 
@@ -137,7 +133,6 @@ public sealed partial class PageBuilderService(
         var page = await db.Pages.FindAsync(id) ?? throw new NotFoundException("Page", id);
 
         page.DraftContent = request.Content;
-        page.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 
@@ -149,8 +144,9 @@ public sealed partial class PageBuilderService(
     {
         var page = await db.Pages.FindAsync(id) ?? throw new NotFoundException("Page", id);
 
-        page.DeletedAt = DateTime.UtcNow;
         page.IsPublished = false;
+        page.IsDeleted = true;
+        page.DeletedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync();
 
         LogPageDeleted(logger, id);
@@ -167,7 +163,6 @@ public sealed partial class PageBuilderService(
         }
 
         page.IsPublished = true;
-        page.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 
@@ -180,7 +175,6 @@ public sealed partial class PageBuilderService(
         var page = await db.Pages.FindAsync(id) ?? throw new NotFoundException("Page", id);
 
         page.IsPublished = false;
-        page.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 
@@ -193,7 +187,7 @@ public sealed partial class PageBuilderService(
             .Pages.IgnoreQueryFilters()
             .AsNoTracking()
             .Include(p => p.Tags)
-            .Where(p => p.DeletedAt != null)
+            .Where(p => p.IsDeleted)
             .OrderByDescending(p => p.DeletedAt)
             .Select(p => new PageSummary
             {
@@ -213,13 +207,12 @@ public sealed partial class PageBuilderService(
     public async Task<Page> RestorePageAsync(PageId id)
     {
         var page =
-            await db
-                .Pages.IgnoreQueryFilters()
-                .FirstOrDefaultAsync(p => p.Id == id && p.DeletedAt != null)
+            await db.Pages.IgnoreQueryFilters().FirstOrDefaultAsync(p => p.Id == id && p.IsDeleted)
             ?? throw new NotFoundException("Page", id);
 
+        page.IsDeleted = false;
         page.DeletedAt = null;
-        page.UpdatedAt = DateTime.UtcNow;
+        page.DeletedBy = null;
         await db.SaveChangesAsync();
 
         LogPageRestored(logger, page.Id, page.Title);
@@ -236,8 +229,10 @@ public sealed partial class PageBuilderService(
             ?? throw new NotFoundException("Page", id);
 
         page.Tags.Clear();
-        db.Pages.Remove(page);
         await db.SaveChangesAsync();
+
+        // Bypass the soft-delete interceptor for a true hard delete.
+        await db.Pages.IgnoreQueryFilters().Where(p => p.Id == id).ExecuteDeleteAsync();
 
         LogPagePermanentlyDeleted(logger, id);
     }
@@ -247,12 +242,7 @@ public sealed partial class PageBuilderService(
 
     public async Task<PageTemplate> CreateTemplateAsync(CreatePageTemplateRequest request)
     {
-        var template = new PageTemplate
-        {
-            Name = request.Name,
-            Content = request.Content,
-            CreatedAt = DateTime.UtcNow,
-        };
+        var template = new PageTemplate { Name = request.Name, Content = request.Content };
 
         db.Templates.Add(template);
         await db.SaveChangesAsync();

--- a/modules/PageBuilder/src/SimpleModule.PageBuilder/types.ts
+++ b/modules/PageBuilder/src/SimpleModule.PageBuilder/types.ts
@@ -14,7 +14,6 @@ export interface CreatePageTemplateRequest {
 }
 
 export interface Page {
-  id: number;
   title: string;
   slug: string;
   content: string;
@@ -24,10 +23,17 @@ export interface Page {
   ogImage: string;
   isPublished: boolean;
   order: number;
+  tags: PageTag[];
+  isDeleted: boolean;
+  deletedAt: string | null;
+  deletedBy: string;
+  version: number;
+  createdBy: string;
+  updatedBy: string;
+  id: number;
   createdAt: string;
   updatedAt: string;
-  tags: PageTag[];
-  deletedAt: string | null;
+  concurrencyStamp: string;
 }
 
 export interface PageSummary {
@@ -49,10 +55,12 @@ export interface PageTag {
 }
 
 export interface PageTemplate {
-  id: number;
   name: string;
   content: string;
+  id: number;
   createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface UpdatePageContentRequest {

--- a/modules/PageBuilder/tests/SimpleModule.PageBuilder.Tests/PageBuilderServiceTests.cs
+++ b/modules/PageBuilder/tests/SimpleModule.PageBuilder.Tests/PageBuilderServiceTests.cs
@@ -104,11 +104,12 @@ public sealed class PageBuilderServiceTests : IDisposable
 
         await _sut.DeletePageAsync(page.Id);
 
-        // Soft deleted — not in normal queries
-        var found = await _sut.GetPageByIdAsync(page.Id);
-        found.Should().BeNull();
+        // The soft-deleted row stays in storage with IsDeleted=true.
+        var row = await _db.Pages.IgnoreQueryFilters().SingleAsync(p => p.Id == page.Id);
+        row.IsDeleted.Should().BeTrue();
+        row.DeletedAt.Should().NotBeNull();
 
-        // But in trash
+        // And the trash list surfaces it.
         var trashed = await _sut.GetTrashedPagesAsync();
         trashed.Should().ContainSingle().Which.Title.Should().Be("To Soft Delete");
     }

--- a/modules/Permissions/src/SimpleModule.Permissions.Contracts/RolePermission.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions.Contracts/RolePermission.cs
@@ -1,8 +1,9 @@
-using SimpleModule.Permissions.Contracts;
+using SimpleModule.Core;
 
-namespace SimpleModule.Permissions.Entities;
+namespace SimpleModule.Permissions.Contracts;
 
 #pragma warning disable CA1711
+[NoDtoGeneration]
 public class RolePermission
 #pragma warning restore CA1711
 {

--- a/modules/Permissions/src/SimpleModule.Permissions.Contracts/SimpleModule.Permissions.Contracts.csproj
+++ b/modules/Permissions/src/SimpleModule.Permissions.Contracts/SimpleModule.Permissions.Contracts.csproj
@@ -5,6 +5,7 @@
     <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Vogen" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
     <ProjectReference Include="..\..\..\..\modules\Users\src\SimpleModule.Users.Contracts\SimpleModule.Users.Contracts.csproj" />

--- a/modules/Permissions/src/SimpleModule.Permissions.Contracts/UserPermission.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions.Contracts/UserPermission.cs
@@ -1,8 +1,10 @@
+using SimpleModule.Core;
 using SimpleModule.Users.Contracts;
 
-namespace SimpleModule.Permissions.Entities;
+namespace SimpleModule.Permissions.Contracts;
 
 #pragma warning disable CA1711
+[NoDtoGeneration]
 public class UserPermission
 #pragma warning restore CA1711
 {

--- a/modules/Permissions/src/SimpleModule.Permissions/EntityConfigurations/RolePermissionConfiguration.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions/EntityConfigurations/RolePermissionConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SimpleModule.Permissions.Contracts;
-using SimpleModule.Permissions.Entities;
 
 namespace SimpleModule.Permissions.EntityConfigurations;
 

--- a/modules/Permissions/src/SimpleModule.Permissions/EntityConfigurations/UserPermissionConfiguration.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions/EntityConfigurations/UserPermissionConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.Permissions.Entities;
+using SimpleModule.Permissions.Contracts;
 using SimpleModule.Users.Contracts;
 
 namespace SimpleModule.Permissions.EntityConfigurations;

--- a/modules/Permissions/src/SimpleModule.Permissions/PermissionService.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions/PermissionService.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using SimpleModule.Permissions.Contracts;
-using SimpleModule.Permissions.Entities;
 using SimpleModule.Users.Contracts;
 
 namespace SimpleModule.Permissions;

--- a/modules/Permissions/src/SimpleModule.Permissions/PermissionsDbContext.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions/PermissionsDbContext.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
-using SimpleModule.Permissions.Entities;
+using SimpleModule.Permissions.Contracts;
 using SimpleModule.Permissions.EntityConfigurations;
 
 namespace SimpleModule.Permissions;

--- a/modules/Permissions/src/SimpleModule.Permissions/Services/PermissionSeedService.cs
+++ b/modules/Permissions/src/SimpleModule.Permissions/Services/PermissionSeedService.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using SimpleModule.Core.Authorization;
 using SimpleModule.Permissions.Contracts;
 using SimpleModule.Users.Contracts;
-using RolePermission = SimpleModule.Permissions.Entities.RolePermission;
 
 namespace SimpleModule.Permissions.Services;
 

--- a/modules/Products/src/SimpleModule.Products.Contracts/Product.cs
+++ b/modules/Products/src/SimpleModule.Products.Contracts/Product.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Products.Contracts;
 
-public class Product
+public class Product : Entity<ProductId>
 {
-    public ProductId Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public decimal Price { get; set; }
 }

--- a/modules/Products/src/SimpleModule.Products/EntityConfigurations/ProductConfiguration.cs
+++ b/modules/Products/src/SimpleModule.Products/EntityConfigurations/ProductConfiguration.cs
@@ -7,12 +7,16 @@ namespace SimpleModule.Products.EntityConfigurations;
 
 public class ProductConfiguration : IEntityTypeConfiguration<Product>
 {
+    // Deterministic seed timestamp so migrations stay stable across builds.
+    private static readonly DateTimeOffset SeedTimestamp = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     public void Configure(EntityTypeBuilder<Product> builder)
     {
         builder.HasKey(p => p.Id);
         builder.Property(p => p.Id).ValueGeneratedOnAdd();
         builder.Property(p => p.Name).IsRequired();
         builder.Property(p => p.Price).HasColumnType("decimal(18,2)");
+        builder.Property(p => p.ConcurrencyStamp).HasMaxLength(64);
 
         builder.HasData(GenerateSeedProducts());
     }
@@ -31,7 +35,10 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
                         f.Commerce.Price(10, 1000),
                         System.Globalization.CultureInfo.InvariantCulture
                     )
-            );
+            )
+            .RuleFor(p => p.CreatedAt, _ => SeedTimestamp)
+            .RuleFor(p => p.UpdatedAt, _ => SeedTimestamp)
+            .RuleFor(p => p.ConcurrencyStamp, _ => string.Empty);
 
         return faker.Generate(10).ToArray();
     }

--- a/modules/Products/src/SimpleModule.Products/ProductsDbContext.cs
+++ b/modules/Products/src/SimpleModule.Products/ProductsDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Products.Contracts;
@@ -24,5 +25,17 @@ public class ProductsDbContext(
         configurationBuilder
             .Properties<ProductId>()
             .HaveConversion<ProductId.EfCoreValueConverter, ProductId.EfCoreValueComparer>();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("Products") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/Products/src/SimpleModule.Products/types.ts
+++ b/modules/Products/src/SimpleModule.Products/types.ts
@@ -5,9 +5,12 @@ export interface CreateProductRequest {
 }
 
 export interface Product {
-  id: number;
   name: string;
   price: number;
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface UpdateProductRequest {

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/RateLimitRule.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/RateLimitRule.cs
@@ -1,10 +1,10 @@
+using SimpleModule.Core.Entities;
 using SimpleModule.Core.RateLimiting;
 
 namespace SimpleModule.RateLimiting.Contracts;
 
-public class RateLimitRule
+public class RateLimitRule : Entity<RateLimitRuleId>
 {
-    public RateLimitRuleId Id { get; set; }
     public string PolicyName { get; set; } = string.Empty;
     public RateLimitPolicyType PolicyType { get; set; } = RateLimitPolicyType.FixedWindow;
     public RateLimitTarget Target { get; set; } = RateLimitTarget.Ip;
@@ -17,6 +17,4 @@ public class RateLimitRule
     public int QueueLimit { get; set; }
     public string? EndpointPattern { get; set; }
     public bool IsEnabled { get; set; } = true;
-    public DateTime CreatedAt { get; set; }
-    public DateTime? UpdatedAt { get; set; }
 }

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/EntityConfigurations/RateLimitRuleConfiguration.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/EntityConfigurations/RateLimitRuleConfiguration.cs
@@ -15,5 +15,6 @@ public class RateLimitRuleConfiguration : IEntityTypeConfiguration<RateLimitRule
         builder.Property(r => r.EndpointPattern).HasMaxLength(500);
         builder.Property(r => r.PolicyType).HasConversion<string>().HasMaxLength(50);
         builder.Property(r => r.Target).HasConversion<string>().HasMaxLength(50);
+        builder.Property(r => r.ConcurrencyStamp).HasMaxLength(64);
     }
 }

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingDbContext.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.RateLimiting.Contracts;
@@ -27,5 +28,17 @@ public class RateLimitingDbContext(
                 RateLimitRuleId.EfCoreValueConverter,
                 RateLimitRuleId.EfCoreValueComparer
             >();
+
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("RateLimiting") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingService.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingService.cs
@@ -39,7 +39,6 @@ public partial class RateLimitingService(
             QueueLimit = request.QueueLimit,
             EndpointPattern = request.EndpointPattern,
             IsEnabled = request.IsEnabled,
-            CreatedAt = DateTime.UtcNow,
         };
 
         db.Rules.Add(rule);
@@ -72,7 +71,6 @@ public partial class RateLimitingService(
         rule.QueueLimit = request.QueueLimit;
         rule.EndpointPattern = request.EndpointPattern;
         rule.IsEnabled = request.IsEnabled;
-        rule.UpdatedAt = DateTime.UtcNow;
 
         await db.SaveChangesAsync();
 

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/types.ts
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/types.ts
@@ -15,7 +15,6 @@ export interface CreateRateLimitRuleRequest {
 }
 
 export interface RateLimitRule {
-  id: number;
   policyName: string;
   policyType: any;
   target: any;
@@ -28,8 +27,10 @@ export interface RateLimitRule {
   queueLimit: number;
   endpointPattern: string;
   isEnabled: boolean;
+  id: number;
   createdAt: string;
-  updatedAt: string | null;
+  updatedAt: string;
+  concurrencyStamp: string;
 }
 
 export interface UpdateRateLimitRuleRequest {

--- a/modules/RateLimiting/tests/SimpleModule.RateLimiting.Tests/RateLimitingServiceTests.cs
+++ b/modules/RateLimiting/tests/SimpleModule.RateLimiting.Tests/RateLimitingServiceTests.cs
@@ -104,7 +104,6 @@ public sealed class RateLimitingServiceTests : IDisposable
         updated.PermitLimit.Should().Be(200);
         updated.PolicyType.Should().Be(RateLimitPolicyType.SlidingWindow);
         updated.Target.Should().Be(RateLimitTarget.User);
-        updated.UpdatedAt.Should().NotBeNull();
     }
 
     [Fact]

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/CreateMenuItemRequest.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/CreateMenuItemRequest.cs
@@ -2,7 +2,7 @@ namespace SimpleModule.Settings.Contracts;
 
 public class CreateMenuItemRequest
 {
-    public int? ParentId { get; set; }
+    public PublicMenuItemId? ParentId { get; set; }
     public string Label { get; set; } = "";
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemDto.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemDto.cs
@@ -2,8 +2,8 @@ namespace SimpleModule.Settings.Contracts;
 
 public class PublicMenuItemDto
 {
-    public int Id { get; set; }
-    public int? ParentId { get; set; }
+    public PublicMenuItemId Id { get; set; }
+    public PublicMenuItemId? ParentId { get; set; }
     public string Label { get; set; } = "";
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.Settings.Contracts;
 
-namespace SimpleModule.Settings.Entities;
+namespace SimpleModule.Settings.Contracts;
 
+[NoDtoGeneration]
 public class PublicMenuItemEntity : Entity<PublicMenuItemId>
 {
     public PublicMenuItemId? ParentId { get; set; }

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemId.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/PublicMenuItemId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Settings.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct PublicMenuItemId;

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/ReorderMenuItemsRequest.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/ReorderMenuItemsRequest.cs
@@ -7,7 +7,7 @@ public class ReorderMenuItemsRequest
 
 public class ReorderItem
 {
-    public int Id { get; set; }
-    public int? ParentId { get; set; }
+    public PublicMenuItemId Id { get; set; }
+    public PublicMenuItemId? ParentId { get; set; }
     public int SortOrder { get; set; }
 }

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/SettingEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/SettingEntity.cs
@@ -1,9 +1,10 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
 using SimpleModule.Core.Settings;
-using SimpleModule.Settings.Contracts;
 
-namespace SimpleModule.Settings.Entities;
+namespace SimpleModule.Settings.Contracts;
 
+[NoDtoGeneration]
 public class SettingEntity : Entity<SettingId>
 {
     public string Key { get; set; } = string.Empty;

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/SettingId.cs
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/SettingId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Settings.Contracts;
+
+[ValueObject<int>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct SettingId;

--- a/modules/Settings/src/SimpleModule.Settings.Contracts/SimpleModule.Settings.Contracts.csproj
+++ b/modules/Settings/src/SimpleModule.Settings.Contracts/SimpleModule.Settings.Contracts.csproj
@@ -2,8 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Vogen" />
     <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/DeleteMenuItemEndpoint.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/DeleteMenuItemEndpoint.cs
@@ -17,7 +17,7 @@ public class DeleteMenuItemEndpoint : IEndpoint
                 Route,
                 async Task<IResult> (int id, PublicMenuService service) =>
                 {
-                    var deleted = await service.DeleteAsync(id);
+                    var deleted = await service.DeleteAsync(PublicMenuItemId.From(id));
                     return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
                 }
             )

--- a/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/SetHomePageEndpoint.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/SetHomePageEndpoint.cs
@@ -17,7 +17,7 @@ public class SetHomePageEndpoint : IEndpoint
                 Route,
                 async (int id, PublicMenuService service) =>
                 {
-                    await service.SetHomePageAsync(id);
+                    await service.SetHomePageAsync(PublicMenuItemId.From(id));
                     return TypedResults.NoContent();
                 }
             )

--- a/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/UpdateMenuItemEndpoint.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Endpoints/Menus/UpdateMenuItemEndpoint.cs
@@ -21,7 +21,7 @@ public class UpdateMenuItemEndpoint : IEndpoint
                     PublicMenuService service
                 ) =>
                 {
-                    var entity = await service.UpdateAsync(id, request);
+                    var entity = await service.UpdateAsync(PublicMenuItemId.From(id), request);
                     return entity is not null ? TypedResults.NoContent() : TypedResults.NotFound();
                 }
             )

--- a/modules/Settings/src/SimpleModule.Settings/Entities/PublicMenuItemEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Entities/PublicMenuItemEntity.cs
@@ -1,10 +1,11 @@
 using SimpleModule.Core.Entities;
+using SimpleModule.Settings.Contracts;
 
 namespace SimpleModule.Settings.Entities;
 
-public class PublicMenuItemEntity : Entity<int>
+public class PublicMenuItemEntity : Entity<PublicMenuItemId>
 {
-    public int? ParentId { get; set; }
+    public PublicMenuItemId? ParentId { get; set; }
     public PublicMenuItemEntity? Parent { get; set; }
     public List<PublicMenuItemEntity> Children { get; set; } = [];
 

--- a/modules/Settings/src/SimpleModule.Settings/Entities/PublicMenuItemEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Entities/PublicMenuItemEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core.Entities;
+
 namespace SimpleModule.Settings.Entities;
 
-public class PublicMenuItemEntity
+public class PublicMenuItemEntity : Entity<int>
 {
-    public int Id { get; set; }
     public int? ParentId { get; set; }
     public PublicMenuItemEntity? Parent { get; set; }
     public List<PublicMenuItemEntity> Children { get; set; } = [];
@@ -22,6 +23,4 @@ public class PublicMenuItemEntity
     public bool IsVisible { get; set; } = true;
     public bool IsHomePage { get; set; }
     public int SortOrder { get; set; }
-    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
-    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/modules/Settings/src/SimpleModule.Settings/Entities/SettingEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Entities/SettingEntity.cs
@@ -1,13 +1,12 @@
+using SimpleModule.Core.Entities;
 using SimpleModule.Core.Settings;
 
 namespace SimpleModule.Settings.Entities;
 
-public class SettingEntity
+public class SettingEntity : Entity<int>
 {
-    public int Id { get; set; }
     public string Key { get; set; } = string.Empty;
     public string? Value { get; set; }
     public SettingScope Scope { get; set; }
     public string? UserId { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/modules/Settings/src/SimpleModule.Settings/Entities/SettingEntity.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Entities/SettingEntity.cs
@@ -1,9 +1,10 @@
 using SimpleModule.Core.Entities;
 using SimpleModule.Core.Settings;
+using SimpleModule.Settings.Contracts;
 
 namespace SimpleModule.Settings.Entities;
 
-public class SettingEntity : Entity<int>
+public class SettingEntity : Entity<SettingId>
 {
     public string Key { get; set; } = string.Empty;
     public string? Value { get; set; }

--- a/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
+++ b/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.Settings.Entities;
+using SimpleModule.Settings.Contracts;
 
 namespace SimpleModule.Settings.EntityConfigurations;
 

--- a/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
+++ b/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
@@ -9,6 +9,7 @@ public class PublicMenuItemEntityConfiguration : IEntityTypeConfiguration<Public
     public void Configure(EntityTypeBuilder<PublicMenuItemEntity> builder)
     {
         builder.HasKey(m => m.Id);
+        builder.Property(m => m.Id).ValueGeneratedOnAdd();
         builder.Property(m => m.Label).IsRequired().HasMaxLength(200);
         builder.Property(m => m.Url).HasMaxLength(2048);
         builder.Property(m => m.PageRoute).HasMaxLength(256);

--- a/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
+++ b/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/PublicMenuItemEntityConfiguration.cs
@@ -14,6 +14,7 @@ public class PublicMenuItemEntityConfiguration : IEntityTypeConfiguration<Public
         builder.Property(m => m.PageRoute).HasMaxLength(256);
         builder.Property(m => m.Icon).HasMaxLength(4000);
         builder.Property(m => m.CssClass).HasMaxLength(500);
+        builder.Property(m => m.ConcurrencyStamp).HasMaxLength(64);
 
         builder
             .HasOne(m => m.Parent)

--- a/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/SettingEntityConfiguration.cs
+++ b/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/SettingEntityConfiguration.cs
@@ -14,7 +14,9 @@ public class SettingEntityConfiguration : IEntityTypeConfiguration<SettingEntity
         builder.Property(s => s.Value).IsRequired(false);
         builder.Property(s => s.Scope).HasConversion<int>();
         builder.Property(s => s.UserId).IsRequired(false).HasMaxLength(450);
+        builder.Property(s => s.CreatedAt).IsRequired();
         builder.Property(s => s.UpdatedAt).IsRequired();
+        builder.Property(s => s.ConcurrencyStamp).HasMaxLength(64);
 
         builder
             .HasIndex(s => new

--- a/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/SettingEntityConfiguration.cs
+++ b/modules/Settings/src/SimpleModule.Settings/EntityConfigurations/SettingEntityConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using SimpleModule.Settings.Entities;
+using SimpleModule.Settings.Contracts;
 
 namespace SimpleModule.Settings.EntityConfigurations;
 

--- a/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Options;
 using SimpleModule.Core.Caching;
 using SimpleModule.Core.Menu;
 using SimpleModule.Settings.Contracts;
-using SimpleModule.Settings.Entities;
 
 namespace SimpleModule.Settings.Services;
 

--- a/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
@@ -71,9 +71,10 @@ public sealed class PublicMenuService(
                 );
         }
 
+        var parentId = request.ParentId;
         var maxSortOrder =
             await db
-                .PublicMenuItems.Where(e => e.ParentId == request.ParentId)
+                .PublicMenuItems.Where(e => e.ParentId == parentId)
                 .MaxAsync(e => (int?)e.SortOrder)
             ?? -1;
 
@@ -100,7 +101,10 @@ public sealed class PublicMenuService(
         return entity;
     }
 
-    public async Task<PublicMenuItemEntity?> UpdateAsync(int id, UpdateMenuItemRequest request)
+    public async Task<PublicMenuItemEntity?> UpdateAsync(
+        PublicMenuItemId id,
+        UpdateMenuItemRequest request
+    )
     {
         var entity = await db.PublicMenuItems.FindAsync(id);
         if (entity is null)
@@ -123,7 +127,7 @@ public sealed class PublicMenuService(
         return entity;
     }
 
-    public async Task<bool> DeleteAsync(int id)
+    public async Task<bool> DeleteAsync(PublicMenuItemId id)
     {
         var entity = await db.PublicMenuItems.FindAsync(id);
         if (entity is null)
@@ -151,7 +155,7 @@ public sealed class PublicMenuService(
         await InvalidateCache();
     }
 
-    public async Task SetHomePageAsync(int id)
+    public async Task SetHomePageAsync(PublicMenuItemId id)
     {
         await ClearAllHomePageFlags();
 
@@ -182,15 +186,16 @@ public sealed class PublicMenuService(
         }
     }
 
-    private async Task<int> GetDepthAsync(int parentId)
+    private async Task<int> GetDepthAsync(PublicMenuItemId parentId)
     {
         var depth = 1;
-        var currentId = (int?)parentId;
+        PublicMenuItemId? currentId = parentId;
 
         while (currentId is not null)
         {
+            var lookupId = currentId.Value;
             var parent = await db
-                .PublicMenuItems.Where(e => e.Id == currentId)
+                .PublicMenuItems.Where(e => e.Id == lookupId)
                 .Select(e => e.ParentId)
                 .FirstOrDefaultAsync();
 
@@ -204,7 +209,7 @@ public sealed class PublicMenuService(
 
     private static List<PublicMenuItem> BuildPublicTree(
         List<PublicMenuItemEntity> entities,
-        int? parentId
+        PublicMenuItemId? parentId
     )
     {
         return entities
@@ -224,7 +229,7 @@ public sealed class PublicMenuService(
 
     private static List<PublicMenuItemDto> BuildDtoTree(
         List<PublicMenuItemEntity> entities,
-        int? parentId
+        PublicMenuItemId? parentId
     )
     {
         return entities

--- a/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
+++ b/modules/Settings/src/SimpleModule.Settings/Services/PublicMenuService.cs
@@ -92,8 +92,6 @@ public sealed class PublicMenuService(
             IsVisible = request.IsVisible,
             IsHomePage = request.IsHomePage,
             SortOrder = maxSortOrder + 1,
-            CreatedAt = DateTimeOffset.UtcNow,
-            UpdatedAt = DateTimeOffset.UtcNow,
         };
 
         db.PublicMenuItems.Add(entity);
@@ -119,7 +117,6 @@ public sealed class PublicMenuService(
         entity.OpenInNewTab = request.OpenInNewTab;
         entity.IsVisible = request.IsVisible;
         entity.IsHomePage = request.IsHomePage;
-        entity.UpdatedAt = DateTimeOffset.UtcNow;
 
         await db.SaveChangesAsync();
         await InvalidateCache();
@@ -147,7 +144,6 @@ public sealed class PublicMenuService(
             {
                 entity.ParentId = item.ParentId;
                 entity.SortOrder = item.SortOrder;
-                entity.UpdatedAt = DateTimeOffset.UtcNow;
             }
         }
 
@@ -163,7 +159,6 @@ public sealed class PublicMenuService(
         if (entity is not null)
         {
             entity.IsHomePage = true;
-            entity.UpdatedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync();
         }
 
@@ -184,7 +179,6 @@ public sealed class PublicMenuService(
         foreach (var hp in homePages)
         {
             hp.IsHomePage = false;
-            hp.UpdatedAt = DateTimeOffset.UtcNow;
         }
     }
 

--- a/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
+++ b/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Settings.Entities;
@@ -18,5 +19,20 @@ public class SettingsDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(SettingsDbContext).Assembly);
         modelBuilder.ApplyModuleSchema("Settings", dbOptions.Value);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
+        // Store as long (binary ticks) only when running against SQLite.
+        if (dbOptions.Value.DetectProvider("Settings") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
     }
 }

--- a/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
+++ b/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Settings.Contracts;
-using SimpleModule.Settings.Entities;
 
 namespace SimpleModule.Settings;
 

--- a/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
+++ b/modules/Settings/src/SimpleModule.Settings/SettingsDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
+using SimpleModule.Settings.Contracts;
 using SimpleModule.Settings.Entities;
 
 namespace SimpleModule.Settings;
@@ -23,6 +24,16 @@ public class SettingsDbContext(
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
+        configurationBuilder
+            .Properties<SettingId>()
+            .HaveConversion<SettingId.EfCoreValueConverter, SettingId.EfCoreValueComparer>();
+        configurationBuilder
+            .Properties<PublicMenuItemId>()
+            .HaveConversion<
+                PublicMenuItemId.EfCoreValueConverter,
+                PublicMenuItemId.EfCoreValueComparer
+            >();
+
         // SQLite cannot ORDER BY or compare DateTimeOffset expressions natively.
         // Store as long (binary ticks) only when running against SQLite.
         if (dbOptions.Value.DetectProvider("Settings") == DatabaseProvider.Sqlite)

--- a/modules/Settings/src/SimpleModule.Settings/SettingsService.cs
+++ b/modules/Settings/src/SimpleModule.Settings/SettingsService.cs
@@ -92,7 +92,6 @@ public sealed partial class SettingsService(
         if (existing is not null)
         {
             existing.Value = value;
-            existing.UpdatedAt = DateTimeOffset.UtcNow;
         }
         else
         {
@@ -103,7 +102,6 @@ public sealed partial class SettingsService(
                     Value = value,
                     Scope = scope,
                     UserId = scope == SettingScope.User ? userId : null,
-                    UpdatedAt = DateTimeOffset.UtcNow,
                 }
             );
         }

--- a/modules/Settings/src/SimpleModule.Settings/SettingsService.cs
+++ b/modules/Settings/src/SimpleModule.Settings/SettingsService.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Options;
 using SimpleModule.Core.Caching;
 using SimpleModule.Core.Settings;
 using SimpleModule.Settings.Contracts;
-using SimpleModule.Settings.Entities;
 
 namespace SimpleModule.Settings;
 

--- a/modules/Settings/src/SimpleModule.Settings/types.ts
+++ b/modules/Settings/src/SimpleModule.Settings/types.ts
@@ -1,6 +1,6 @@
 // Auto-generated from [Dto] types — do not edit
 export interface CreateMenuItemRequest {
-  parentId: number | null;
+  parentId: any | null;
   label: string;
   url: string;
   pageRoute: string;
@@ -13,7 +13,7 @@ export interface CreateMenuItemRequest {
 
 export interface PublicMenuItemDto {
   id: number;
-  parentId: number | null;
+  parentId: any | null;
   label: string;
   url: string;
   pageRoute: string;
@@ -32,7 +32,7 @@ export interface ReorderMenuItemsRequest {
 
 export interface ReorderItem {
   id: number;
-  parentId: number | null;
+  parentId: any | null;
   sortOrder: number;
 }
 

--- a/modules/Settings/tests/SimpleModule.Settings.Tests/Unit/PublicMenuServiceTests.cs
+++ b/modules/Settings/tests/SimpleModule.Settings.Tests/Unit/PublicMenuServiceTests.cs
@@ -52,7 +52,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Parent",
                 IsVisible = true,
                 SortOrder = 0,
@@ -61,8 +61,8 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 2,
-                ParentId = 1,
+                Id = PublicMenuItemId.From(2),
+                ParentId = PublicMenuItemId.From(1),
                 Label = "Child",
                 IsVisible = true,
                 SortOrder = 0,
@@ -84,7 +84,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Visible",
                 IsVisible = true,
                 SortOrder = 0,
@@ -93,7 +93,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 2,
+                Id = PublicMenuItemId.From(2),
                 Label = "Hidden",
                 IsVisible = false,
                 SortOrder = 1,
@@ -113,7 +113,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Page",
                 Url = "/some-page",
                 IsVisible = true,
@@ -134,7 +134,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Home",
                 Url = "/home",
                 IsVisible = true,
@@ -155,7 +155,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Level 1",
                 IsVisible = true,
                 SortOrder = 0,
@@ -164,8 +164,8 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 2,
-                ParentId = 1,
+                Id = PublicMenuItemId.From(2),
+                ParentId = PublicMenuItemId.From(1),
                 Label = "Level 2",
                 IsVisible = true,
                 SortOrder = 0,
@@ -174,8 +174,8 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 3,
-                ParentId = 2,
+                Id = PublicMenuItemId.From(3),
+                ParentId = PublicMenuItemId.From(2),
                 Label = "Level 3",
                 IsVisible = true,
                 SortOrder = 0,
@@ -183,7 +183,11 @@ public sealed class PublicMenuServiceTests : IDisposable
         );
         await _db.SaveChangesAsync();
 
-        var request = new CreateMenuItemRequest { ParentId = 3, Label = "Level 4" };
+        var request = new CreateMenuItemRequest
+        {
+            ParentId = PublicMenuItemId.From(3),
+            Label = "Level 4",
+        };
 
         var act = () => _service.CreateAsync(request);
 
@@ -196,7 +200,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 1,
+                Id = PublicMenuItemId.From(1),
                 Label = "Old Home",
                 IsVisible = true,
                 IsHomePage = true,
@@ -206,7 +210,7 @@ public sealed class PublicMenuServiceTests : IDisposable
         _db.PublicMenuItems.Add(
             new PublicMenuItemEntity
             {
-                Id = 2,
+                Id = PublicMenuItemId.From(2),
                 Label = "New Home",
                 IsVisible = true,
                 IsHomePage = false,
@@ -215,10 +219,10 @@ public sealed class PublicMenuServiceTests : IDisposable
         );
         await _db.SaveChangesAsync();
 
-        await _service.SetHomePageAsync(2);
+        await _service.SetHomePageAsync(PublicMenuItemId.From(2));
 
-        var oldHome = await _db.PublicMenuItems.FindAsync(1);
-        var newHome = await _db.PublicMenuItems.FindAsync(2);
+        var oldHome = await _db.PublicMenuItems.FindAsync(PublicMenuItemId.From(1));
+        var newHome = await _db.PublicMenuItems.FindAsync(PublicMenuItemId.From(2));
         oldHome!.IsHomePage.Should().BeFalse();
         newHome!.IsHomePage.Should().BeTrue();
     }

--- a/modules/Settings/tests/SimpleModule.Settings.Tests/Unit/PublicMenuServiceTests.cs
+++ b/modules/Settings/tests/SimpleModule.Settings.Tests/Unit/PublicMenuServiceTests.cs
@@ -6,7 +6,6 @@ using SimpleModule.Core.Caching;
 using SimpleModule.Database;
 using SimpleModule.Settings;
 using SimpleModule.Settings.Contracts;
-using SimpleModule.Settings.Entities;
 using SimpleModule.Settings.Services;
 
 namespace Settings.Tests.Unit;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantEntity.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.Tenants.Contracts;
 
-namespace SimpleModule.Tenants.Entities;
+namespace SimpleModule.Tenants.Contracts;
 
+[NoDtoGeneration]
 public sealed class TenantEntity : AuditableEntity<TenantId>
 {
     public string Name { get; set; } = string.Empty;

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantEntity.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantEntity.cs
@@ -11,7 +11,12 @@ public sealed class TenantEntity : AuditableEntity<TenantId>
     public TenantStatus Status { get; set; }
     public string? AdminEmail { get; set; }
     public string? EditionName { get; set; }
+
+    // Infrastructure-only: populated and read by the Tenants module's tenant
+    // resolution pipeline. Other modules must not read this directly; use
+    // ITenantsContracts to go through the authorization boundary.
     public string? ConnectionString { get; set; }
+
     public DateTimeOffset? ValidUpTo { get; set; }
     public ICollection<TenantHostEntity> Hosts { get; set; } = [];
 }

--- a/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHostEntity.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants.Contracts/TenantHostEntity.cs
@@ -1,8 +1,9 @@
+using SimpleModule.Core;
 using SimpleModule.Core.Entities;
-using SimpleModule.Tenants.Contracts;
 
-namespace SimpleModule.Tenants.Entities;
+namespace SimpleModule.Tenants.Contracts;
 
+[NoDtoGeneration]
 public sealed class TenantHostEntity : Entity<TenantHostId>
 {
     public TenantId TenantId { get; set; }

--- a/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SimpleModule.Tenants.Contracts;
-using SimpleModule.Tenants.Entities;
 
 namespace SimpleModule.Tenants.EntityConfigurations;
 

--- a/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantHostConfiguration.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/EntityConfigurations/TenantHostConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SimpleModule.Tenants.Contracts;
-using SimpleModule.Tenants.Entities;
 
 namespace SimpleModule.Tenants.EntityConfigurations;
 

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
@@ -4,7 +4,6 @@ using SimpleModule.Core.Events;
 using SimpleModule.Core.Exceptions;
 using SimpleModule.Tenants.Contracts;
 using SimpleModule.Tenants.Contracts.Events;
-using SimpleModule.Tenants.Entities;
 
 namespace SimpleModule.Tenants;
 

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantsDbContext.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantsDbContext.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SimpleModule.Database;
 using SimpleModule.Tenants.Contracts;
-using SimpleModule.Tenants.Entities;
 using SimpleModule.Tenants.EntityConfigurations;
 
 namespace SimpleModule.Tenants;

--- a/template/SimpleModule.Host/Migrations/20260411055822_UseBaseEntities.Designer.cs
+++ b/template/SimpleModule.Host/Migrations/20260411055822_UseBaseEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimpleModule.Host;
 
@@ -10,9 +11,11 @@ using SimpleModule.Host;
 namespace SimpleModule.Host.Migrations
 {
     [DbContext(typeof(HostDbContext))]
-    partial class HostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411055822_UseBaseEntities")]
+    partial class UseBaseEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.3");

--- a/template/SimpleModule.Host/Migrations/20260411055822_UseBaseEntities.cs
+++ b/template/SimpleModule.Host/Migrations/20260411055822_UseBaseEntities.cs
@@ -1,0 +1,920 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimpleModule.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class UseBaseEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PageBuilder_Pages_DeletedAt",
+                table: "PageBuilder_Pages"
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_Tenants",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_TenantHosts",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Settings_Settings",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Settings_Settings",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Settings_PublicMenuItems",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "RateLimiting_Rules",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                ),
+                oldClrType: typeof(DateTime),
+                oldType: "TEXT",
+                oldNullable: true
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "RateLimiting_Rules",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "RateLimiting_Rules",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Products_Products",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Products_Products",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Products_Products",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Products_Products",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Templates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "PageBuilder_Templates",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "PageBuilder_Templates",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Tags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Pages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "PageBuilder_Pages",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "PageBuilder_Pages",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeletedBy",
+                table: "PageBuilder_Pages",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "PageBuilder_Pages",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdatedBy",
+                table: "PageBuilder_Pages",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<int>(
+                name: "Version",
+                table: "PageBuilder_Pages",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Orders_Orders",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Orders_Orders",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Orders_Orders",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Orders_Orders",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdatedBy",
+                table: "Orders_Orders",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FileStorage_StoredFiles",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "FileStorage_StoredFiles",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "FileStorage_StoredFiles",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Email_EmailTemplates",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                ),
+                oldClrType: typeof(DateTime),
+                oldType: "TEXT",
+                oldNullable: true
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailTemplates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Email_EmailTemplates",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailMessages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Email_EmailMessages",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Email_EmailMessages",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Chat_Conversations",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Chat_ChatMessages",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<long>(
+                name: "UpdatedAt",
+                table: "Chat_ChatMessages",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "BackgroundJobs_JobQueueEntries",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "BackgroundJobs_JobQueueEntries",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "BackgroundJobs_JobProgress",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "BackgroundJobs_JobProgress",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "AuditLogs_AuditEntries",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConcurrencyStamp",
+                table: "Agents_Sessions",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: ""
+            );
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Agents_Sessions",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(
+                    new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    new TimeSpan(0, 0, 0, 0, 0)
+                )
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 8,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 9,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.UpdateData(
+                table: "Products_Products",
+                keyColumn: "Id",
+                keyValue: 10,
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "UpdatedAt" },
+                values: new object[]
+                {
+                    "",
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                    new DateTimeOffset(
+                        new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                        new TimeSpan(0, 0, 0, 0, 0)
+                    ),
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Pages_IsDeleted_DeletedAt",
+                table: "PageBuilder_Pages",
+                columns: new[] { "IsDeleted", "DeletedAt" }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PageBuilder_Pages_IsDeleted_DeletedAt",
+                table: "PageBuilder_Pages"
+            );
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Settings_Settings");
+
+            migrationBuilder.DropColumn(name: "CreatedAt", table: "Settings_Settings");
+
+            migrationBuilder.DropColumn(
+                name: "ConcurrencyStamp",
+                table: "Settings_PublicMenuItems"
+            );
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "RateLimiting_Rules");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Products_Products");
+
+            migrationBuilder.DropColumn(name: "CreatedAt", table: "Products_Products");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "Products_Products");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "PageBuilder_Templates");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "PageBuilder_Templates");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "CreatedBy", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "DeletedBy", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "IsDeleted", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "UpdatedBy", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "Version", table: "PageBuilder_Pages");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Orders_Orders");
+
+            migrationBuilder.DropColumn(name: "CreatedBy", table: "Orders_Orders");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "Orders_Orders");
+
+            migrationBuilder.DropColumn(name: "UpdatedBy", table: "Orders_Orders");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "FileStorage_StoredFiles");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "FileStorage_StoredFiles");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Email_EmailTemplates");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Email_EmailMessages");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "Email_EmailMessages");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Chat_Conversations");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Chat_ChatMessages");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "Chat_ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ConcurrencyStamp",
+                table: "BackgroundJobs_JobQueueEntries"
+            );
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "BackgroundJobs_JobQueueEntries");
+
+            migrationBuilder.DropColumn(
+                name: "ConcurrencyStamp",
+                table: "BackgroundJobs_JobProgress"
+            );
+
+            migrationBuilder.DropColumn(name: "CreatedAt", table: "BackgroundJobs_JobProgress");
+
+            migrationBuilder.DropColumn(name: "ConcurrencyStamp", table: "Agents_Sessions");
+
+            migrationBuilder.DropColumn(name: "UpdatedAt", table: "Agents_Sessions");
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_Tenants",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_TenantHosts",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "RateLimiting_Rules",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "TEXT"
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "RateLimiting_Rules",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Products_Products",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Templates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Tags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "PageBuilder_Pages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Orders_Orders",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FileStorage_StoredFiles",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Email_EmailTemplates",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "TEXT"
+            );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailTemplates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailMessages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "AuditLogs_AuditEntries",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Pages_DeletedAt",
+                table: "PageBuilder_Pages",
+                column: "DeletedAt"
+            );
+        }
+    }
+}

--- a/template/SimpleModule.Host/Migrations/20260411065821_UseBaseEntities.Designer.cs
+++ b/template/SimpleModule.Host/Migrations/20260411065821_UseBaseEntities.Designer.cs
@@ -11,7 +11,7 @@ using SimpleModule.Host;
 namespace SimpleModule.Host.Migrations
 {
     [DbContext(typeof(HostDbContext))]
-    [Migration("20260411055822_UseBaseEntities")]
+    [Migration("20260411065821_UseBaseEntities")]
     partial class UseBaseEntities
     {
         /// <inheritdoc />

--- a/template/SimpleModule.Host/Migrations/20260411065821_UseBaseEntities.cs
+++ b/template/SimpleModule.Host/Migrations/20260411065821_UseBaseEntities.cs
@@ -38,6 +38,17 @@ namespace SimpleModule.Host.Migrations
                 )
                 .OldAnnotation("Sqlite:Autoincrement", true);
 
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_Settings",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
             migrationBuilder.AddColumn<string>(
                 name: "ConcurrencyStamp",
                 table: "Settings_Settings",
@@ -57,6 +68,17 @@ namespace SimpleModule.Host.Migrations
                     new TimeSpan(0, 0, 0, 0, 0)
                 )
             );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_PublicMenuItems",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
 
             migrationBuilder.AddColumn<string>(
                 name: "ConcurrencyStamp",
@@ -317,6 +339,28 @@ namespace SimpleModule.Host.Migrations
                     new TimeSpan(0, 0, 0, 0, 0)
                 )
             );
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlagOverrides",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
 
             migrationBuilder.AlterColumn<DateTimeOffset>(
                 name: "UpdatedAt",
@@ -782,6 +826,28 @@ namespace SimpleModule.Host.Migrations
                 )
                 .Annotation("Sqlite:Autoincrement", true);
 
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_Settings",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_PublicMenuItems",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
             migrationBuilder.AlterColumn<DateTime>(
                 name: "UpdatedAt",
                 table: "RateLimiting_Rules",
@@ -861,6 +927,28 @@ namespace SimpleModule.Host.Migrations
                 .AlterColumn<int>(
                     name: "Id",
                     table: "FileStorage_StoredFiles",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlagOverrides",
                     type: "INTEGER",
                     nullable: false,
                     oldClrType: typeof(int),

--- a/tests/SimpleModule.Generator.Tests/DiagnosticTests.cs
+++ b/tests/SimpleModule.Generator.Tests/DiagnosticTests.cs
@@ -1224,10 +1224,9 @@ public class DiagnosticTests
             }
             """;
 
-        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
-            "SimpleModule.Products",
-            source
-        );
+        var compilation = GeneratorTestHelper
+            .CreateCompilationWithEfCore(source)
+            .WithAssemblyName("SimpleModule.Products");
         var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
 
         diagnostics.Should().Contain(d => d.Id == "SM0055");
@@ -1268,10 +1267,9 @@ public class DiagnosticTests
             }
             """;
 
-        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
-            "SimpleModule.Products.Contracts",
-            source
-        );
+        var compilation = GeneratorTestHelper
+            .CreateCompilationWithEfCore(source)
+            .WithAssemblyName("SimpleModule.Products.Contracts");
         var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
 
         diagnostics.Should().NotContain(d => d.Id == "SM0055");
@@ -1309,10 +1307,9 @@ public class DiagnosticTests
             }
             """;
 
-        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
-            "SimpleModule.Agents.Module",
-            source
-        );
+        var compilation = GeneratorTestHelper
+            .CreateCompilationWithEfCore(source)
+            .WithAssemblyName("SimpleModule.Agents.Module");
         var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
 
         diagnostics.Should().Contain(d => d.Id == "SM0055");
@@ -1352,10 +1349,9 @@ public class DiagnosticTests
             }
             """;
 
-        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
-            "Contoso.Widgets",
-            source
-        );
+        var compilation = GeneratorTestHelper
+            .CreateCompilationWithEfCore(source)
+            .WithAssemblyName("Contoso.Widgets");
         var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
 
         diagnostics.Should().NotContain(d => d.Id == "SM0055");

--- a/tests/SimpleModule.Generator.Tests/DiagnosticTests.cs
+++ b/tests/SimpleModule.Generator.Tests/DiagnosticTests.cs
@@ -1192,4 +1192,174 @@ public class DiagnosticTests
     }
 
     #endregion
+
+    #region SM0055: Entity class must live in a Contracts assembly
+
+    [Fact]
+    public void SM0055_EntityInImplementationAssembly_ReportsError()
+    {
+        var source = """
+            using SimpleModule.Core;
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.Extensions.Options;
+            using SimpleModule.Database;
+
+            namespace TestApp.Products
+            {
+                // Entity declared in an implementation (non-Contracts) assembly.
+                public class Product { public int Id { get; set; } }
+
+                [Module("Products")]
+                public class ProductsModule : IModule { }
+
+                public class ProductsDbContext : DbContext
+                {
+                    public ProductsDbContext(
+                        DbContextOptions<ProductsDbContext> options,
+                        IOptions<DatabaseOptions> dbOptions
+                    ) : base(options) { }
+
+                    public DbSet<Product> Products => Set<Product>();
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
+            "SimpleModule.Products",
+            source
+        );
+        var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
+
+        diagnostics.Should().Contain(d => d.Id == "SM0055");
+        var diag = diagnostics.First(d => d.Id == "SM0055");
+        var message = diag.GetMessage(System.Globalization.CultureInfo.InvariantCulture);
+        message.Should().Contain("Product");
+        message.Should().Contain("Products");
+        message.Should().Contain("SimpleModule.Products");
+        message.Should().Contain("SimpleModule.Products.Contracts");
+    }
+
+    [Fact]
+    public void SM0055_EntityInContractsAssembly_NoDiagnostic()
+    {
+        var source = """
+            using SimpleModule.Core;
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.Extensions.Options;
+            using SimpleModule.Database;
+
+            namespace TestApp.Products
+            {
+                // Entity declared in the Contracts assembly — compliant.
+                public class Product { public int Id { get; set; } }
+
+                [Module("Products")]
+                public class ProductsModule : IModule { }
+
+                public class ProductsDbContext : DbContext
+                {
+                    public ProductsDbContext(
+                        DbContextOptions<ProductsDbContext> options,
+                        IOptions<DatabaseOptions> dbOptions
+                    ) : base(options) { }
+
+                    public DbSet<Product> Products => Set<Product>();
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
+            "SimpleModule.Products.Contracts",
+            source
+        );
+        var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
+
+        diagnostics.Should().NotContain(d => d.Id == "SM0055");
+    }
+
+    [Fact]
+    public void SM0055_EntityInModuleSuffixedAssembly_SuggestsContractsSibling()
+    {
+        // When the implementation assembly has the '.Module' suffix (e.g.
+        // SimpleModule.Agents.Module), the suggested replacement is the
+        // '.Contracts' sibling (SimpleModule.Agents.Contracts), not a
+        // double-suffixed '.Module.Contracts' assembly.
+        var source = """
+            using SimpleModule.Core;
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.Extensions.Options;
+            using SimpleModule.Database;
+
+            namespace TestApp.Agents
+            {
+                public class AgentSession { public int Id { get; set; } }
+
+                [Module("Agents")]
+                public class AgentsModule : IModule { }
+
+                public class AgentsDbContext : DbContext
+                {
+                    public AgentsDbContext(
+                        DbContextOptions<AgentsDbContext> options,
+                        IOptions<DatabaseOptions> dbOptions
+                    ) : base(options) { }
+
+                    public DbSet<AgentSession> Sessions => Set<AgentSession>();
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
+            "SimpleModule.Agents.Module",
+            source
+        );
+        var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
+
+        diagnostics.Should().Contain(d => d.Id == "SM0055");
+        var diag = diagnostics.First(d => d.Id == "SM0055");
+        var message = diag.GetMessage(System.Globalization.CultureInfo.InvariantCulture);
+        message.Should().Contain("SimpleModule.Agents.Contracts");
+        message.Should().NotContain("SimpleModule.Agents.Module.Contracts");
+    }
+
+    [Fact]
+    public void SM0055_NonSimpleModuleAssembly_NoDiagnostic()
+    {
+        // External entities (e.g. OpenIddict) live outside SimpleModule.* and
+        // cannot be moved by the author, so we don't flag them.
+        var source = """
+            using SimpleModule.Core;
+            using Microsoft.EntityFrameworkCore;
+            using Microsoft.Extensions.Options;
+            using SimpleModule.Database;
+
+            namespace TestApp.Widgets
+            {
+                public class Widget { public int Id { get; set; } }
+
+                [Module("Widgets")]
+                public class WidgetsModule : IModule { }
+
+                public class WidgetsDbContext : DbContext
+                {
+                    public WidgetsDbContext(
+                        DbContextOptions<WidgetsDbContext> options,
+                        IOptions<DatabaseOptions> dbOptions
+                    ) : base(options) { }
+
+                    public DbSet<Widget> Widgets => Set<Widget>();
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHelper.CreateEfCoreCompilationWithAssemblyName(
+            "Contoso.Widgets",
+            source
+        );
+        var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
+
+        diagnostics.Should().NotContain(d => d.Id == "SM0055");
+    }
+
+    #endregion
 }

--- a/tests/SimpleModule.Generator.Tests/Helpers/GeneratorTestHelper.cs
+++ b/tests/SimpleModule.Generator.Tests/Helpers/GeneratorTestHelper.cs
@@ -85,15 +85,6 @@ public static class GeneratorTestHelper
         );
     }
 
-    public static CSharpCompilation CreateCompilationWithAssemblyName(
-        string assemblyName,
-        params string[] sources
-    )
-    {
-        var compilation = CreateCompilation(sources);
-        return compilation.WithAssemblyName(assemblyName);
-    }
-
     public static CSharpCompilation CreateCompilationWithEfCore(params string[] sources)
     {
         var compilation = CreateCompilation(sources);
@@ -142,14 +133,6 @@ public static class GeneratorTestHelper
             efCoreReferences.Add(MetadataReference.CreateFromFile(identityStoresPath));
 
         return compilation.AddReferences(efCoreReferences);
-    }
-
-    public static CSharpCompilation CreateEfCoreCompilationWithAssemblyName(
-        string assemblyName,
-        params string[] sources
-    )
-    {
-        return CreateCompilationWithEfCore(sources).WithAssemblyName(assemblyName);
     }
 
     public static GeneratorDriverRunResult RunGenerator(CSharpCompilation compilation)

--- a/tests/SimpleModule.Generator.Tests/Helpers/GeneratorTestHelper.cs
+++ b/tests/SimpleModule.Generator.Tests/Helpers/GeneratorTestHelper.cs
@@ -85,6 +85,15 @@ public static class GeneratorTestHelper
         );
     }
 
+    public static CSharpCompilation CreateCompilationWithAssemblyName(
+        string assemblyName,
+        params string[] sources
+    )
+    {
+        var compilation = CreateCompilation(sources);
+        return compilation.WithAssemblyName(assemblyName);
+    }
+
     public static CSharpCompilation CreateCompilationWithEfCore(params string[] sources)
     {
         var compilation = CreateCompilation(sources);
@@ -133,6 +142,14 @@ public static class GeneratorTestHelper
             efCoreReferences.Add(MetadataReference.CreateFromFile(identityStoresPath));
 
         return compilation.AddReferences(efCoreReferences);
+    }
+
+    public static CSharpCompilation CreateEfCoreCompilationWithAssemblyName(
+        string assemblyName,
+        params string[] sources
+    )
+    {
+        return CreateCompilationWithEfCore(sources).WithAssemblyName(assemblyName);
     }
 
     public static GeneratorDriverRunResult RunGenerator(CSharpCompilation compilation)


### PR DESCRIPTION
Replace ad-hoc timestamp/audit fields with inheritance from the Core
base entities (Entity<T>, AuditableEntity<T>, FullAuditableEntity<T>).
This brings automatic CreatedAt/UpdatedAt tracking, concurrency stamps,
versioning, and soft-delete semantics to modules that were previously
rolling their own or missing them entirely.

Changes:
- BackgroundJobs: JobProgress and JobQueueEntryEntity now extend
  Entity<Guid>.
- Settings: SettingEntity and PublicMenuItemEntity now extend
  Entity<int>; services drop manual UpdatedAt assignments.
- Chat: Conversation extends Entity<ConversationId>, ChatMessage
  extends Entity<ChatMessageId>; UpdatedAt is maintained on
  append/rename.
- FileStorage: StoredFile extends Entity<FileStorageId>.
- Email: EmailMessage and EmailTemplate extend Entity<TId> /
  AuditableEntity<TId>; DateTime fields migrated to DateTimeOffset
  and query filters updated accordingly.
- Orders: Order extends AuditableEntity<OrderId> with DateTimeOffset
  timestamps; seed service updated to emit DateTimeOffset values.
- PageBuilder: Page uses FullAuditableEntity<PageId> (soft delete via
  IsDeleted/DeletedAt), PageTemplate uses Entity<PageTemplateId>,
  PageSummary DTO switched to DateTimeOffset; permanent-delete path
  uses ExecuteDeleteAsync to bypass the soft-delete interceptor.
- Products: Product extends Entity<ProductId> with deterministic
  seed timestamps so EF Core migrations remain stable.
- RateLimiting: RateLimitRule extends Entity<RateLimitRuleId>.
- Agents: AgentSession gains inherited audit fields via Entity<string>.

SQLite support: modules that now carry DateTimeOffset properties and
run queries against SQLite (tests, local dev) apply
DateTimeOffsetToBinaryConverter conditionally so ORDER BY and range
filters translate. A new DatabaseOptionsExtensions.DetectProvider()
helper centralizes the provider detection for this decision, falling
back gracefully when only a module-specific connection string is
configured.

A single EF Core migration (UseBaseEntities) adds the new columns
(ConcurrencyStamp, CreatedAt/UpdatedAt, soft-delete fields, version)
and adjusts the existing DateTime columns where modules moved to
DateTimeOffset.