### PR TITLE
docs: sync site against recent framework changes

### DIFF
--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -127,13 +127,13 @@ Dependencies flow one way: **implementation --> contracts --> core**. Never side
 
 ### Resolving Circular Dependencies
 
-- Use the event bus: module B publishes an event, module A handles it. No reference needed.
+- Use events: module B publishes via `IMessageBus`, module A handles it. No reference needed.
 - Extract shared concepts into a third Contracts project, or rethink ownership.
 
 ### DI Injection Rules
 
 - Inject contract interfaces, never concrete services.
-- Framework services (`IEventBus`, `ISettingsContracts`) are injected directly.
+- Framework services (Wolverine's `IMessageBus`, `ISettingsContracts`, `IFusionCache`) are injected directly.
 - DbContext is injected only within the owning module's implementation.
 
 ---
@@ -194,17 +194,12 @@ This is cosmetic organization -- all modules share one connection.
 
 ### Events
 
-- Cross-module notifications use `IEventBus.PublishAsync<T>()`
-- Events are defined in the publishing module's Contracts project
-- Any module can handle any event via `IEventHandler<T>`
-- Handlers currently execute sequentially in registration order; all run even if some fail. Design handlers as order-independent for forward compatibility.
-- Failures are collected into `AggregateException`
+- Cross-module notifications use Wolverine's `IMessageBus.PublishAsync<T>()`
+- Events are records implementing the `IEvent` marker, defined in the publishing module's Contracts project
+- Any module can handle any event by declaring a class with a `Handle` / `Consume` / `HandleAsync` method taking the event as its first parameter — Wolverine discovers handlers by naming convention
+- In-process only: no external transports, no durable outbox, no cross-restart persistence. For durable work use the Background Jobs module.
 - Handlers should be stateless, independent, and idempotent
-
-### PublishAsync vs PublishInBackground
-
-- **`PublishAsync<T>()`** -- synchronous dispatch. The caller blocks until all handlers complete. Exceptions propagate to the caller.
-- **`PublishInBackground<T>()`** -- fire-and-forget. Failures are logged, not thrown. No cancellation token is accepted, so callers cannot cancel in-flight background work, and handlers may be interrupted on host shutdown. Use for notifications where the caller must not block or fail (audit logging, cache invalidation).
+- Non-critical handlers (audit, metrics, cache invalidation) should catch their own exceptions so they never break the primary operation
 
 ### When to Use Which Communication Pattern
 

--- a/docs/missing-cross-cutting-modules.md
+++ b/docs/missing-cross-cutting-modules.md
@@ -6,8 +6,8 @@ Analysis of cross-cutting concerns not yet covered by the framework.
 
 - Exception handling (`GlobalExceptionHandler`)
 - Authorization & permissions (`PermissionRegistry`, `IPermissionContracts`)
-- Event bus (`IEventBus`)
-- Validation (`ValidationBuilder`)
+- Event bus (Wolverine `IMessageBus`)
+- Validation (FluentValidation + `ValidationResultExtensions`)
 - Settings (`ISettingsContracts`, `SettingDefinitionRegistry`)
 - Menu system (`IMenuRegistry`)
 - Health checks (`DatabaseHealthCheck`, `/health/live`, `/health/ready`)

--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         {
           text: 'Communication',
           items: [
-            { text: 'Event Bus', link: '/guide/events' },
+            { text: 'Events', link: '/guide/events' },
             { text: 'Permissions', link: '/guide/permissions' },
             { text: 'Menus', link: '/guide/menus' },
             { text: 'Settings', link: '/guide/settings' },
@@ -61,6 +61,7 @@ export default defineConfig({
             { text: 'Background Jobs', link: '/guide/background-jobs' },
             { text: 'File Storage', link: '/guide/file-storage' },
             { text: 'Localization', link: '/guide/localization' },
+            { text: 'Error Pages', link: '/guide/error-pages' },
             { text: 'AI Agents & RAG', link: '/guide/ai-agents' },
           ],
         },

--- a/docs/site/advanced/source-generator.md
+++ b/docs/site/advanced/source-generator.md
@@ -57,6 +57,9 @@ The generator scans both referenced assemblies and the current compilation for:
 | **Entity Configurations** | Classes implementing `IEntityTypeConfiguration<T>` |
 | **Contract Interfaces** | Interfaces in `*.Contracts` assemblies with implementations |
 | **Permission Classes** | Sealed classes implementing `IModulePermissions` |
+| **Feature Flag Classes** | Classes implementing `IModuleFeatures` |
+| **Module Options** | `[ModuleOptions]`-annotated classes |
+| **Agents** | `[Agent]` classes, `IAgentToolProvider` implementations, knowledge sources |
 | **Interceptors** | Classes implementing `ISaveChangesInterceptor` |
 | **Vogen Value Objects** | Types with Vogen value object markers |
 
@@ -73,10 +76,46 @@ internal readonly record struct DiscoveryData(
     ImmutableArray<ContractInterfaceInfoRecord> ContractInterfaces,
     ImmutableArray<ContractImplementationRecord> ContractImplementations,
     ImmutableArray<PermissionClassRecord> PermissionClasses,
+    ImmutableArray<FeatureClassRecord> FeatureClasses,
     ImmutableArray<InterceptorInfoRecord> Interceptors,
-    ImmutableArray<VogenValueObjectRecord> VogenValueObjects
+    ImmutableArray<VogenValueObjectRecord> VogenValueObjects,
+    ImmutableArray<ModuleOptionsRecord> ModuleOptions,
+    ImmutableArray<AgentDefinitionRecord> AgentDefinitions,
+    ImmutableArray<AgentToolProviderRecord> AgentToolProviders,
+    ImmutableArray<KnowledgeSourceRecord> KnowledgeSources,
+    ImmutableArray<string> ContractsAssemblyNames,
+    bool HasAgentsAssembly,
+    string HostAssemblyName
 );
 ```
+
+### Discovery Files
+
+Discovery logic is split across focused files under `Discovery/`:
+
+```
+Discovery/
+├── SymbolDiscovery.cs          # orchestrator — calls the finders
+├── DiscoveryDataBuilder.cs     # assembles the final DiscoveryData record
+├── DependencyAnalyzer.cs       # computes module dependencies + illegal references
+├── CoreSymbols.cs              # one-shot resolution of framework symbols (IEndpoint, [Module], ...)
+├── AssemblyConventions.cs      # "is this a *.Contracts assembly?" etc.
+├── SymbolHelpers.cs
+├── TopologicalSort.cs          # orders modules by dependency
+├── Finders/
+│   ├── ModuleFinder.cs
+│   ├── EndpointFinder.cs
+│   ├── DtoFinder.cs
+│   ├── ContractFinder.cs
+│   ├── PermissionFeatureFinder.cs
+│   ├── DbContextFinder.cs
+│   ├── InterceptorFinder.cs
+│   ├── VogenFinder.cs
+│   └── AgentFinder.cs
+└── Records/                    # equatable value-type records used in DiscoveryData
+```
+
+`CoreSymbols` resolves framework symbols (`IEndpoint`, `[Module]`, `IModulePermissions`, ...) once per compilation and passes them into each finder, avoiding repeated `Compilation.GetTypeByMetadataName` lookups in hot paths.
 
 ## What It Generates
 
@@ -90,6 +129,12 @@ The generator feeds `DiscoveryData` through a pipeline of **emitters**, each res
 | `EndpointExtensionsEmitter` | `EndpointExtensions.g.cs` | `MapModuleEndpoints()` -- maps all `IEndpoint` and `IViewEndpoint` implementations with route groups and authorization |
 | `MenuExtensionsEmitter` | `MenuExtensions.g.cs` | `CollectModuleMenuItems()` -- collects menu items from all modules that implement `ConfigureMenu` |
 | `SettingsExtensionsEmitter` | `SettingsExtensions.g.cs` | Collects settings definitions from modules that implement `ConfigureSettings` |
+| `ModuleOptionsEmitter` | `ModuleOptionsExtensions.g.cs` | Binds `[ModuleOptions]` classes to configuration sections |
+| `ContractRegistryEmitter` | `ContractRegistry.g.cs` | Registers each `I{Name}Contracts` against its implementation |
+| `AgentExtensionsEmitter` | `AgentExtensions.g.cs` | Registers agents, tool providers, and knowledge sources (when the Agents framework assembly is referenced) |
+| `LocalizationExtensionsEmitter` | `LocalizationExtensions.g.cs` | Aggregates localization resources across modules |
+| `RoutesEmitter` | `ModuleRoutes.g.cs` | Strongly-typed C# route constants |
+| `TypeScriptRoutesEmitter` | `TypeScriptRoutes.g.cs` | Embedded TypeScript route constants for the ClientApp |
 | `HostingExtensionsEmitter` | `HostingExtensions.g.cs` | Top-level `AddSimpleModule()` that orchestrates all registrations |
 
 ### Frontend Integration
@@ -141,7 +186,7 @@ Emitters[].Emit(context, data)
     │  ModuleExtensionsEmitter → ModuleExtensions.g.cs
     │  EndpointExtensionsEmitter → EndpointExtensions.g.cs
     │  TypeScriptDefinitionsEmitter → DtoTypeScript_*.g.cs
-    │  ... (14 emitters total)
+    │  ... (19 emitters total)
     │
     ▼
 Generated source added to compilation
@@ -165,9 +210,15 @@ public class ModuleDiscovererGenerator : IIncrementalGenerator
         new JsonResolverEmitter(),
         new TypeScriptDefinitionsEmitter(),
         new HostingExtensionsEmitter(),
+        new ModuleOptionsEmitter(),
         new HostDbContextEmitter(),
         new ValueConverterConventionsEmitter(),
         new DbContextRegistryEmitter(),
+        new ContractRegistryEmitter(),
+        new AgentExtensionsEmitter(),
+        new LocalizationExtensionsEmitter(),
+        new RoutesEmitter(),
+        new TypeScriptRoutesEmitter(),
     ];
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/docs/site/cli/new-project.md
+++ b/docs/site/cli/new-project.md
@@ -50,7 +50,7 @@ MyApp/
 ## Project Details
 
 - **Api** -- the host application that calls generated `AddModules()` and `MapModuleEndpoints()` extension methods
-- **Core** -- defines the `IModule` interface, `[Module]` attribute, `IEndpoint`, `[Dto]`, event bus, and menu system
+- **Core** -- defines the `IModule` interface, `[Module]` attribute, `IEndpoint`, `[Dto]`, events (`IEvent` + Wolverine), and menu system
 - **Database** -- multi-provider database support with schema isolation per module
 - **Generator** -- Roslyn incremental source generator targeting `netstandard2.0` for compile-time module discovery
 - **Tests.Shared** -- `WebApplicationFactory` base class, fake data generators, and test authentication

--- a/docs/site/cli/overview.md
+++ b/docs/site/cli/overview.md
@@ -23,7 +23,12 @@ Once installed, the `sm` command is available globally from any terminal.
 | `sm new project [name]` | Scaffold a new SimpleModule solution |
 | `sm new module [name]` | Create a module with contracts, endpoints, and tests |
 | `sm new feature [name]` | Add a feature endpoint to an existing module |
+| `sm new agent [name]` | Add an AI agent to an existing module |
+| `sm dev` | Start the full dev environment (dotnet watch + Vite HMR) |
+| `sm list` | List discovered modules in the current project with their route prefixes |
+| `sm install <package>` | Install a SimpleModule package from NuGet |
 | `sm doctor [--fix]` | Validate project structure and conventions |
+| `sm version` | Print the `sm` CLI version (also `sm --version`) |
 
 All `sm new` commands support interactive prompts. If you omit required arguments, the CLI will ask for them using an interactive selection UI powered by [Spectre.Console](https://spectreconsole.net/).
 

--- a/docs/site/getting-started/project-structure.md
+++ b/docs/site/getting-started/project-structure.md
@@ -15,7 +15,6 @@ MyApp/
 │   ├── SimpleModule.Generator/
 │   ├── SimpleModule.Database/
 │   ├── SimpleModule.Hosting/
-│   ├── SimpleModule.DevTools/
 │   ├── SimpleModule.Agents/       # AI agent runtime and registry
 │   ├── SimpleModule.AI.Anthropic/ # Claude API provider
 │   ├── SimpleModule.AI.OpenAI/    # OpenAI API provider
@@ -59,6 +58,8 @@ MyApp/
 │       └── wwwroot/
 ├── cli/
 │   └── SimpleModule.Cli/         # The sm CLI tool
+├── tools/                        # Non-module .NET utilities (dev-time tooling)
+│   └── SimpleModule.DevTools/
 ├── tests/                        # Framework-level test projects
 ├── SimpleModule.slnx             # Solution file
 ├── package.json                  # Root npm workspace config
@@ -78,8 +79,7 @@ The foundation. Defines all the interfaces and attributes that modules implement
 - **`IEndpoint` / `IViewEndpoint`** -- endpoint contracts. `IEndpoint` for API routes, `IViewEndpoint` for pages that render React views.
 - **`[Dto]` attribute** -- marks types for source generator processing (JSON serialization, TypeScript extraction).
 - **`IMenuRegistry`** -- register navigation menu items from your module.
-- **`IEventBus`** -- publish events for cross-module communication.
-- **`IEventHandler<T>`** -- handle events from other modules.
+- **`IEvent`** -- marker interface for events used in cross-module communication (publishing uses Wolverine's `IMessageBus`; see [Events](/guide/events)).
 - **`Inertia`** -- server-side helpers for rendering React pages with props.
 
 ### SimpleModule.Generator
@@ -117,10 +117,6 @@ Multi-provider database support built on EF Core. Handles:
 
 Module registration infrastructure and Inertia page rendering. Provides the runtime plumbing that the generated `AddModules()` and `MapModuleEndpoints()` methods call into. Handles service collection extensions, endpoint routing integration, module lifecycle management, and renders the static HTML shell with embedded JSON props for React hydration.
 
-### SimpleModule.DevTools
-
-Development utilities including hot reload support, diagnostic middleware, and developer experience tooling that is excluded from production builds.
-
 ### SimpleModule.Agents
 
 AI agent runtime and orchestration. Provides `IAgentRegistry` for agent discovery, `AgentChatService` for chat (streaming and non-streaming), `IAgentToolProvider` with `[AgentTool]` attribute for tool discovery, and middleware for rate limiting, token tracking, and guardrails (PII redaction, prompt injection detection).
@@ -149,6 +145,14 @@ File storage abstraction with `IStorageProvider` interface (save, get, delete, e
 - **SimpleModule.Storage.Local** -- local filesystem storage
 - **SimpleModule.Storage.S3** -- AWS S3 and S3-compatible services
 - **SimpleModule.Storage.Azure** -- Azure Blob Storage
+
+## Tools
+
+The `tools/` directory holds non-module .NET utilities consumed by the host or the framework bootstrap. They are not modules and do not go under `modules/`.
+
+### SimpleModule.DevTools
+
+Development utilities including hot reload support, diagnostic middleware, and developer experience tooling. Wired into the host only when `builder.Environment.IsDevelopment()` is true, so it is excluded from production.
 
 ## Module Structure
 
@@ -388,25 +392,21 @@ public sealed class CreateOrder : IEndpoint
 
 ### Events (Asynchronous)
 
-For loose coupling, modules publish events through `IEventBus`:
+For loose coupling, modules publish events through Wolverine's `IMessageBus`:
 
 ```csharp
 // Publisher (in Orders module)
-await eventBus.PublishAsync(new OrderCreatedEvent(order.Id, order.ProductId));
+await bus.PublishAsync(new OrderCreatedEvent(order.Id, order.ProductId));
 
-// Handler (in Products module, or any module)
-public sealed class UpdateStockOnOrderCreated : IEventHandler<OrderCreatedEvent>
+// Handler (in Products module, or any module) -- discovered by naming convention
+public sealed class UpdateStockOnOrderCreated(IProductContracts products)
 {
-    public async Task HandleAsync(
-        OrderCreatedEvent @event,
-        CancellationToken cancellationToken)
-    {
-        // Reduce stock for the ordered product
-    }
+    public Task Handle(OrderCreatedEvent evt, CancellationToken ct) =>
+        products.ReduceStockAsync(evt.ProductId, ct);
 }
 ```
 
-Event handlers run sequentially and failures are isolated -- if one handler throws, the others still execute.
+Wolverine discovers handlers by naming convention (`*Handler`/`*Consumer` class with a `Handle`/`Consume` method). See [Events](/guide/events) for delivery semantics and best practices.
 
 ## Solution File
 

--- a/docs/site/guide/contracts.md
+++ b/docs/site/guide/contracts.md
@@ -308,7 +308,7 @@ public sealed record OrderCreatedEvent(
     OrderId OrderId, UserId UserId, decimal Total) : IEvent;
 ```
 
-Any module can implement `IEventHandler<OrderCreatedEvent>` to react when an order is created, without depending on the Orders implementation.
+Any module can handle `OrderCreatedEvent` by declaring a handler class with a `Handle` method — Wolverine discovers it by naming convention — without depending on the Orders implementation.
 
 ## Summary
 
@@ -324,5 +324,5 @@ Any module can implement `IEventHandler<OrderCreatedEvent>` to react when an ord
 ## Next Steps
 
 - [Database](/guide/database) -- configure per-module database contexts and schema isolation
-- [Event Bus](/guide/events) -- publish and handle cross-module events
+- [Events](/guide/events) -- publish and handle cross-module events
 - [Type Generation](/advanced/type-generation) -- how DTOs become TypeScript interfaces

--- a/docs/site/guide/database.md
+++ b/docs/site/guide/database.md
@@ -363,6 +363,6 @@ Full `Database` configuration section:
 
 ## Next Steps
 
-- [Event Bus](/guide/events) -- cross-module communication via events
+- [Events](/guide/events) -- cross-module communication via events
 - [EF Core Interceptors](/advanced/interceptors) -- safe dependency injection patterns for interceptors
 - [Deployment](/advanced/deployment) -- production database configuration and migrations

--- a/docs/site/guide/endpoints.md
+++ b/docs/site/guide/endpoints.md
@@ -62,15 +62,19 @@ public class CreateEndpoint : IEndpoint
     public void Map(IEndpointRouteBuilder app) =>
         app.MapPost(
                 "/",
-                (CreateProductRequest request, IProductContracts productContracts) =>
+                async (
+                    CreateProductRequest request,
+                    IValidator<CreateProductRequest> validator,
+                    IProductContracts productContracts
+                ) =>
                 {
-                    var validation = CreateRequestValidator.Validate(request);
+                    var validation = await validator.ValidateAsync(request);
                     if (!validation.IsValid)
                     {
-                        throw new ValidationException(validation.Errors);
+                        throw new ValidationException(validation.ToValidationErrors());
                     }
 
-                    return CrudEndpoints.Create(
+                    return await CrudEndpoints.Create(
                         () => productContracts.CreateProductAsync(request),
                         p => $"{ProductsConstants.RoutePrefix}/{p.Id}"
                     );
@@ -88,16 +92,20 @@ public class UpdateEndpoint : IEndpoint
     public void Map(IEndpointRouteBuilder app) =>
         app.MapPut(
                 "/{id}",
-                (ProductId id, UpdateProductRequest request,
-                 IProductContracts productContracts) =>
+                async (
+                    ProductId id,
+                    UpdateProductRequest request,
+                    IValidator<UpdateProductRequest> validator,
+                    IProductContracts productContracts
+                ) =>
                 {
-                    var validation = UpdateRequestValidator.Validate(request);
+                    var validation = await validator.ValidateAsync(request);
                     if (!validation.IsValid)
                     {
-                        throw new ValidationException(validation.Errors);
+                        throw new ValidationException(validation.ToValidationErrors());
                     }
 
-                    return CrudEndpoints.Update(
+                    return await CrudEndpoints.Update(
                         () => productContracts.UpdateProductAsync(id, request));
                 }
             )
@@ -390,6 +398,41 @@ app.MapGet("/", ([FromServices] IProductContracts products) => ...);
 app.MapGet("/", (IProductContracts products) => ...);
 ```
 
+## Validation
+
+Request validation uses **[FluentValidation](https://docs.fluentvalidation.net/)**. Write an `AbstractValidator<T>` for every request DTO that needs validation.
+
+```csharp
+using FluentValidation;
+
+public sealed class CreateRequestValidator : AbstractValidator<CreateProductRequest>
+{
+    public CreateRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().WithMessage("Product name is required.");
+        RuleFor(x => x.Price).GreaterThan(0).WithMessage("Price must be greater than zero.");
+    }
+}
+```
+
+Register validators once in your module's `ConfigureServices`:
+
+```csharp
+services.AddValidatorsFromAssemblyContaining<ProductsModule>();
+```
+
+Endpoints inject `IValidator<T>`, call `ValidateAsync`, and convert failures to the framework's `ValidationException`:
+
+```csharp
+var validation = await validator.ValidateAsync(request);
+if (!validation.IsValid)
+{
+    throw new ValidationException(validation.ToValidationErrors());
+}
+```
+
+`ToValidationErrors()` (in `SimpleModule.Core.Validation`) converts FluentValidation failures into the shape `GlobalExceptionHandler` expects. See [Error Pages](/guide/error-pages) for the response format.
+
 ## File Organization
 
 By convention, endpoints are organized in the module's directory structure:
@@ -401,9 +444,9 @@ modules/Products/src/Products/
       GetAllEndpoint.cs
       GetByIdEndpoint.cs
       CreateEndpoint.cs
-      CreateRequestValidator.cs
+      CreateRequestValidator.cs    # AbstractValidator<CreateProductRequest>
       UpdateEndpoint.cs
-      UpdateRequestValidator.cs
+      UpdateRequestValidator.cs    # AbstractValidator<UpdateProductRequest>
       DeleteEndpoint.cs
   Views/
     BrowseEndpoint.cs

--- a/docs/site/guide/error-pages.md
+++ b/docs/site/guide/error-pages.md
@@ -1,0 +1,145 @@
+---
+outline: deep
+---
+
+# Error Pages
+
+SimpleModule ships a consistent error-handling pipeline that serves the right response shape depending on who's asking:
+
+- **Inertia (browser) requests** get a React error page rendered as a full Inertia response.
+- **API / fetch requests** get an RFC 7807 `ProblemDetails` JSON body.
+- **Catastrophic failures** (exception before Inertia can render) fall back to a static `wwwroot/error.html`.
+
+No per-module wiring is required — everything below is turned on by `AddSimpleModuleInfrastructure()` and `UseSimpleModule()`.
+
+## How Dispatch Works
+
+### Thrown exceptions
+
+The framework registers `GlobalExceptionHandler` via `AddExceptionHandler<GlobalExceptionHandler>()`. It maps domain exceptions to HTTP status codes:
+
+| Exception | Status | Notes |
+|-----------|--------|-------|
+| `ValidationException` | 400 | Errors serialized into the `errors` extension |
+| `ArgumentException` | 400 | Fallback for unchecked arg errors |
+| `NotFoundException` | 404 | Prefer this over returning `NotFound()` for domain misses |
+| `ForbiddenException` | 403 | For authorization failures surfaced from services |
+| `ConflictException` | 409 | Optimistic concurrency, duplicate keys, etc. |
+| _anything else_ | 500 | Logged at `Error`; the response message is `ErrorMessages.UnexpectedError` |
+
+The handler inspects `X-Inertia` on the request:
+
+- **Present** → writes an Inertia page JSON with component `Error/{statusCode}` and props `{ status, title, message }`.
+- **Absent** → writes `ProblemDetails` JSON.
+
+### Unmatched routes
+
+`UseSimpleModule()` registers a `MapFallback` for `GET` requests so browser navigation to a non-existent URL gets a 404 page instead of a bare 404:
+
+```text
+GET /some/unknown/path
+  → MapFallback
+  → RenderErrorPage(404)
+  → Inertia.Render("Error/404", { status, title, message })
+```
+
+The fallback only fires for unmatched requests. Endpoints that return bare `401`/`403` from authentication middleware are untouched, so API tests that assert on those status codes keep working.
+
+### Direct error URLs
+
+`GET /error/{statusCode}` renders an Inertia error page for any status — useful for linking from emails, redirects, or testing.
+
+```text
+GET /error/403
+  → Inertia.Render("Error/403", { status: 403, title: "...", message: "..." })
+```
+
+### Static fallback
+
+If an exception occurs so early that Inertia can't render (e.g., DI resolution failure), `UseExceptionHandler` writes the contents of `wwwroot/error.html` with a 500 status. Keep this file lean — it must render without any server state.
+
+## Raising Domain Errors
+
+Throw the framework exceptions from services or endpoints; the handler takes care of the status code and response shape.
+
+```csharp
+public async Task<Product> GetProductAsync(ProductId id)
+{
+    var product = await db.Products.FindAsync(id);
+    if (product is null)
+    {
+        throw new NotFoundException("Product", id);
+    }
+    return product;
+}
+```
+
+```csharp
+public async Task<Order> CancelOrderAsync(OrderId id, UserId actor)
+{
+    var order = await db.Orders.FindAsync(id);
+    if (order is null)
+    {
+        throw new NotFoundException("Order", id);
+    }
+    if (order.OwnerId != actor)
+    {
+        throw new ForbiddenException("You cannot cancel another user's order.");
+    }
+    // ...
+}
+```
+
+## React Error Components
+
+`template/SimpleModule.Host/ClientApp/app.tsx` maps the `Error/*` component names to React components before any normal page resolution runs:
+
+```tsx
+const ERROR_PAGES: Record<string, { default: React.ComponentType }> = {
+  'Error/404': { default: ErrorPage404 },
+  'Error/403': { default: ErrorPage403 },
+  'Error/500': { default: ErrorPage500 },
+};
+
+createInertiaApp({
+  resolve: async (name) => {
+    if (name in ERROR_PAGES) {
+      return ERROR_PAGES[name];
+    }
+    // ...normal page resolution
+  },
+});
+```
+
+The default components come from `@simplemodule/ui`. To customize, swap in your own component for the relevant status code. The component receives `{ status, title, message }` via Inertia props.
+
+## Customizing
+
+- **Change messages** — override `ErrorMessages` constants, or pass custom `title`/`message` via a new exception type.
+- **Add a status code** — create a new exception mapping in `GlobalExceptionHandler` and a matching `Error/{code}` React component in `ERROR_PAGES`.
+- **Static HTML fallback** — edit `template/SimpleModule.Host/wwwroot/error.html`. Keep it self-contained (inlined CSS, no external assets) so it works when the pipeline is degraded.
+
+## Testing Error Pages
+
+Assert on the status code and, for Inertia flows, the component name:
+
+```csharp
+[Fact]
+public async Task Missing_product_returns_404_problem_details()
+{
+    using var client = factory.CreateAuthenticatedClient();
+
+    var response = await client.GetAsync("/api/products/99999");
+
+    response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+    problem!.Title.Should().Be("Resource not found");
+}
+```
+
+For Inertia pages, send `X-Inertia: true` and assert on the JSON component field.
+
+## Next Steps
+
+- [Endpoints](/guide/endpoints) — how validation errors become 400 responses
+- [Permissions](/guide/permissions) — how `RequirePermission` interacts with 403 responses

--- a/docs/site/guide/events.md
+++ b/docs/site/guide/events.md
@@ -2,15 +2,15 @@
 outline: deep
 ---
 
-# Event Bus
+# Events
 
-The event bus enables decoupled communication between modules. Instead of modules referencing each other directly, they publish events that any module can subscribe to. This keeps modules independent while allowing cross-cutting behavior like audit logging, notifications, or cache invalidation.
+Modules communicate without direct references by publishing events. SimpleModule builds on **[Wolverine](https://wolverinefx.net/)** for in-process messaging: handlers are discovered by convention and invoked through `IMessageBus`.
 
 ## Core Concepts
 
 ### IEvent
 
-`IEvent` is a marker interface. Any record or class implementing it can be published through the event bus:
+`IEvent` is a marker interface. Any record or class implementing it is treated as a domain event by the framework (audit capture, domain-event dispatch from `AuditableAggregateRoot`, etc.). Events are typically defined in a module's **Contracts** project so other modules can reference them without depending on the implementation.
 
 ```csharp
 using SimpleModule.Core.Events;
@@ -18,286 +18,165 @@ using SimpleModule.Core.Events;
 public sealed record OrderCreatedEvent(OrderId OrderId, UserId UserId, decimal Total) : IEvent;
 ```
 
-Events are typically defined in a module's **Contracts** project so other modules can reference them without depending on the implementation.
+### Publishing with IMessageBus
 
-### IEventBus
-
-`IEventBus` exposes a single method for publishing events to all registered handlers:
+Inject Wolverine's `IMessageBus` and call `PublishAsync`:
 
 ```csharp
-public interface IEventBus
-{
-    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
-        where T : IEvent;
-}
-```
+using Wolverine;
 
-Inject `IEventBus` into any service and call `PublishAsync`:
-
-```csharp
 public sealed partial class OrderService(
     OrdersDbContext db,
-    IEventBus eventBus,
+    IMessageBus bus,
     ILogger<OrderService> logger
 ) : IOrderContracts
 {
     public async Task<Order> CreateOrderAsync(CreateOrderRequest request)
     {
-        // ... create the order ...
+        var order = new Order { UserId = request.UserId, Total = request.Total };
 
         db.Orders.Add(order);
         await db.SaveChangesAsync();
 
-        await eventBus.PublishAsync(
-            new OrderCreatedEvent(order.Id, order.UserId, order.Total)
-        );
+        await bus.PublishAsync(new OrderCreatedEvent(order.Id, order.UserId, order.Total));
 
         return order;
     }
 }
 ```
 
-### IEventHandler\<T\>
+`IMessageBus` is registered as scoped by `AddSimpleModuleInfrastructure()` — no per-module wiring needed.
 
-Implement `IEventHandler<T>` to react to a specific event type. Register handlers in DI and they are automatically discovered by the event bus:
-
-```csharp
-public sealed class OrderCreatedNotificationHandler : IEventHandler<OrderCreatedEvent>
-{
-    public async Task HandleAsync(
-        OrderCreatedEvent @event,
-        CancellationToken cancellationToken
-    )
-    {
-        // Send notification, update cache, etc.
-    }
-}
-```
-
-Register in your module's `ConfigureServices`:
-
-```csharp
-services.AddScoped<IEventHandler<OrderCreatedEvent>, OrderCreatedNotificationHandler>();
-```
-
-## Partial Success Semantics
-
-The event bus guarantees that **all handlers execute even if some fail**. This is the most important design decision in the event system.
-
-### How It Works
-
-1. Handlers execute **sequentially** in registration order
-2. If a handler throws, the exception is **caught and logged**
-3. Execution **continues** to the next handler
-4. After all handlers complete, any collected exceptions are thrown as a single `AggregateException`
-
-```
-Handler A  ──→ ✅ Success (side effects preserved)
-Handler B  ──→ ❌ Throws (exception caught and logged)
-Handler C  ──→ ✅ Success (still executes despite B's failure)
-
-Result: AggregateException containing B's exception
-```
-
-::: warning
-Side effects from successful handlers are **preserved** even when the `AggregateException` is thrown. Design your error handling accordingly.
+::: tip Breaking factory cycles
+If two services form a cycle through the bus (for example, a settings service whose decorator also needs the bus), inject `Lazy<IMessageBus>` instead. The framework registers it out of the box.
 :::
 
-### Handling AggregateException
+### Writing a Handler
 
-The caller is responsible for handling the aggregate exception. Inspect `InnerExceptions` to see which handlers failed:
+Wolverine discovers handlers by **naming convention**: a public class whose type or name ends with `Handler` / `Consumer`, with a method named `Handle` / `Consume` / `HandleAsync` that takes the event as its first parameter. No interface, no DI registration.
 
 ```csharp
-try
+public sealed class OrderCreatedNotificationHandler(INotificationService notifications)
 {
-    await eventBus.PublishAsync(new OrderCreatedEvent(orderId, userId, total));
+    public Task Handle(OrderCreatedEvent evt, CancellationToken ct) =>
+        notifications.SendAsync(evt.UserId, $"Order {evt.OrderId} confirmed", ct);
 }
-catch (AggregateException ex)
+```
+
+Handlers resolve through the request scope, so injected services (DbContext, loggers, contracts) behave exactly as they would inside an endpoint.
+
+## Dispatching Domain Events from Aggregates
+
+Entities that derive from `AuditableAggregateRoot` (or implement `IHasDomainEvents`) can queue events that are flushed via `IMessageBus` after `SaveChangesAsync()` succeeds. This keeps write logic transactional: events only fire if the save commits.
+
+```csharp
+public sealed class Order : AuditableAggregateRoot<OrderId>
 {
-    foreach (var inner in ex.InnerExceptions)
+    public decimal Total { get; set; }
+    public OrderStatus Status { get; set; }
+
+    public void Confirm()
     {
-        logger.LogError(inner, "Handler failed for OrderCreatedEvent");
+        Status = OrderStatus.Confirmed;
+        AddDomainEvent(new OrderConfirmedEvent(Id, Total));
     }
 }
 ```
+
+The `DomainEventInterceptor` (registered by the hosting layer) picks up queued events after a successful save and publishes them through the bus.
+
+## Delivery Semantics
+
+Wolverine routes `PublishAsync` to **every matching handler** in the process:
+
+- **In-process only.** The framework configures Wolverine with no external transports and no durable outbox — events are not persisted and are not retried across process restarts.
+- **Handler isolation.** Each handler runs in its own dispatch. A failing handler does not stop dispatch to the others.
+- **Exceptions surface.** By default, handler exceptions are logged and rethrown once all handlers have been attempted. If you need finer control, configure Wolverine policies in `builder.Host.UseWolverine(opts => ...)`.
+- **Audit capture.** The AuditLogs module wraps `IMessageBus` with `AuditingMessageBus`, which records an audit entry for every published `IEvent`. Audit failures are swallowed and logged — they never break the primary operation.
+
+::: warning Not a durable queue
+Wolverine is running in-memory here. For work that must survive a restart, use the [Background Jobs](/guide/background-jobs) module instead of relying on events.
+:::
 
 ## Handler Best Practices
 
-### Be Stateless
+### Keep Handlers Focused
 
-Handlers may be called concurrently in future versions. Avoid mutable state:
-
-```csharp
-// Good: stateless, uses injected services
-public sealed class AuditHandler(IAuditContext audit) : IEventHandler<OrderCreatedEvent>
-{
-    public async Task HandleAsync(OrderCreatedEvent @event, CancellationToken ct)
-    {
-        await audit.LogAsync("Order created", @event.OrderId.ToString());
-    }
-}
-```
-
-### Be Independent
-
-Do not rely on side effects from other handlers. They may execute in any order or be skipped in future versions.
+A handler should do one thing. If `OrderCreatedEvent` needs to send an email, update a search index, and invalidate caches, write three handlers. Wolverine invokes them independently.
 
 ### Be Idempotent
 
-The same event may be reprocessed in retry scenarios. Design handlers to handle duplicate calls gracefully.
+An event may be replayed (retry logic, re-run of a background job). Handlers should tolerate seeing the same event twice — check for existing state before writing.
 
-### Don't Throw for Expected Failures
+### Don't Throw for Non-Critical Work
 
-For non-critical work like audit logging, catch exceptions inside the handler rather than letting them propagate:
+Audit logging, metrics, cache invalidation, and similar cross-cutting concerns should catch their own exceptions. Reserve rethrown exceptions for failures the caller actually needs to know about.
 
 ```csharp
-public sealed class AuditLogEventHandler(
-    IAuditContext audit,
-    ILogger<AuditLogEventHandler> logger
-) : IEventHandler<OrderCreatedEvent>
+public sealed class OrderMetricsHandler(IMetrics metrics, ILogger<OrderMetricsHandler> logger)
 {
-    public async Task HandleAsync(
-        OrderCreatedEvent @event,
-        CancellationToken cancellationToken
-    )
+    public Task Handle(OrderCreatedEvent evt, CancellationToken ct)
     {
         try
         {
-            await audit.LogAsync("Order created", @event.OrderId.ToString());
+            metrics.Increment("orders.created", tags: new { evt.UserId });
         }
+#pragma warning disable CA1031
         catch (Exception ex)
         {
-            // Don't throw: audit logging must never disrupt the primary operation
-            logger.LogError(ex, "Failed to log event");
+            logger.LogWarning(ex, "Failed to record order metrics");
         }
+#pragma warning restore CA1031
+        return Task.CompletedTask;
     }
 }
 ```
 
-### Avoid Long-Running Work
+### Offload Long-Running Work
 
-For expensive operations, queue work for a background service instead of blocking the event bus:
-
-```csharp
-public sealed class EmailHandler(EmailChannel channel) : IEventHandler<OrderCreatedEvent>
-{
-    public Task HandleAsync(OrderCreatedEvent @event, CancellationToken ct)
-    {
-        // Queue for background processing instead of sending synchronously
-        return channel.EnqueueAsync(new OrderConfirmationEmail(@event.OrderId));
-    }
-}
-```
+Handlers run inline with the publishing scope. For anything expensive (external HTTP, PDF rendering, batch writes), enqueue a background job instead of blocking the caller.
 
 ## Testing Events
 
-### Basic Handler Test
+### Unit-Testing a Handler
+
+Instantiate the handler directly. No DI container is required.
 
 ```csharp
 [Fact]
-public async Task Handler_processes_event()
+public async Task OrderCreatedNotificationHandler_sends_confirmation()
 {
-    var handler = new OrderCreatedNotificationHandler();
-    var @event = new OrderCreatedEvent(OrderId.From(1), UserId.From(1), 99.99m);
+    var notifications = Substitute.For<INotificationService>();
+    var handler = new OrderCreatedNotificationHandler(notifications);
 
-    await handler.HandleAsync(@event, CancellationToken.None);
-
-    // Assert side effects
-}
-```
-
-### Testing Partial Failure
-
-Verify that successful handlers complete their work even when other handlers fail:
-
-```csharp
-[Fact]
-public async Task Successful_handlers_complete_when_others_fail()
-{
-    var services = new ServiceCollection();
-    services.AddScoped<IEventHandler<TestEvent>, SuccessfulHandler>();
-    services.AddScoped<IEventHandler<TestEvent>, FailingHandler>();
-    services.AddScoped<IEventHandler<TestEvent>, AnotherSuccessfulHandler>();
-
-    var provider = services.BuildServiceProvider();
-    var bus = new EventBus(provider, NullLogger<EventBus>.Instance);
-
-    var ex = await Assert.ThrowsAsync<AggregateException>(
-        () => bus.PublishAsync(new TestEvent("value"))
+    await handler.Handle(
+        new OrderCreatedEvent(OrderId.From(1), UserId.From(42), 99.99m),
+        CancellationToken.None
     );
 
-    ex.InnerExceptions.Should().HaveCount(1);
-    // Verify successful handlers completed their work
+    await notifications.Received().SendAsync(UserId.From(42), Arg.Any<string>(), Arg.Any<CancellationToken>());
 }
 ```
 
-### Testing Handler Execution Order
+### Verifying Publishes in a Service Test
 
-Handlers run in registration order. You can verify this:
+In service-level tests, substitute `IMessageBus` and assert on the recorded calls:
 
 ```csharp
 [Fact]
-public async Task Handlers_execute_in_registration_order()
+public async Task CreateOrder_publishes_order_created_event()
 {
-    var order = new List<string>();
+    var bus = Substitute.For<IMessageBus>();
+    var service = new OrderService(db, bus, NullLogger<OrderService>.Instance);
 
-    var services = new ServiceCollection();
-    services.AddScoped<IEventHandler<TestEvent>>(_ => new OrderTrackingHandler("A", order));
-    services.AddScoped<IEventHandler<TestEvent>>(_ => new OrderTrackingHandler("B", order));
+    var order = await service.CreateOrderAsync(new CreateOrderRequest(UserId.From(42), 99.99m));
 
-    var provider = services.BuildServiceProvider();
-    var bus = new EventBus(provider, NullLogger<EventBus>.Instance);
-
-    await bus.PublishAsync(new TestEvent("value"));
-
-    order.Should().ContainInOrder("A", "B");
+    await bus.Received().PublishAsync(Arg.Is<OrderCreatedEvent>(e => e.OrderId == order.Id));
 }
 ```
-
-## EventBus Internals
-
-The `EventBus` implementation resolves all `IEventHandler<T>` instances from `IServiceProvider` and iterates through them:
-
-```csharp
-public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
-    where T : IEvent
-{
-    var handlers = serviceProvider.GetServices<IEventHandler<T>>();
-    List<Exception>? exceptions = null;
-
-    foreach (var handler in handlers)
-    {
-        try
-        {
-            await handler.HandleAsync(@event, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            LogHandlerFailed(logger, handler.GetType().Name, typeof(T).Name, ex);
-            exceptions ??= [];
-            exceptions.Add(ex);
-        }
-    }
-
-    if (exceptions is { Count: > 0 })
-    {
-        throw new AggregateException(
-            $"One or more event handlers for {typeof(T).Name} failed.",
-            exceptions
-        );
-    }
-}
-```
-
-Key implementation details:
-
-- Handlers are resolved via `GetServices<IEventHandler<T>>()`, so registration order matters
-- Failed handlers are logged with structured logging (`[LoggerMessage]` source generator)
-- The `CancellationToken` is passed to every handler, allowing cooperative cancellation
-- The `EventBus` is registered as scoped, so handlers share the same DI scope as the request
 
 ## Next Steps
 
-- [Permissions](/guide/permissions) -- claims-based authorization for endpoints
-- [Database](/guide/database) -- persistence patterns commonly paired with events
-- [Unit Tests](/testing/unit-tests) -- how to test event handlers and partial failure scenarios
+- [Permissions](/guide/permissions) — claims-based authorization for endpoints
+- [Database](/guide/database) — persistence patterns commonly paired with events
+- [Unit Tests](/testing/unit-tests) — how to test event handlers and service-level publishing

--- a/docs/site/guide/modules.md
+++ b/docs/site/guide/modules.md
@@ -241,7 +241,7 @@ The source generator performs a topological sort of modules based on their depen
 The lifecycle during application startup:
 
 1. **`AddSimpleModule()`** is called on the `WebApplicationBuilder`
-2. Infrastructure services are registered (event bus, Blazor, etc.)
+2. Infrastructure services are registered (Wolverine messaging, FusionCache, Inertia, etc.)
 3. **`AddModules()`** calls `ConfigureServices` on each module in dependency order
 4. Contract implementations are auto-registered as scoped services
 5. Permissions are collected from all modules

--- a/docs/site/reference/api.md
+++ b/docs/site/reference/api.md
@@ -124,7 +124,7 @@ Every `IViewEndpoint` must have a corresponding entry in the module's `Pages/ind
 
 ### IEvent
 
-Marker interface for event types. All events published through the event bus must implement this interface.
+Marker interface for event types. All events published through `IMessageBus` should implement this interface.
 
 ```csharp
 namespace SimpleModule.Core.Events;
@@ -140,69 +140,39 @@ public sealed record OrderCreatedEvent(int OrderId, string CustomerName) : IEven
 
 ---
 
-### IEventBus
+### IMessageBus (Wolverine)
 
-Publishes events to all registered handlers with exception isolation semantics.
-
-```csharp
-namespace SimpleModule.Core.Events;
-
-public interface IEventBus
-{
-    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
-        where T : IEvent;
-}
-```
-
-**Behavior:**
-- Handlers execute **sequentially** in registration order
-- Handler failures are **isolated** -- if one handler throws, the others still run
-- After all handlers execute, any exceptions are rethrown as `AggregateException`
-
-**Usage:**
+Publishing is provided by **[Wolverine](https://wolverinefx.net/)**'s `IMessageBus` (namespace `Wolverine`), registered by `AddSimpleModuleInfrastructure()`. Inject it like any other scoped service.
 
 ```csharp
+using Wolverine;
+
 public sealed class CreateOrder : IEndpoint
 {
     public void Map(IEndpointRouteBuilder app)
     {
         app.MapPost("/", async (CreateOrderRequest request,
-            IOrderContracts orders, IEventBus eventBus) =>
+            IOrderContracts orders, IMessageBus bus) =>
         {
             var order = await orders.CreateAsync(request);
-            await eventBus.PublishAsync(new OrderCreatedEvent(order.Id, request.CustomerName));
+            await bus.PublishAsync(new OrderCreatedEvent(order.Id, request.CustomerName));
             return TypedResults.Created($"/{order.Id}", order);
         });
     }
 }
 ```
 
----
-
-### IEventHandler\<T\>
-
-Handles a specific event type. Implementations are registered in DI and invoked by the event bus.
+Handlers are discovered by Wolverine's naming convention — a class with a `Handle` / `Consume` / `HandleAsync` method taking the event as its first parameter. See [Events](/guide/events) for the full guide.
 
 ```csharp
-namespace SimpleModule.Core.Events;
-
-public interface IEventHandler<in T> where T : IEvent
+public sealed class OrderCreatedAuditHandler(IAuditContext audit)
 {
-    Task HandleAsync(T @event, CancellationToken cancellationToken);
+    public Task Handle(OrderCreatedEvent evt, CancellationToken ct) =>
+        audit.LogAsync("Order created", evt.OrderId.ToString(), ct);
 }
 ```
 
-**Usage:**
-
-```csharp
-public sealed class OrderCreatedAuditHandler : IEventHandler<OrderCreatedEvent>
-{
-    public async Task HandleAsync(OrderCreatedEvent @event, CancellationToken cancellationToken)
-    {
-        // Log the order creation for audit purposes
-    }
-}
-```
+`Lazy<IMessageBus>` is also registered to let services break factory-lambda cycles.
 
 ---
 

--- a/docs/site/testing/unit-tests.md
+++ b/docs/site/testing/unit-tests.md
@@ -177,25 +177,26 @@ var service = new OrderService(fakeProducts, db, logger);
 
 ## Testing Event Handlers
 
-Event handlers are tested by invoking `HandleAsync` directly and asserting on side effects:
+Wolverine handlers are plain classes — instantiate them directly and call `Handle` / `HandleAsync`:
 
 ```csharp
 [Fact]
-public async Task HandleAsync_LogsEvent()
+public async Task Handle_LogsEvent()
 {
-    var handler = new AuditLogEventHandler(logger);
-    var @event = new OrderCreatedEvent { OrderId = OrderId.From(1) };
+    var audit = Substitute.For<IAuditContext>();
+    var handler = new OrderCreatedAuditHandler(audit);
+    var evt = new OrderCreatedEvent(OrderId.From(1), UserId.From(42), 99.99m);
 
-    await handler.HandleAsync(@event, CancellationToken.None);
+    await handler.Handle(evt, CancellationToken.None);
 
-    // Assert on side effects (e.g., logger calls, database writes)
+    await audit.Received().LogAsync("Order created", "1", Arg.Any<CancellationToken>());
 }
 ```
 
-For testing the `EventBus` itself, including partial failure semantics, see the `EventBusPartialFailureTests` in the core test project.
+To verify a service publishes the right event, substitute `IMessageBus` and assert on the recorded calls — see [Events](/guide/events#testing-events) for a full example.
 
 ## Next Steps
 
 - [Integration Tests](/testing/integration-tests) -- test HTTP endpoints through the full pipeline
 - [E2E Tests](/testing/e2e-tests) -- browser-based testing with Playwright
-- [Event Bus](/guide/events) -- understand event handler patterns and partial failure
+- [Events](/guide/events) -- handler conventions and delivery semantics


### PR DESCRIPTION
## Summary

Audit of `docs/site/` and `docs/CONSTITUTION.md` against recent merges, with drift fixed and a missing feature documented.

## What changed

- **Events** — rewrote [guide/events.md](docs/site/guide/events.md) and the event sections of [reference/api.md](docs/site/reference/api.md), [getting-started/project-structure.md](docs/site/getting-started/project-structure.md), [guide/contracts.md](docs/site/guide/contracts.md), and [CONSTITUTION.md](docs/CONSTITUTION.md) around Wolverine's `IMessageBus` (PR #114). `PublishInBackground` / `IEventHandler<T>` / `AggregateException` semantics removed; handler discovery is now by Wolverine naming convention.
- **Validation** — [guide/endpoints.md](docs/site/guide/endpoints.md) samples now inject `IValidator<T>` and use `ValidationResultExtensions.ToValidationErrors()` (PR #112). Added a dedicated Validation section.
- **Project layout** — moved `SimpleModule.DevTools` out of `framework/` into a new `tools/` section (PR #115).
- **CLI** — [cli/overview.md](docs/site/cli/overview.md) now lists `sm version`, `sm list`, `sm dev`, `sm install`, `sm new agent` (PR #117).
- **Error pages** — new [guide/error-pages.md](docs/site/guide/error-pages.md) covering `GlobalExceptionHandler` Inertia-vs-ProblemDetails dispatch, `/error/{statusCode}`, `MapFallback`, `ForbiddenException`, the static `error.html` fallback, and the React `ERROR_PAGES` registry (PR #106).
- **Source generator** — [advanced/source-generator.md](docs/site/advanced/source-generator.md) reflects the post-split layout: new `DiscoveryData` fields, `Discovery/Finders/` files, `CoreSymbols`, expanded emitter table (19 emitters, corrected generated filenames) (PR #113).
- **Other drift** — renamed sidebar "Event Bus" → "Events" and updated every cross-link; swept residual lowercase "event bus" mentions; fixed stale `(event bus, Blazor, etc.)` in [guide/modules.md](docs/site/guide/modules.md) (wrong stack).

## Reviewer notes

- No framework code touched — docs-only change.
- Code samples were verified against the actual source (Products module, hosting extensions, generator emitters, CLI `Program.cs`, `app.tsx`).
- `docs/plans/` and `docs/superpowers/` still contain historical planning docs with pre-refactor terminology; those are intentionally left alone.

## Test plan

- [ ] `npm run docs:build` succeeds (VitePress)
- [ ] Sidebar renders with "Events" and new "Error Pages" entries
- [ ] All internal `/guide/*` and `/advanced/*` links resolve