### PR TITLE
feat(cli): add version/list commands, shared tree renderer, async install

### DIFF
--- a/cli/SimpleModule.Cli/Commands/Doctor/DoctorCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Doctor/DoctorCommand.cs
@@ -18,8 +18,7 @@ public sealed class DoctorCommand : Command<DoctorSettings>
             return 1;
         }
 
-        AnsiConsole.MarkupLine("[blue]Running project health checks...[/]");
-        AnsiConsole.MarkupLine("");
+        AnsiConsole.Write(new Rule("[blue]Project health check[/]").LeftJustified());
 
         IDoctorCheck[] checks =
         [
@@ -43,25 +42,49 @@ public sealed class DoctorCommand : Command<DoctorSettings>
             results.AddRange(check.Run(solution));
         }
 
-        // Auto-fix if requested
+        var fixedCount = 0;
         if (settings.Fix)
         {
+            var beforeFail = results.Count(r => r.Status == CheckStatus.Fail);
             AutoFix(solution, results);
-            // Re-run checks after fix
             results.Clear();
             foreach (var check in checks)
             {
                 results.AddRange(check.Run(solution));
             }
+            fixedCount = beforeFail - results.Count(r => r.Status == CheckStatus.Fail);
         }
 
-        // Display results table
-        var table = new Table();
+        RenderResults(results);
+
+        var failCount = results.Count(r => r.Status == CheckStatus.Fail);
+        var warnCount = results.Count(r => r.Status == CheckStatus.Warning);
+        var passCount = results.Count(r => r.Status == CheckStatus.Pass);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(
+            BuildSummaryPanel(passCount, warnCount, failCount, fixedCount, settings.Fix)
+        );
+
+        return failCount > 0 ? 1 : 0;
+    }
+
+    private static void RenderResults(IReadOnlyList<CheckResult> results)
+    {
+        // Failures first so they're the first thing the user sees, then warnings,
+        // then passes. Preserve discovery order within each status bucket.
+        var ordered = results
+            .Select((r, i) => (Result: r, Index: i))
+            .OrderBy(x => StatusPriority(x.Result.Status))
+            .ThenBy(x => x.Index)
+            .Select(x => x.Result);
+
+        var table = new Table().RoundedBorder();
         table.AddColumn("Status");
         table.AddColumn("Check");
         table.AddColumn("Details");
 
-        foreach (var result in results)
+        foreach (var result in ordered)
         {
             var statusMarkup = result.Status switch
             {
@@ -74,38 +97,67 @@ public sealed class DoctorCommand : Command<DoctorSettings>
         }
 
         AnsiConsole.Write(table);
+    }
 
-        var failCount = results.Count(r => r.Status == CheckStatus.Fail);
-        var warnCount = results.Count(r => r.Status == CheckStatus.Warning);
-
-        AnsiConsole.MarkupLine("");
-        if (failCount > 0)
+    private static int StatusPriority(CheckStatus status) =>
+        status switch
         {
-            AnsiConsole.MarkupLine(
-                $"[red]{failCount} failure(s)[/], [yellow]{warnCount} warning(s)[/]"
-            );
-            if (!settings.Fix)
-            {
-                AnsiConsole.MarkupLine(
-                    "[dim]Run with --fix to auto-fix missing slnx entries, project references, Pages registry entries, and npm workspace globs.[/]"
-                );
-            }
+            CheckStatus.Fail => 0,
+            CheckStatus.Warning => 1,
+            CheckStatus.Pass => 2,
+            _ => 3,
+        };
 
-            return 1;
+    private static Panel BuildSummaryPanel(
+        int passCount,
+        int warnCount,
+        int failCount,
+        int fixedCount,
+        bool fixRequested
+    )
+    {
+        var total = passCount + warnCount + failCount;
+        var lines = new List<string>
+        {
+            $"[green]{passCount} pass[/]  ·  [yellow]{warnCount} warn[/]  ·  [red]{failCount} fail[/]  [dim](of {total})[/]",
+        };
+
+        if (fixRequested && fixedCount > 0)
+        {
+            lines.Add($"[green]✓[/] Auto-fixed [green]{fixedCount}[/] issue(s)");
         }
 
-        if (warnCount > 0)
+        if (failCount > 0)
         {
-            AnsiConsole.MarkupLine(
-                $"[green]All checks passed[/] with [yellow]{warnCount} warning(s)[/]"
+            lines.Add(
+                fixRequested
+                    ? "[red]Some failures could not be auto-fixed.[/] See table above for details."
+                    : "[dim]Run with --fix to auto-fix slnx entries, project references, Pages registry, and npm workspace globs.[/]"
             );
+        }
+        else if (warnCount > 0)
+        {
+            lines.Add("[green]All failures resolved.[/] Warnings are non-blocking.");
         }
         else
         {
-            AnsiConsole.MarkupLine("[green]All checks passed![/]");
+            lines.Add("[green]All checks passed.[/]");
         }
 
-        return 0;
+        var color =
+            failCount > 0 ? Color.Red
+            : warnCount > 0 ? Color.Yellow
+            : Color.Green;
+        var header =
+            failCount > 0 ? "Failing"
+            : warnCount > 0 ? "Passing with warnings"
+            : "Healthy";
+
+        return new Panel(string.Join("\n", lines))
+            .Header($"[bold]{header}[/]")
+            .Border(BoxBorder.Rounded)
+            .BorderColor(color)
+            .Expand();
     }
 
     private static void AutoFix(SolutionContext solution, List<CheckResult> results)

--- a/cli/SimpleModule.Cli/Commands/Install/InstallCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Install/InstallCommand.cs
@@ -5,9 +5,9 @@ using Spectre.Console.Cli;
 
 namespace SimpleModule.Cli.Commands.Install;
 
-public sealed class InstallCommand : Command<InstallSettings>
+public sealed class InstallCommand : AsyncCommand<InstallSettings>
 {
-    public override int Execute(CommandContext context, InstallSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, InstallSettings settings)
     {
         var solution = SolutionContext.Discover();
         if (solution is null)
@@ -53,9 +53,9 @@ public sealed class InstallCommand : Command<InstallSettings>
         process.Start();
         var outputTask = process.StandardOutput.ReadToEndAsync();
         var errorTask = process.StandardError.ReadToEndAsync();
-        process.WaitForExit();
-        var output = outputTask.GetAwaiter().GetResult();
-        var error = errorTask.GetAwaiter().GetResult();
+        await process.WaitForExitAsync().ConfigureAwait(false);
+        var output = await outputTask.ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
 
         if (process.ExitCode != 0)
         {

--- a/cli/SimpleModule.Cli/Commands/List/ListCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/List/ListCommand.cs
@@ -1,0 +1,119 @@
+using System.Text.RegularExpressions;
+using SimpleModule.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.List;
+
+public sealed partial class ListCommand : Command<ListSettings>
+{
+    [GeneratedRegex(
+        """RoutePrefix\s*=\s*(?:"(?<literal>[^"]*)"|(?<constref>[A-Za-z_][\w\.]*))""",
+        RegexOptions.Singleline,
+        matchTimeoutMilliseconds: 1000
+    )]
+    private static partial Regex RoutePrefixRegex();
+
+    [GeneratedRegex(
+        """public\s+const\s+string\s+RoutePrefix\s*=\s*"(?<value>[^"]*)"\s*;""",
+        RegexOptions.Singleline,
+        matchTimeoutMilliseconds: 1000
+    )]
+    private static partial Regex ConstantsRoutePrefixRegex();
+
+    public override int Execute(CommandContext context, ListSettings settings)
+    {
+        var solution = SolutionContext.Discover();
+        if (solution is null)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]No .slnx file found. Run this command from inside a SimpleModule project.[/]"
+            );
+            return 1;
+        }
+
+        if (solution.ExistingModules.Count == 0)
+        {
+            AnsiConsole.MarkupLine(
+                "[yellow]No modules found.[/] Create one with [green]sm new module <Name>[/]."
+            );
+            return 0;
+        }
+
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Module");
+        table.AddColumn("Route prefix");
+        table.AddColumn(new TableColumn("Endpoints").RightAligned());
+
+        foreach (var module in solution.ExistingModules)
+        {
+            var routePrefix = ReadRoutePrefix(solution, module);
+            var endpointCount = CountEndpoints(solution, module);
+
+            table.AddRow(
+                $"[green]{Markup.Escape(module)}[/]",
+                Markup.Escape(routePrefix ?? "—"),
+                endpointCount.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            );
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine(
+            $"\n[dim]{solution.ExistingModules.Count} module(s) in {Markup.Escape(solution.RootPath)}[/]"
+        );
+        return 0;
+    }
+
+    private static string? ReadRoutePrefix(SolutionContext solution, string module)
+    {
+        var moduleClassPath = Path.Combine(
+            solution.GetModuleProjectPath(module),
+            $"{module}Module.cs"
+        );
+        if (!File.Exists(moduleClassPath))
+        {
+            return null;
+        }
+
+        var content = File.ReadAllText(moduleClassPath);
+        var match = RoutePrefixRegex().Match(content);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        if (match.Groups["literal"].Success)
+        {
+            return match.Groups["literal"].Value;
+        }
+
+        // RoutePrefix = ModuleConstants.RoutePrefix — try to resolve from Constants.cs
+        var constantsPath = Path.Combine(
+            solution.GetModuleProjectPath(module),
+            $"{module}Constants.cs"
+        );
+        if (File.Exists(constantsPath))
+        {
+            var constantsMatch = ConstantsRoutePrefixRegex().Match(File.ReadAllText(constantsPath));
+            if (constantsMatch.Success)
+            {
+                return constantsMatch.Groups["value"].Value;
+            }
+        }
+
+        return match.Groups["constref"].Value;
+    }
+
+    private static int CountEndpoints(SolutionContext solution, string module)
+    {
+        var endpointsDir = Path.Combine(solution.GetModuleProjectPath(module), "Endpoints");
+        if (!Directory.Exists(endpointsDir))
+        {
+            return 0;
+        }
+
+        return Directory
+            .EnumerateFiles(endpointsDir, "*Endpoint.cs", SearchOption.AllDirectories)
+            .Count();
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/List/ListSettings.cs
+++ b/cli/SimpleModule.Cli/Commands/List/ListSettings.cs
@@ -1,0 +1,5 @@
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.List;
+
+public sealed class ListSettings : CommandSettings;

--- a/cli/SimpleModule.Cli/Commands/New/NewFeatureCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewFeatureCommand.cs
@@ -61,7 +61,7 @@ public sealed class NewFeatureCommand : Command<NewFeatureSettings>
 
         if (settings.DryRun)
         {
-            RenderDryRunTree(ops);
+            FileTreeRenderer.Render("Would create/modify", ops, isDryRun: true);
             return 0;
         }
 
@@ -103,20 +103,5 @@ public sealed class NewFeatureCommand : Command<NewFeatureSettings>
     {
         File.WriteAllText(path, content);
         AnsiConsole.MarkupLine($"[green]  + {Markup.Escape(Path.GetFileName(path))}[/]");
-    }
-
-    private static void RenderDryRunTree(List<(string Path, FileAction Action)> ops)
-    {
-        AnsiConsole.MarkupLine("[dim]Dry run — no files written[/]\n");
-        var tree = new Tree("[dim]Would create/modify:[/]");
-        foreach (var (path, action) in ops)
-        {
-            var label =
-                action == FileAction.Modify
-                    ? $"[yellow]{Markup.Escape(Path.GetFileName(path))}[/] [dim](modify)[/]"
-                    : $"[green]{Markup.Escape(Path.GetFileName(path))}[/] [dim](create)[/]";
-            tree.AddNode(label);
-        }
-        AnsiConsole.Write(tree);
     }
 }

--- a/cli/SimpleModule.Cli/Commands/New/NewModuleCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewModuleCommand.cs
@@ -59,7 +59,7 @@ public sealed class NewModuleCommand : Command<NewModuleSettings>
 
         if (settings.DryRun)
         {
-            RenderDryRunTree(moduleName, ops);
+            FileTreeRenderer.Render(moduleName, ops, isDryRun: true);
             return 0;
         }
 
@@ -147,7 +147,7 @@ public sealed class NewModuleCommand : Command<NewModuleSettings>
                 }
             );
 
-        RenderCreatedTree(moduleName, ops);
+        FileTreeRenderer.Render(moduleName, ops);
 
         AnsiConsole.MarkupLine($"\n[green]Module '{Markup.Escape(moduleName)}' created![/]");
         AnsiConsole.MarkupLine("[dim]Next steps:[/]");
@@ -156,41 +156,5 @@ public sealed class NewModuleCommand : Command<NewModuleSettings>
         );
         AnsiConsole.MarkupLine("[dim]  dotnet build[/]");
         return 0;
-    }
-
-    private static void RenderDryRunTree(
-        string moduleName,
-        List<(string Path, FileAction Action)> ops
-    )
-    {
-        AnsiConsole.MarkupLine("[dim]Dry run — no files written[/]\n");
-        var tree = new Tree($"[blue]{Markup.Escape(moduleName)}[/]");
-        foreach (var (path, action) in ops)
-        {
-            var label =
-                action == FileAction.Modify
-                    ? $"[yellow]{Markup.Escape(Path.GetFileName(path))}[/] [dim](modify)[/]"
-                    : $"[green]{Markup.Escape(Path.GetFileName(path))}[/] [dim](create)[/]";
-            tree.AddNode(label);
-        }
-        AnsiConsole.Write(tree);
-    }
-
-    private static void RenderCreatedTree(
-        string moduleName,
-        List<(string Path, FileAction Action)> ops
-    )
-    {
-        AnsiConsole.MarkupLine("");
-        var tree = new Tree($"[blue]{Markup.Escape(moduleName)}[/]");
-        foreach (var (path, action) in ops)
-        {
-            var label =
-                action == FileAction.Modify
-                    ? $"[yellow]{Markup.Escape(Path.GetFileName(path))}[/] [dim](modified)[/]"
-                    : $"[green]{Markup.Escape(Path.GetFileName(path))}[/]";
-            tree.AddNode(label);
-        }
-        AnsiConsole.Write(tree);
     }
 }

