### PR TITLE
fix(cli,framework): make scaffolded projects build and run out of the box

### DIFF
--- a/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
@@ -491,7 +491,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
         """
             import { defineModuleConfig } from '@simplemodule/client/module';
 
-            export default defineModuleConfig(__dirname);
+            export default defineModuleConfig(import.meta.dirname);
             """;
 
     private static string StarterPackageJson(string projectName) =>
@@ -501,9 +501,9 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
               "name": "@{{projectName.ToLowerInvariant()}}/items",
               "version": "0.0.0",
               "scripts": {
-                "build": "vite build",
-                "build:dev": "cross-env VITE_MODE=dev vite build",
-                "watch": "cross-env VITE_MODE=dev vite build --watch"
+                "build": "cross-env VITE_MODE=prod vite build --configLoader runner",
+                "build:dev": "cross-env VITE_MODE=dev vite build --configLoader runner",
+                "watch": "cross-env VITE_MODE=dev vite build --configLoader runner --watch"
               },
               "peerDependencies": {
                 "react": "^19.0.0",

--- a/cli/SimpleModule.Cli/Templates/ProjectTemplates.cs
+++ b/cli/SimpleModule.Cli/Templates/ProjectTemplates.cs
@@ -707,11 +707,13 @@ public sealed class ProjectTemplates
         string frameworkVersion
     )
     {
-        var name = projectName.ToLowerInvariant();
+        // npm 'name' field must be lowercase; workspace glob uses actual project casing.
+        var npmName = projectName.ToLowerInvariant();
 
         string clientDep;
         string uiDep;
         string themeDep;
+        string tsconfigDep;
 
         if (frameworkPackagesPath is not null)
         {
@@ -719,22 +721,24 @@ public sealed class ProjectTemplates
             clientDep = $"\"file:{pkgPath}/SimpleModule.Client\"";
             uiDep = $"\"file:{pkgPath}/SimpleModule.UI\"";
             themeDep = $"\"file:{pkgPath}/SimpleModule.Theme.Default\"";
+            tsconfigDep = $"\"file:{pkgPath}/SimpleModule.TsConfig\"";
         }
         else
         {
             clientDep = $"\"^{frameworkVersion}\"";
             uiDep = $"\"^{frameworkVersion}\"";
             themeDep = $"\"^{frameworkVersion}\"";
+            tsconfigDep = $"\"^{frameworkVersion}\"";
         }
 
         return $$"""
             {
               "private": true,
-              "name": "{{name}}",
+              "name": "{{npmName}}",
               "version": "0.0.0",
               "workspaces": [
                 "src/modules/*/src/*",
-                "src/{{name}}.Host/ClientApp"
+                "src/{{projectName}}.Host/ClientApp"
               ],
               "scripts": {
                 "lint": "biome lint .",
@@ -745,23 +749,25 @@ public sealed class ProjectTemplates
                 "build:dev": "cross-env VITE_MODE=dev npm run build --workspaces --if-present"
               },
               "devDependencies": {
-                "@biomejs/biome": "^2.4.6",
-                "@tailwindcss/vite": "^4.2.1",
+                "@biomejs/biome": "^2.4.10",
+                "@tailwindcss/vite": "^4.2.2",
                 "@types/react": "^19.0.0",
                 "@types/react-dom": "^19.0.0",
-                "@vitejs/plugin-react": "^4.4.0",
-                "cross-env": "^7.0.3",
-                "typescript": "^5.8.0",
-                "vite": "^6.2.0"
+                "@vitejs/plugin-react": "^6.0.1",
+                "cross-env": "^10.1.0",
+                "typescript": "^6.0.2",
+                "vite": "^8.0.3"
               },
               "dependencies": {
-                "@inertiajs/react": "^2.0.0",
+                "@inertiajs/react": "^3.0.0",
                 "@simplemodule/client": {{clientDep}},
                 "@simplemodule/ui": {{uiDep}},
                 "@simplemodule/theme-default": {{themeDep}},
+                "@simplemodule/tsconfig": {{tsconfigDep}},
+                "esbuild": "^0.27.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
-                "tailwindcss": "^4.2.1"
+                "tailwindcss": "^4.2.2"
               }
             }
             """;

--- a/framework/SimpleModule.Generator/Discovery/CoreSymbols.cs
+++ b/framework/SimpleModule.Generator/Discovery/CoreSymbols.cs
@@ -27,7 +27,8 @@ internal readonly record struct CoreSymbols(
     INamedTypeSymbol? ModuleFeatures,
     INamedTypeSymbol? SaveChangesInterceptor,
     INamedTypeSymbol? ModuleOptions,
-    bool HasAgentsAssembly
+    bool HasAgentsAssembly,
+    bool HasRagAssembly
 )
 {
     /// <summary>
@@ -81,6 +82,10 @@ internal readonly record struct CoreSymbols(
             ModuleOptions: compilation.GetTypeByMetadataName("SimpleModule.Core.IModuleOptions"),
             HasAgentsAssembly: compilation.GetTypeByMetadataName(
                 "SimpleModule.Agents.SimpleModuleAgentExtensions"
+            )
+                is not null,
+            HasRagAssembly: compilation.GetTypeByMetadataName(
+                "SimpleModule.Rag.RagSettingsDefinitions"
             )
                 is not null
         );

--- a/framework/SimpleModule.Generator/Discovery/DiscoveryData.cs
+++ b/framework/SimpleModule.Generator/Discovery/DiscoveryData.cs
@@ -49,6 +49,7 @@ internal readonly record struct DiscoveryData(
     ImmutableArray<KnowledgeSourceRecord> KnowledgeSources,
     ImmutableArray<string> ContractsAssemblyNames,
     bool HasAgentsAssembly,
+    bool HasRagAssembly,
     string HostAssemblyName
 )
 {
@@ -80,6 +81,7 @@ internal readonly record struct DiscoveryData(
         ImmutableArray<KnowledgeSourceRecord>.Empty,
         ImmutableArray<string>.Empty,
         false,
+        false,
         ""
     );
 
@@ -103,6 +105,7 @@ internal readonly record struct DiscoveryData(
             && KnowledgeSources.SequenceEqual(other.KnowledgeSources)
             && ContractsAssemblyNames.SequenceEqual(other.ContractsAssemblyNames)
             && HasAgentsAssembly == other.HasAgentsAssembly
+            && HasRagAssembly == other.HasRagAssembly
             && HostAssemblyName == other.HostAssemblyName;
     }
 
@@ -127,6 +130,7 @@ internal readonly record struct DiscoveryData(
         hash = HashHelper.HashArray(hash, KnowledgeSources);
         hash = HashHelper.HashArray(hash, ContractsAssemblyNames);
         hash = HashHelper.Combine(hash, HasAgentsAssembly.GetHashCode());
+        hash = HashHelper.Combine(hash, HasRagAssembly.GetHashCode());
         hash = HashHelper.Combine(hash, (HostAssemblyName ?? "").GetHashCode());
         return hash;
     }

--- a/framework/SimpleModule.Generator/Discovery/DiscoveryDataBuilder.cs
+++ b/framework/SimpleModule.Generator/Discovery/DiscoveryDataBuilder.cs
@@ -31,6 +31,7 @@ internal static class DiscoveryDataBuilder
         List<DiscoveredTypeInfo> knowledgeSources,
         Dictionary<string, string> contractsAssemblyMap,
         bool hasAgentsAssembly,
+        bool hasRagAssembly,
         string hostAssemblyName
     )
     {
@@ -175,6 +176,7 @@ internal static class DiscoveryDataBuilder
                 .ToImmutableArray(),
             contractsAssemblyMap.Keys.ToImmutableArray(),
             hasAgentsAssembly,
+            hasRagAssembly,
             hostAssemblyName
         );
     }

--- a/framework/SimpleModule.Generator/Discovery/SymbolDiscovery.cs
+++ b/framework/SimpleModule.Generator/Discovery/SymbolDiscovery.cs
@@ -255,6 +255,7 @@ internal static class SymbolDiscovery
             knowledgeSources,
             contractsAssemblyMap,
             s.HasAgentsAssembly,
+            s.HasRagAssembly,
             hostAssemblyName
         );
     }

