### PR TITLE
ci(release): drop broken SSH deploy key, use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Bump version
         id: bump


### PR DESCRIPTION
## Summary

- Remove `ssh-key: \${{ secrets.DEPLOY_KEY }}` from the release workflow's checkout step and rely on `GITHUB_TOKEN` via `persist-credentials: true`.

## Why

Every run of `release.yml` currently fails at the very first step:

```
Load key "...": error in libcrypto
git@github.com: Permission denied (publickey).
```

The `DEPLOY_KEY` secret is no longer a parseable OpenSSH private key (likely CRLF corruption or a stale value), so `actions/checkout@v6` can't authenticate over SSH.

The job already declares `permissions: contents: write`, which grants the default `GITHUB_TOKEN` enough authority to push the version bump commit and tag back to \`main\`. Dropping the SSH input unblocks the workflow without adding new secrets.

## Reviewer notes / caveats

- If \`main\` has a branch protection rule that forbids \`github-actions[bot]\` pushes, the \`git push origin main\` step will 403 and we'll need to switch back to a deploy-key (or PAT) flow — regenerating the secret with correct line endings.
- \`GITHUB_TOKEN\`-driven pushes do **not** trigger other workflows. If any downstream workflow is expected to fire on the release commit, that will need a separate mechanism (e.g. \`workflow_dispatch\` via \`gh workflow run\`).

## Test plan

- [ ] Run the \`release\` workflow with \`bump: patch\` and confirm checkout, version bump, push, tag, and GitHub Release creation all succeed.
- [ ] Verify the \`publish-nuget\` and follow-up jobs still run off the newly created tag.