--- a/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
@@ -35,7 +35,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
         if (settings.DryRun)
         {
             var ops = PlanFiles(projectName, rootDir);
-            RenderDryRunTree(projectName, ops, rootDir);
+            FileTreeRenderer.Render($"{projectName}/", ops, rootDir, isDryRun: true);
             return 0;
         }
 
@@ -52,7 +52,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
             );
 
         var allOps = PlanFiles(projectName, rootDir);
-        RenderFileTree(projectName, allOps, rootDir);
+        FileTreeRenderer.Render($"{projectName}/", allOps, rootDir);
 
         AnsiConsole.MarkupLine($"\n[green]Project '{Markup.Escape(projectName)}' created![/]");
         AnsiConsole.MarkupLine("[dim]Next steps:[/]");
@@ -357,16 +357,6 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
                 </Folder>
             </Solution>
             """;
-    }
-
-    private static void RenderDryRunTree(
-        string projectName,
-        List<(string Path, FileAction Action)> ops,
-        string rootDir
-    )
-    {
-        AnsiConsole.MarkupLine("[dim]Dry run — no files written[/]\n");
-        RenderFileTree(projectName, ops, rootDir, isDryRun: true);
     }
 
     private static string StarterModuleClass(string moduleName, string singularName) =>
@@ -727,28 +717,4 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
             .min-w-\[160px\] { min-width: 160px; }
             .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1); }
             """;