--- a/framework/SimpleModule.Generator/Emitters/AgentExtensionsEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/AgentExtensionsEmitter.cs
@@ -30,6 +30,18 @@ internal sealed class AgentExtensionsEmitter : IEmitter
         );
         sb.AppendLine("    {");
 
+        if (!data.HasAgentsAssembly)
+        {
+            sb.AppendLine("        return services;");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            context.AddSource(
+                "AgentExtensions.g.cs",
+                SourceText.From(sb.ToString(), Encoding.UTF8)
+            );
+            return;
+        }
+
         // Register agent definitions
         foreach (var agent in data.AgentDefinitions)
         {

--- a/framework/SimpleModule.Generator/Emitters/SettingsExtensionsEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/SettingsExtensionsEmitter.cs
@@ -34,11 +34,14 @@ internal sealed class SettingsExtensionsEmitter : IEmitter
             );
         }
 
-        sb.AppendLine();
-        sb.AppendLine("        // RAG settings definitions");
-        sb.AppendLine(
-            "        global::SimpleModule.Rag.RagSettingsDefinitions.Register(settings);"
-        );
+        if (data.HasRagAssembly)
+        {
+            sb.AppendLine();
+            sb.AppendLine("        // RAG settings definitions");
+            sb.AppendLine(
+                "        global::SimpleModule.Rag.RagSettingsDefinitions.Register(settings);"
+            );
+        }
 
         sb.AppendLine();
         sb.AppendLine(

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -145,12 +145,23 @@ public static partial class SimpleModuleHostExtensions
 
             foreach (var info in infos)
             {
-                if (info.ModuleName != DatabaseConstants.HostModuleName)
+                if (scope.ServiceProvider.GetService(info.DbContextType) is not DbContext db)
                     continue;
 
-                if (scope.ServiceProvider.GetService(info.DbContextType) is DbContext db)
+                // DbContexts with EF migrations use MigrateAsync; those without (e.g. scaffolded
+                // module contexts that ship no migrations) fall back to EnsureCreatedAsync so
+                // their tables exist on first run. Only the Host context typically ships
+                // migrations; module contexts rely on the unified HostDbContext for schema.
+                if (info.ModuleName == DatabaseConstants.HostModuleName)
                 {
-                    await db.Database.MigrateAsync();
+                    if (db.Database.GetMigrations().Any())
+                    {
+                        await db.Database.MigrateAsync();
+                    }
+                    else
+                    {
+                        await db.Database.EnsureCreatedAsync();
+                    }
                 }
             }
         }

