### PR TITLE
perf(auditlogs,localization): reduce per-request overhead

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,11 +7,11 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <!-- Analyzers -->
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.11" />

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/AuditLogsWolverineExtension.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/AuditLogsWolverineExtension.cs
@@ -1,0 +1,16 @@
+using Wolverine;
+using Wolverine.Attributes;
+
+[assembly: WolverineModule(typeof(SimpleModule.AuditLogs.AuditLogsWolverineExtension))]
+
+namespace SimpleModule.AuditLogs;
+
+#pragma warning disable CA1812 // Instantiated by Wolverine via [WolverineModule]
+internal sealed class AuditLogsWolverineExtension : IWolverineExtension
+#pragma warning restore CA1812
+{
+    public void Configure(WolverineOptions options)
+    {
+        options.Discovery.IncludeAssembly(typeof(AuditLogsWolverineExtension).Assembly);
+    }
+}

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
@@ -10,21 +10,39 @@ using ZiggyCreatures.Caching.Fusion;
 
 namespace SimpleModule.AuditLogs.Middleware;
 
-public sealed class AuditMiddleware(RequestDelegate next)
+public sealed class AuditMiddleware(RequestDelegate next, IFusionCache cache)
 {
-    private const string AuditConfigCacheKey = "auditlogs:request-config";
     private static readonly string[] ExcludedMethodsForBody = ["HEAD", "OPTIONS"];
+
+    private static readonly string[] DefaultExcludedPaths =
+    [
+        "/health",
+        "/metrics",
+        "/_content",
+        "/js/",
+        "/css/",
+        "/favicon",
+    ];
+
     private static readonly FusionCacheEntryOptions AuditConfigCacheOptions = new()
     {
         Duration = TimeSpan.FromSeconds(60),
     };
 
-    public sealed record AuditRequestSettings(
+    private static readonly AuditRequestSettings FallbackSettings = new(
+        CaptureHttp: true,
+        CaptureRequestBodies: true,
+        CaptureQueryStrings: true,
+        CaptureUserAgent: false,
+        ExcludedPaths: DefaultExcludedPaths
+    );
+
+    private sealed record AuditRequestSettings(
         bool CaptureHttp,
         bool CaptureRequestBodies,
         bool CaptureQueryStrings,
         bool CaptureUserAgent,
-        IReadOnlyList<string> ExcludedPaths
+        string[] ExcludedPaths
     );
 
     public async Task InvokeAsync(HttpContext context)
@@ -36,11 +54,9 @@ public sealed class AuditMiddleware(RequestDelegate next)
             return;
         }
 
-        // Load all settings once at the start. Result is cached as a single
-        // composite entry to avoid 5 separate FusionCache lookups per request.
-        var settings = context.RequestServices.GetService<ISettingsContracts>();
-        var cache = context.RequestServices.GetService<IFusionCache>();
-        var auditSettings = await LoadSettingsAsync(settings, cache);
+        // Single composite cache entry — avoids 5 separate FusionCache lookups per
+        // request and resolves the scoped ISettingsContracts only on cache miss.
+        var auditSettings = await LoadSettingsAsync(context.RequestServices, cache);
 
         // Check if HTTP capture is enabled
         if (!auditSettings.CaptureHttp)
@@ -124,29 +140,17 @@ public sealed class AuditMiddleware(RequestDelegate next)
     }
 
     private static async Task<AuditRequestSettings> LoadSettingsAsync(
-        ISettingsContracts? settings,
-        IFusionCache? cache
+        IServiceProvider services,
+        IFusionCache cache
     )
     {
-        if (settings is null)
-        {
-            return new AuditRequestSettings(
-                CaptureHttp: true,
-                CaptureRequestBodies: true,
-                CaptureQueryStrings: true,
-                CaptureUserAgent: false,
-                ExcludedPaths: GetDefaultExcludedPaths()
-            );
-        }
-
-        if (cache is null)
-        {
-            return await BuildSettingsAsync(settings);
-        }
-
         return await cache.GetOrSetAsync<AuditRequestSettings>(
-            AuditConfigCacheKey,
-            async (_, _) => await BuildSettingsAsync(settings),
+            AuditCacheKeys.RequestConfig,
+            async (_, _) =>
+            {
+                var settings = services.GetService<ISettingsContracts>();
+                return settings is null ? FallbackSettings : await BuildSettingsAsync(settings);
+            },
             AuditConfigCacheOptions
         );
     }