-
-    private static void RenderFileTree(
-        string projectName,
-        List<(string Path, FileAction Action)> ops,
-        string rootDir,
-        bool isDryRun = false
-    )
-    {
-        AnsiConsole.MarkupLine("");
-        var tree = new Tree($"[blue]{Markup.Escape(projectName)}/[/]");
-
-        foreach (var (path, action) in ops)
-        {
-            var relativePath = Path.GetRelativePath(rootDir, path).Replace('\\', '/');
-            var label =
-                action == FileAction.Modify
-                    ? $"[yellow]{Markup.Escape(relativePath)}[/] [dim]({(isDryRun ? "modify" : "modified")})[/]"
-                : isDryRun ? $"[green]{Markup.Escape(relativePath)}[/] [dim](create)[/]"
-                : $"[green]{Markup.Escape(relativePath)}[/]";
-            tree.AddNode(label);
-        }
-
-        AnsiConsole.Write(tree);
-    }
 }

--- a/cli/SimpleModule.Cli/Commands/Version/VersionCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Version/VersionCommand.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Version;
+
+public sealed class VersionCommand : Command
+{
+    public override int Execute(CommandContext context)
+    {
+        AnsiConsole.MarkupLine($"[green]sm[/] [dim]v[/]{ResolveVersion()}");
+        return 0;
+    }
+
+    internal static string ResolveVersion()
+    {
+        var assembly = typeof(VersionCommand).Assembly;
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            // Strip the "+<commit-sha>" suffix MSBuild appends to SourceLink builds.
+            var plus = informational.IndexOf('+', StringComparison.Ordinal);
+            return plus < 0 ? informational : informational[..plus];
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "0.0.0";
+    }
+}