--- a/tests/SimpleModule.Generator.Tests/TopologicalSortTests.cs
+++ b/tests/SimpleModule.Generator.Tests/TopologicalSortTests.cs
@@ -249,6 +249,7 @@ public class TopologicalSortTests
             ImmutableArray<KnowledgeSourceRecord>.Empty,
             ImmutableArray<string>.Empty,
             false,
+            false,
             "SimpleModule.Host"
         );
 
@@ -323,6 +324,7 @@ public class TopologicalSortTests
             ImmutableArray<AgentToolProviderRecord>.Empty,
             ImmutableArray<KnowledgeSourceRecord>.Empty,
             ImmutableArray<string>.Empty,
+            false,
             false,
             "SimpleModule.Host"
         );
@@ -414,6 +416,7 @@ public class TopologicalSortTests
             ImmutableArray<AgentToolProviderRecord>.Empty,
             ImmutableArray<KnowledgeSourceRecord>.Empty,
             ImmutableArray<string>.Empty,
+            false,
             false,
             "SimpleModule.Host"
         );


### PR DESCRIPTION
## Summary

`sm new project` produced a project that failed to compile, `npm install`, or serve API traffic. This PR fixes the full chain so a freshly-scaffolded app works end-to-end via the standard `npm install && npm run build && dotnet run` flow — no manual patching.

## Root causes & fixes

### Source generator emitted references to assemblies that lean hosts don't reference
[AgentExtensionsEmitter.cs](framework/SimpleModule.Generator/Emitters/AgentExtensionsEmitter.cs) and [SettingsExtensionsEmitter.cs](framework/SimpleModule.Generator/Emitters/SettingsExtensionsEmitter.cs) unconditionally emitted `global::SimpleModule.Agents.AgentRegistry` and `global::SimpleModule.Rag.RagSettingsDefinitions`. A scaffolded host only references `SimpleModule.Hosting`, which does not transitively pull in Agents/Rag, so builds failed with `CS0234: The type or namespace name 'Agents' does not exist in the namespace 'SimpleModule'`.