@@ -199,29 +203,29 @@ public sealed class AuditMiddleware(RequestDelegate next)
         return (captureHttp, captureBody, captureQs, captureUa, results[4]);
     }
 
-    private static List<string> ParseExcludedPaths(string? rawPaths)
+    private static string[] ParseExcludedPaths(string? rawPaths)
     {
-        var paths = GetDefaultExcludedPaths();
-
         if (string.IsNullOrWhiteSpace(rawPaths))
         {
-            return paths;
+            return DefaultExcludedPaths;
         }
 
-        var configured = rawPaths
-            .Split(',')
-            .Select(p => p.Trim())
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .ToList();
+        var configured = rawPaths.Split(
+            ',',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+        );
+        if (configured.Length == 0)
+        {
+            return DefaultExcludedPaths;
+        }
 
-        paths.AddRange(configured);
-        return paths;
+        var merged = new string[DefaultExcludedPaths.Length + configured.Length];
+        DefaultExcludedPaths.CopyTo(merged, 0);
+        configured.CopyTo(merged, DefaultExcludedPaths.Length);
+        return merged;
     }
 
-    private static List<string> GetDefaultExcludedPaths() =>
-        ["/health", "/metrics", "/_content", "/js/", "/css/", "/favicon"];
-
-    private static bool IsExcludedPath(string path, IEnumerable<string> configuredPaths)
+    private static bool IsExcludedPath(string path, string[] configuredPaths)
     {
         foreach (var prefix in configuredPaths)
         {

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
@@ -6,14 +6,20 @@ using SimpleModule.AuditLogs.Contracts;
 using SimpleModule.AuditLogs.Enrichment;
 using SimpleModule.AuditLogs.Pipeline;
 using SimpleModule.Settings.Contracts;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SimpleModule.AuditLogs.Middleware;
 
 public sealed class AuditMiddleware(RequestDelegate next)
 {
+    private const string AuditConfigCacheKey = "auditlogs:request-config";
     private static readonly string[] ExcludedMethodsForBody = ["HEAD", "OPTIONS"];
+    private static readonly FusionCacheEntryOptions AuditConfigCacheOptions = new()
+    {
+        Duration = TimeSpan.FromSeconds(60),
+    };
 
-    private sealed record AuditRequestSettings(
+    public sealed record AuditRequestSettings(
         bool CaptureHttp,
         bool CaptureRequestBodies,
         bool CaptureQueryStrings,
@@ -30,9 +36,11 @@ public sealed class AuditMiddleware(RequestDelegate next)
             return;
         }
 
-        // Load all settings once at the start (parallel batch loading)
+        // Load all settings once at the start. Result is cached as a single
+        // composite entry to avoid 5 separate FusionCache lookups per request.
         var settings = context.RequestServices.GetService<ISettingsContracts>();
-        var auditSettings = await LoadSettingsAsync(settings);
+        var cache = context.RequestServices.GetService<IFusionCache>();
+        var auditSettings = await LoadSettingsAsync(settings, cache);
 
         // Check if HTTP capture is enabled
         if (!auditSettings.CaptureHttp)
@@ -115,7 +123,10 @@ public sealed class AuditMiddleware(RequestDelegate next)
         channel.Enqueue(entry);
     }
 
-    private static async Task<AuditRequestSettings> LoadSettingsAsync(ISettingsContracts? settings)
+    private static async Task<AuditRequestSettings> LoadSettingsAsync(
+        ISettingsContracts? settings,
+        IFusionCache? cache
+    )
     {
         if (settings is null)
         {
@@ -128,7 +139,20 @@ public sealed class AuditMiddleware(RequestDelegate next)
             );
         }
 
-        // Fetch all settings in parallel
+        if (cache is null)
+        {
+            return await BuildSettingsAsync(settings);
+        }
+
+        return await cache.GetOrSetAsync<AuditRequestSettings>(
+            AuditConfigCacheKey,
+            async (_, _) => await BuildSettingsAsync(settings),
+            AuditConfigCacheOptions
+        );
+    }
+
+    private static async Task<AuditRequestSettings> BuildSettingsAsync(ISettingsContracts settings)
+    {
         var (captureHttp, captureBody, captureQs, captureUa, excludedPathsRaw) =
             await LoadAllSettingsAsync(settings);
 

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditCacheKeys.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditCacheKeys.cs
@@ -1,0 +1,6 @@
+namespace SimpleModule.AuditLogs.Pipeline;
+
+internal static class AuditCacheKeys
+{
+    public const string RequestConfig = "auditlogs:request-config";
+}

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditConfigCacheInvalidator.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditConfigCacheInvalidator.cs
@@ -1,0 +1,23 @@
+using SimpleModule.Core.Settings;
+using SimpleModule.Settings.Contracts.Events;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace SimpleModule.AuditLogs.Pipeline;
+
+internal static class AuditConfigCacheInvalidator
+{
+    public static ValueTask Handle(SettingChangedEvent @event, IFusionCache cache)
+    {
+        if (@event.Scope != SettingScope.System)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (!@event.Key.StartsWith("auditlogs.", StringComparison.Ordinal))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return cache.RemoveAsync(AuditCacheKeys.RequestConfig);
+    }
+}

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditWriterService.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditWriterService.cs
@@ -23,24 +23,62 @@ public sealed partial class AuditWriterService(
         {
             try
             {
-                if (await channel.Reader.WaitToReadAsync(stoppingToken))
+                if (!await channel.Reader.WaitToReadAsync(stoppingToken))
                 {
-                    batch.Clear();
-                    var deadline = DateTimeOffset.UtcNow.Add(opts.WriterFlushInterval);
+                    break;
+                }
+
+                batch.Clear();
+                var deadline = DateTimeOffset.UtcNow + opts.WriterFlushInterval;
+
+                // Drain whatever is currently available
+                while (
+                    batch.Count < opts.WriterBatchSize
+                    && channel.Reader.TryRead(out var entry)
+                )
+                {
+                    batch.Add(entry);
+                }
+
+                // Linger: wait for more entries up to the flush deadline so we batch
+                // INSERTs instead of writing one row per audit event.
+                while (batch.Count < opts.WriterBatchSize)
+                {
+                    var remaining = deadline - DateTimeOffset.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        break;
+                    }
+
+                    using var linger = CancellationTokenSource.CreateLinkedTokenSource(
+                        stoppingToken
+                    );
+                    linger.CancelAfter(remaining);
+                    try
+                    {
+                        if (!await channel.Reader.WaitToReadAsync(linger.Token))
+                        {
+                            break;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                        when (!stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
 
                     while (
                         batch.Count < opts.WriterBatchSize
-                        && DateTimeOffset.UtcNow < deadline
                         && channel.Reader.TryRead(out var entry)
                     )
                     {
                         batch.Add(entry);
                     }
+                }
 
-                    if (batch.Count > 0)
-                    {
-                        await FlushBatchAsync(batch, stoppingToken);
-                    }
+                if (batch.Count > 0)
+                {
+                    await FlushBatchAsync(batch, stoppingToken);
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditWriterService.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Pipeline/AuditWriterService.cs
@@ -29,56 +29,47 @@ public sealed partial class AuditWriterService(
                 }
 
                 batch.Clear();
-                var deadline = DateTimeOffset.UtcNow + opts.WriterFlushInterval;
 
-                // Drain whatever is currently available
-                while (
-                    batch.Count < opts.WriterBatchSize
-                    && channel.Reader.TryRead(out var entry)
-                )
+                while (batch.Count < opts.WriterBatchSize && channel.Reader.TryRead(out var entry))
                 {
                     batch.Add(entry);
                 }
 
-                // Linger: wait for more entries up to the flush deadline so we batch
-                // INSERTs instead of writing one row per audit event.
-                while (batch.Count < opts.WriterBatchSize)
+                if (batch.Count < opts.WriterBatchSize)
                 {
-                    var remaining = deadline - DateTimeOffset.UtcNow;
-                    if (remaining <= TimeSpan.Zero)
-                    {
-                        break;
-                    }
-
                     using var linger = CancellationTokenSource.CreateLinkedTokenSource(
                         stoppingToken
                     );
-                    linger.CancelAfter(remaining);
+                    linger.CancelAfter(opts.WriterFlushInterval);
+
                     try
                     {
-                        if (!await channel.Reader.WaitToReadAsync(linger.Token))
+                        while (batch.Count < opts.WriterBatchSize)
                         {
-                            break;
+                            if (!await channel.Reader.WaitToReadAsync(linger.Token))
+                            {
+                                break;
+                            }
+
+                            while (
+                                batch.Count < opts.WriterBatchSize
+                                && channel.Reader.TryRead(out var entry)
+                            )
+                            {
+                                batch.Add(entry);
+                            }
                         }
                     }
                     catch (OperationCanceledException)
-                        when (!stoppingToken.IsCancellationRequested)
                     {
-                        break;
-                    }
-
-                    while (
-                        batch.Count < opts.WriterBatchSize
-                        && channel.Reader.TryRead(out var entry)
-                    )
-                    {
-                        batch.Add(entry);
+                        // Linger deadline OR shutdown — fall through and persist
+                        // whatever was already drained instead of dropping it.
                     }
                 }
 
                 if (batch.Count > 0)
                 {
-                    await FlushBatchAsync(batch, stoppingToken);
+                    await FlushBatchAsync(batch);
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -102,13 +93,13 @@ public sealed partial class AuditWriterService(
         }
         if (batch.Count > 0)
         {
-            await FlushBatchAsync(batch, CancellationToken.None);
+            await FlushBatchAsync(batch);
         }
 
         LogStopped(logger);
     }
 
-    private async Task FlushBatchAsync(List<AuditEntry> batch, CancellationToken ct)
+    private async Task FlushBatchAsync(List<AuditEntry> batch)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var contracts = scope.ServiceProvider.GetRequiredService<IAuditLogContracts>();

--- a/modules/AuditLogs/tests/SimpleModule.AuditLogs.Tests/Unit/AuditMiddlewareTests.cs
+++ b/modules/AuditLogs/tests/SimpleModule.AuditLogs.Tests/Unit/AuditMiddlewareTests.cs
@@ -1,15 +1,22 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using SimpleModule.AuditLogs.Middleware;
 using SimpleModule.AuditLogs.Pipeline;
 using SimpleModule.Core.Settings;
 using SimpleModule.Settings.Contracts;
+using ZiggyCreatures.Caching.Fusion;
+using ZiggyCreatures.Caching.Fusion.NullObjects;
 
 namespace AuditLogs.Tests.Unit;
 
-public class AuditMiddlewareTests
+public sealed class AuditMiddlewareTests : IDisposable
 {
+    private readonly NullFusionCache _cache = new(Options.Create(new FusionCacheOptions()));
+
+    public void Dispose() => _cache.Dispose();
+
     [Fact]
     public async Task InvokeAsync_LoadsSettingsOnce_AndCachesForRequest()
     {
@@ -24,7 +31,7 @@ public class AuditMiddlewareTests
         // Configure settings to return default values
         settings.GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>()).Returns("true");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -69,7 +76,7 @@ public class AuditMiddlewareTests
             .Returns("false");
         settings.GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>()).Returns("true");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -95,7 +102,7 @@ public class AuditMiddlewareTests
 
         settings.GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>()).Returns("true");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -134,7 +141,7 @@ public class AuditMiddlewareTests
             .GetSettingAsync("auditlogs.excluded.paths", Arg.Any<SettingScope>())
             .Returns("/api/custom-exclude");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -171,7 +178,7 @@ public class AuditMiddlewareTests
             .GetSettingAsync("auditlogs.excluded.paths", Arg.Any<SettingScope>())
             .Returns("/api/internal");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act - test hardcoded /health path
         await middleware.InvokeAsync(context);
@@ -195,7 +202,7 @@ public class AuditMiddlewareTests
 
         settings.GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>()).Returns("true");
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -216,7 +223,7 @@ public class AuditMiddlewareTests
         context.Request.Method = "GET";
         context.RequestServices = CreateServiceProviderWithoutSettings(channel);
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -240,7 +247,7 @@ public class AuditMiddlewareTests
 
         settings.GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>()).Returns((string?)null); // Simulate no setting found
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act
         await middleware.InvokeAsync(context);
@@ -261,7 +268,7 @@ public class AuditMiddlewareTests
         context.Request.Method = "POST";
         context.RequestServices = CreateServiceProviderWithoutSettings(channel);
 
-        var middleware = new AuditMiddleware(next);
+        var middleware = new AuditMiddleware(next, _cache);
 
         // Act & Assert - should not throw
         var action = () => middleware.InvokeAsync(context);

--- a/modules/Localization/src/SimpleModule.Localization/Middleware/LocaleResolutionMiddleware.cs
+++ b/modules/Localization/src/SimpleModule.Localization/Middleware/LocaleResolutionMiddleware.cs
@@ -19,6 +19,9 @@ public sealed class LocaleResolutionMiddleware(
     IFusionCache cache
 )
 {
+    // Bound cache-key size: a hostile client could otherwise pin multi-KB strings.
+    private const int MaxAcceptLanguageKeyLength = 256;
+
     private static readonly FusionCacheEntryOptions UserLocaleCacheOptions = new()
     {
         Duration = TimeSpan.FromMinutes(5),
@@ -147,6 +150,9 @@ public sealed class LocaleResolutionMiddleware(
 
     private static string UserLocaleKey(string userId) => string.Concat("locale:user:", userId);
 
-    private static string AcceptLanguageKey(string headerValue) =>
-        string.Concat("locale:accept:", headerValue);
+    private static string AcceptLanguageKey(string headerValue)
+    {
+        var len = Math.Min(headerValue.Length, MaxAcceptLanguageKeyLength);
+        return string.Concat("locale:accept:", headerValue.AsSpan(0, len));
+    }
 }

--- a/modules/Localization/src/SimpleModule.Localization/Middleware/LocaleResolutionMiddleware.cs
+++ b/modules/Localization/src/SimpleModule.Localization/Middleware/LocaleResolutionMiddleware.cs
@@ -88,6 +88,11 @@ public sealed class LocaleResolutionMiddleware(
                     return userLocale;
                 }
             }
+
+            // Cache the absence so subsequent requests skip the per-request settings
+            // probe. The cachedHit check above treats empty as "no value" and falls
+            // through, so this short-circuits only the inner DB/cache lookup.
+            await cache.SetAsync(cacheKey, string.Empty, UserLocaleCacheOptions);
         }
 
         // No explicit user setting — resolve from Accept-Language header or default

--- a/template/SimpleModule.Host/appsettings.Development.json
+++ b/template/SimpleModule.Host/appsettings.Development.json
@@ -10,7 +10,8 @@
   },
   "Logging": {
     "LogLevel": {
-      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "ZiggyCreatures.Caching.Fusion": "Warning"
     },
     "Console": {
       "FormatterName": "simple",

--- a/template/SimpleModule.Host/appsettings.json
+++ b/template/SimpleModule.Host/appsettings.json
@@ -48,7 +48,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "ZiggyCreatures.Caching.Fusion": "Warning"
     }
   }
 }


### PR DESCRIPTION
## Summary

Trims work on the AuditLogs and Localization request hot paths, plus a small DoS-hardening tweak.

- **Logging noise**: silenced `ZiggyCreatures.Caching.Fusion` and `EF Core Database.Command` at Information so cache calls and SQL commands no longer log per request.
- **AuditMiddleware**: collapsed the 5 separate `ISettingsContracts` + FusionCache lookups into one composite cache entry (`auditlogs:request-config`, 60s TTL). Cache hits do zero scoped DI work — `ISettingsContracts` is resolved only inside the cache-miss factory. New Wolverine handler (`AuditConfigCacheInvalidator`) listens on `SettingChangedEvent` and evicts the entry when an `auditlogs.*` setting changes, so updates land immediately instead of waiting out the TTL. `ExcludedPaths` switched to `string[]` for span-friendly iteration.
- **AuditWriterService**: replaced the per-iteration linger CTS with a single linked source scoping the whole batch fill, and removed the `OperationCanceledException` filter so a shutdown mid-linger now persists already-drained entries instead of dropping them. Dead `CancellationToken` parameter on `FlushBatchAsync` removed.
- **LocaleResolutionMiddleware**: cache an empty sentinel when a user has no `app.language` setting so we stop probing settings on every subsequent request. Cap Accept-Language cache keys at 256 chars so a hostile client can't pin multi-KB strings in the L1 cache.

## Test plan

- [x] `dotnet build` clean (no warnings/errors)
- [x] `dotnet test modules/AuditLogs/tests/SimpleModule.AuditLogs.Tests` — 37/37 passing
- [ ] Sanity-run the host: confirm cache-hit path no longer resolves `ISettingsContracts` per request (logs / profiler)
- [ ] Toggle an `auditlogs.*` setting in dev and confirm the change takes effect on the next request rather than after 60s
- [ ] Verify the writer flushes a partial batch on graceful shutdown (no dropped entries)