--- a/cli/SimpleModule.Cli/Infrastructure/FileTreeRenderer.cs
+++ b/cli/SimpleModule.Cli/Infrastructure/FileTreeRenderer.cs
@@ -1,0 +1,48 @@
+using Spectre.Console;
+
+namespace SimpleModule.Cli.Infrastructure;
+
+public static class FileTreeRenderer
+{
+    public static void Render(
+        string rootLabel,
+        IEnumerable<(string Path, FileAction Action)> ops,
+        string? rootDir = null,
+        bool isDryRun = false
+    )
+    {
+        if (isDryRun)
+        {
+            AnsiConsole.MarkupLine("[dim]Dry run — no files written[/]\n");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("");
+        }
+
+        var tree = new Tree($"[blue]{Markup.Escape(rootLabel)}[/]");
+        foreach (var (path, action) in ops)
+        {
+            tree.AddNode(FormatNode(path, action, rootDir, isDryRun));
+        }
+        AnsiConsole.Write(tree);
+    }
+
+    internal static string FormatNode(
+        string path,
+        FileAction action,
+        string? rootDir,
+        bool isDryRun
+    )
+    {
+        var display = rootDir is null
+            ? Path.GetFileName(path)
+            : Path.GetRelativePath(rootDir, path).Replace('\\', '/');
+        var escaped = Markup.Escape(display);
+
+        return action == FileAction.Modify
+                ? $"[yellow]{escaped}[/] [dim]({(isDryRun ? "modify" : "modified")})[/]"
+            : isDryRun ? $"[green]{escaped}[/] [dim](create)[/]"
+            : $"[green]{escaped}[/]";
+    }
+}