Gated both emissions on new `HasAgentsAssembly` / `HasRagAssembly` symbol-presence flags in [CoreSymbols.cs](framework/SimpleModule.Generator/Discovery/CoreSymbols.cs) and plumbed them through [DiscoveryData](framework/SimpleModule.Generator/Discovery/DiscoveryData.cs). In-repo host (which does reference Agents/Rag) still gets the full emission.

### Startup DB init never created module tables for scaffolded apps
[SimpleModuleHostExtensions.cs:146](framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs) called `MigrateAsync` on the Host DbContext, but scaffolded apps ship no migrations so no tables were created. First `GET /api/items` returned 500 with `SQLite Error 1: 'no such table: Items_Items'`.

Fall back to `EnsureCreatedAsync` when the context has no migrations; projects with migrations call `MigrateAsync` unchanged.

### CLI `sm new project` generated a broken root `package.json`
[ProjectTemplates.cs:704](cli/SimpleModule.Cli/Templates/ProjectTemplates.cs) had multiple issues:

- Lowercased workspace path (`src/testapp.Host/ClientApp`) — only resolves on case-insensitive filesystems.
- Missing `@simplemodule/tsconfig` dep → vite `TSConfckParseError: failed to resolve "extends":"@simplemodule/tsconfig/base"`.
- Missing `esbuild` peer dep → vite config load fails with `Cannot find module 'esbuild'`.
- `@inertiajs/react@^2.0.0` vs peer `^3.0.0`, `vite@^6.2.0` vs peer `^8.0.0` — both caused `npm install` to ERESOLVE.

Bumped all deps to match the framework packages' peer requirements:

| Dep | Before | After |
|---|---|---|
| `@inertiajs/react` | `^2.0.0` | `^3.0.0` |
| `vite` | `^6.2.0` | `^8.0.3` |
| `@vitejs/plugin-react` | `^4.4.0` | `^6.0.1` |
| `cross-env` | `^7.0.3` | `^10.1.0` |
| `typescript` | `^5.8.0` | `^6.0.2` |
| `tailwindcss` + `@tailwindcss/vite` | `^4.2.1` | `^4.2.2` |
| `@biomejs/biome` | `^2.4.6` | `^2.4.10` |
| `esbuild` | *missing* | `^0.27.0` |
| `@simplemodule/tsconfig` | *missing* | matches framework version |

### Starter module's vite config + scripts were incompatible with vite 8
[NewProjectCommand.cs:494-506](cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs):

- `vite.config.ts` used `__dirname`, which is undefined under vite 8's `configLoader=runner` ESM loader. Switched to `import.meta.dirname` to match the in-repo module convention.
- Starter module `package.json` had `"build": "vite build"` with no `--configLoader runner` flag, causing TS config loads to fail. Updated scripts to `cross-env VITE_MODE=prod vite build --configLoader runner` (and matching `build:dev` / `watch`), matching the in-repo module package.json shape.

## Test plan

- [x] `dotnet build framework/SimpleModule.Generator` succeeds with new HasRagAssembly symbol plumbing
- [x] `dotnet build template/SimpleModule.Host` still succeeds (in-repo host references Agents/Rag)
- [x] Fresh `sm new project DemoApp` scaffolds
- [x] `npm install` resolves cleanly with no ERESOLVE errors (191 packages, no `--legacy-peer-deps` needed)
- [x] `npm run build` produces `wwwroot/js/app.js` + `Items.pages.js`
- [x] `dotnet build` on the scaffolded project succeeds (0 errors) — generator no longer emits dangling Agent/Rag references
- [x] `dotnet run` starts the host; `EnsureCreated` creates `Items_Items` table on first boot
- [x] `GET /api/items` returns `HTTP 200` `[]`
- [x] `GET /` returns `HTTP 200` with the Inertia welcome page
- [x] `GET /swagger/v1/swagger.json` exposes `/api/items`