--- a/cli/SimpleModule.Cli/Program.cs
+++ b/cli/SimpleModule.Cli/Program.cs
@@ -1,7 +1,9 @@
-﻿using SimpleModule.Cli.Commands.Dev;
+using SimpleModule.Cli.Commands.Dev;
 using SimpleModule.Cli.Commands.Doctor;
 using SimpleModule.Cli.Commands.Install;
+using SimpleModule.Cli.Commands.List;
 using SimpleModule.Cli.Commands.New;
+using SimpleModule.Cli.Commands.Version;
 using Spectre.Console.Cli;
 
 var app = new CommandApp();
@@ -9,6 +11,14 @@ var app = new CommandApp();
 app.Configure(config =>
 {
     config.SetApplicationName("sm");
+    config.SetApplicationVersion(VersionCommand.ResolveVersion());
+
+    config.AddExample("new", "project", "MyApp");
+    config.AddExample("new", "module", "Products");
+    config.AddExample("new", "feature", "CreateProduct", "--module", "Products");
+    config.AddExample("dev");
+    config.AddExample("list");
+    config.AddExample("doctor", "--fix");
 
     config.AddBranch(
         "new",
@@ -17,13 +27,16 @@ app.Configure(config =>
             newBranch.SetDescription("Create new projects, modules, or features");
             newBranch
                 .AddCommand<NewProjectCommand>("project")
-                .WithDescription("Scaffold a new SimpleModule solution");
+                .WithDescription("Scaffold a new SimpleModule solution")
+                .WithExample("new", "project", "MyApp");
             newBranch
                 .AddCommand<NewModuleCommand>("module")
-                .WithDescription("Scaffold a new module");
+                .WithDescription("Scaffold a new module")
+                .WithExample("new", "module", "Products");
             newBranch
                 .AddCommand<NewFeatureCommand>("feature")
-                .WithDescription("Add a feature to an existing module");
+                .WithDescription("Add a feature to an existing module")
+                .WithExample("new", "feature", "CreateProduct", "--module", "Products");
             newBranch
                 .AddCommand<NewAgentCommand>("agent")
                 .WithDescription("Add an AI agent to an existing module");
@@ -37,12 +50,18 @@ app.Configure(config =>
         );
 
     config
+        .AddCommand<ListCommand>("list")
+        .WithDescription("List modules in the current project with their route prefixes");
+
+    config
         .AddCommand<InstallCommand>("install")
         .WithDescription("Install a SimpleModule package from NuGet");
 
     config
         .AddCommand<DoctorCommand>("doctor")
         .WithDescription("Validate project structure and conventions");
+
+    config.AddCommand<VersionCommand>("version").WithDescription("Print the sm CLI version");
 });
 
 return app.Run(args);

--- a/tests/SimpleModule.Cli.Tests/DoctorCommandTests.cs
+++ b/tests/SimpleModule.Cli.Tests/DoctorCommandTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using FluentAssertions;
+using SimpleModule.Cli.Commands.Doctor;
+using SimpleModule.Cli.Commands.Doctor.Checks;
+
+namespace SimpleModule.Cli.Tests;
+
+public sealed class DoctorCommandTests
+{
+    private static int InvokeStatusPriority(CheckStatus status)
+    {
+        var method = typeof(DoctorCommand).GetMethod(
+            "StatusPriority",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        return (int)method.Invoke(null, [status])!;
+    }
+
+    [Fact]
+    public void StatusPriority_OrdersFailBeforeWarnBeforePass()
+    {
+        var fail = InvokeStatusPriority(CheckStatus.Fail);
+        var warn = InvokeStatusPriority(CheckStatus.Warning);
+        var pass = InvokeStatusPriority(CheckStatus.Pass);
+
+        fail.Should().BeLessThan(warn);
+        warn.Should().BeLessThan(pass);
+    }
+}

--- a/tests/SimpleModule.Cli.Tests/FileTreeRendererTests.cs
+++ b/tests/SimpleModule.Cli.Tests/FileTreeRendererTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using FluentAssertions;
+using SimpleModule.Cli.Infrastructure;
+
+namespace SimpleModule.Cli.Tests;
+
+public sealed class FileTreeRendererTests
+{
+    private static string InvokeFormatNode(
+        string path,
+        FileAction action,
+        string? rootDir,
+        bool isDryRun
+    )
+    {
+        var method = typeof(FileTreeRenderer).GetMethod(
+            "FormatNode",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        return (string)method.Invoke(null, [path, action, rootDir, isDryRun])!;
+    }
+
+    [Fact]
+    public void FormatNode_Create_DryRun_RendersGreenCreateLabel()
+    {
+        var result = InvokeFormatNode(
+            "/x/Foo.cs",
+            FileAction.Create,
+            rootDir: null,
+            isDryRun: true
+        );
+
+        result.Should().Contain("Foo.cs").And.Contain("(create)").And.Contain("[green]");
+    }
+
+    [Fact]
+    public void FormatNode_Create_NonDryRun_RendersGreenWithoutActionTag()
+    {
+        var result = InvokeFormatNode(
+            "/x/Foo.cs",
+            FileAction.Create,
+            rootDir: null,
+            isDryRun: false
+        );
+
+        result.Should().Contain("Foo.cs").And.Contain("[green]");
+        result.Should().NotContain("(create)").And.NotContain("(modify)");
+    }
+
+    [Fact]
+    public void FormatNode_Modify_DryRun_UsesModifyWord()
+    {
+        var result = InvokeFormatNode(
+            "/x/Existing.cs",
+            FileAction.Modify,
+            rootDir: null,
+            isDryRun: true
+        );
+
+        result.Should().Contain("(modify)").And.Contain("[yellow]");
+    }
+
+    [Fact]
+    public void FormatNode_Modify_NonDryRun_UsesModifiedWord()
+    {
+        var result = InvokeFormatNode(
+            "/x/Existing.cs",
+            FileAction.Modify,
+            rootDir: null,
+            isDryRun: false
+        );
+
+        result.Should().Contain("(modified)").And.Contain("[yellow]");
+    }
+
+    [Fact]
+    public void FormatNode_NoRootDir_ShowsFileNameOnly()
+    {
+        var nestedPath = Path.Combine("some", "deeply", "nested", "Foo.cs");
+
+        var result = InvokeFormatNode(nestedPath, FileAction.Create, rootDir: null, isDryRun: true);
+
+        result.Should().Contain("Foo.cs");
+        result.Should().NotContain("nested").And.NotContain("deeply");
+    }
+
+    [Fact]
+    public void FormatNode_WithRootDir_ShowsRelativePathWithForwardSlashes()
+    {
+        var rootDir = Path.Combine("proj", "root");
+        var filePath = Path.Combine(rootDir, "src", "modules", "Foo.cs");
+
+        var result = InvokeFormatNode(filePath, FileAction.Create, rootDir, isDryRun: true);
+
+        result.Should().Contain("src/modules/Foo.cs");
+        result.Should().NotContain("\\");
+    }
+}

--- a/tests/SimpleModule.Cli.Tests/ListCommandTests.cs
+++ b/tests/SimpleModule.Cli.Tests/ListCommandTests.cs
@@ -1,0 +1,187 @@
+using System.Reflection;
+using FluentAssertions;
+using SimpleModule.Cli.Commands.List;
+using SimpleModule.Cli.Infrastructure;
+
+namespace SimpleModule.Cli.Tests;
+
+public sealed class ListCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ListCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"sm-list-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        File.WriteAllText(Path.Combine(_tempDir, "Test.slnx"), "<Solution />");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private void WriteModuleClass(string moduleName, string content)
+    {
+        var dir = Path.Combine(_tempDir, "src", "modules", moduleName, "src", moduleName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{moduleName}Module.cs"), content);
+    }
+
+    private void WriteConstantsClass(string moduleName, string routePrefix)
+    {
+        var dir = Path.Combine(_tempDir, "src", "modules", moduleName, "src", moduleName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(
+            Path.Combine(dir, $"{moduleName}Constants.cs"),
+            $$"""
+            public static class {{moduleName}}Constants
+            {
+                public const string RoutePrefix = "{{routePrefix}}";
+            }
+            """
+        );
+    }
+
+    private void WriteEndpointFile(string moduleName, string endpointName)
+    {
+        var dir = Path.Combine(
+            _tempDir,
+            "src",
+            "modules",
+            moduleName,
+            "src",
+            moduleName,
+            "Endpoints",
+            moduleName
+        );
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{endpointName}Endpoint.cs"), "// endpoint");
+    }
+
+    private static string? InvokeReadRoutePrefix(SolutionContext solution, string module)
+    {
+        var method = typeof(ListCommand).GetMethod(
+            "ReadRoutePrefix",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        return (string?)method.Invoke(null, [solution, module]);
+    }
+
+    private static int InvokeCountEndpoints(SolutionContext solution, string module)
+    {
+        var method = typeof(ListCommand).GetMethod(
+            "CountEndpoints",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        return (int)method.Invoke(null, [solution, module])!;
+    }
+
+    [Fact]
+    public void ReadRoutePrefix_ReturnsLiteral_WhenModuleAttributeHasStringLiteral()
+    {
+        WriteModuleClass(
+            "Products",
+            """
+            [Module("Products", RoutePrefix = "products")]
+            public class ProductsModule : IModule { }
+            """
+        );
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeReadRoutePrefix(solution, "Products").Should().Be("products");
+    }
+
+    [Fact]
+    public void ReadRoutePrefix_ResolvesConstantFromConstantsFile()
+    {
+        WriteModuleClass(
+            "Orders",
+            """
+            [Module("Orders", RoutePrefix = OrdersConstants.RoutePrefix)]
+            public class OrdersModule : IModule { }
+            """
+        );
+        WriteConstantsClass("Orders", "orders");
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeReadRoutePrefix(solution, "Orders").Should().Be("orders");
+    }
+
+    [Fact]
+    public void ReadRoutePrefix_ReturnsNull_WhenModuleFileMissing()
+    {
+        Directory.CreateDirectory(
+            Path.Combine(_tempDir, "src", "modules", "Ghost", "src", "Ghost")
+        );
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeReadRoutePrefix(solution, "Ghost").Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadRoutePrefix_ReturnsNull_WhenAttributeMissing()
+    {
+        WriteModuleClass(
+            "Naked",
+            """
+            public class NakedModule : IModule { }
+            """
+        );
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeReadRoutePrefix(solution, "Naked").Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadRoutePrefix_ReturnsConstantName_WhenConstantsFileMissing()
+    {
+        WriteModuleClass(
+            "Invoices",
+            """
+            [Module("Invoices", RoutePrefix = InvoicesConstants.RoutePrefix)]
+            public class InvoicesModule : IModule { }
+            """
+        );
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeReadRoutePrefix(solution, "Invoices").Should().Be("InvoicesConstants.RoutePrefix");
+    }
+
+    [Fact]
+    public void CountEndpoints_CountsEndpointSuffixedFilesRecursively()
+    {
+        WriteEndpointFile("Products", "GetAll");
+        WriteEndpointFile("Products", "Create");
+        WriteEndpointFile("Products", "Update");
+
+        // A non-endpoint file that should NOT be counted
+        var endpointsDir = Path.Combine(
+            _tempDir,
+            "src",
+            "modules",
+            "Products",
+            "src",
+            "Products",
+            "Endpoints",
+            "Products"
+        );
+        File.WriteAllText(Path.Combine(endpointsDir, "Helpers.cs"), "// not an endpoint");
+
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeCountEndpoints(solution, "Products").Should().Be(3);
+    }
+
+    [Fact]
+    public void CountEndpoints_ReturnsZero_WhenEndpointsDirMissing()
+    {
+        Directory.CreateDirectory(
+            Path.Combine(_tempDir, "src", "modules", "Empty", "src", "Empty")
+        );
+        var solution = SolutionContext.Discover(_tempDir)!;
+
+        InvokeCountEndpoints(solution, "Empty").Should().Be(0);
+    }
+}

--- a/tests/SimpleModule.Cli.Tests/VersionCommandTests.cs
+++ b/tests/SimpleModule.Cli.Tests/VersionCommandTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using FluentAssertions;
+using SimpleModule.Cli.Commands.Version;
+
+namespace SimpleModule.Cli.Tests;
+
+public sealed class VersionCommandTests
+{
+    private static string InvokeResolveVersion()
+    {
+        var method = typeof(VersionCommand).GetMethod(
+            "ResolveVersion",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        return (string)method.Invoke(null, null)!;
+    }
+
+    [Fact]
+    public void ResolveVersion_ReturnsNonEmptyString()
+    {
+        InvokeResolveVersion().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ResolveVersion_StripsBuildMetadataSuffix()
+    {
+        InvokeResolveVersion().Should().NotContain("+");
+    }
+}


### PR DESCRIPTION
## Summary

Targeted CLI improvements focused on discoverability, DRY, and correctness.

**New commands**
- `sm version` (and `sm --version`) — prints the CLI version, backed by `AssemblyInformationalVersion`.
- `sm list` — lists modules in the current project with their route prefixes and endpoint counts. Resolves `RoutePrefix` from both string literals (`RoutePrefix = "products"`) and constant references (`RoutePrefix = OrdersConstants.RoutePrefix`).

**Refactors**
- Extract `FileTreeRenderer` in `Infrastructure/`. Replaces three near-identical tree renderers in `NewProjectCommand`, `NewModuleCommand`, `NewFeatureCommand` (~80 lines of duplication). Supports both relative-path mode (new project) and filename-only mode (new module / new feature), plus dry-run and created variants.

**Fixes**
- `InstallCommand` now inherits `AsyncCommand` and uses `WaitForExitAsync` + `await` instead of blocking with `GetAwaiter().GetResult()` on the process-output tasks.

**UX**
- Root `sm --help` now includes concrete examples (`sm new project MyApp`, `sm dev`, `sm list`, `sm doctor --fix`, etc.).
- `new project/module/feature` commands get targeted `--help` examples via `WithExample`.

## Test plan

- [x] `dotnet build` — full solution, 0 warnings / 0 errors
- [x] CLI tests: **127 passed, 0 failed** (added `VersionCommandTests`, `ListCommandTests`, `FileTreeRendererTests`)
- [x] Manual smoke — `sm --version` prints `1.0.0`, `sm --help` shows examples
- [x] Manual smoke — `sm list` on a simulated project renders a rounded table with route prefixes and endpoint counts for both literal and constant-reference prefixes
- [x] Manual smoke — `sm new project Acme --dry-run` renders the expected tree via the shared renderer

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLdR9ZVVEskmoL4D4kVZyn)_