### PR TITLE
fix(pack): ship static web assets in module .nupkgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,29 @@ jobs:
           path: tests/e2e/playwright-report/
           retention-days: 14
 
+  pack-smoke:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+      - run: dotnet restore
+      - run: dotnet pack -c Release -p:Version=0.0.0-ci --no-restore -o ./nupkgs
+
+      - name: Verify module .nupkgs contain static web assets
+        run: node scripts/verify-nupkg-static-assets.mjs ./nupkgs
+
   docker:
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm run build
       - run: dotnet restore
       - run: dotnet pack -c Release -p:Version=${{ needs.release.outputs.version }} --no-restore -o ./nupkgs
       - run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/modules/Directory.Build.targets
+++ b/modules/Directory.Build.targets
@@ -23,9 +23,20 @@
   >
     <Warning Text="node_modules not found. Frontend JavaScript will not be compiled. Run 'npm install' in the repository root." />
   </Target>
+  <!--
+    Run BEFORE the targets that enumerate static web assets so the wwwroot/
+    contents Vite emits are visible to:
+      - Build (runtime path)
+      - ResolveStaticWebAssetsConfiguration / ResolveProjectStaticWebAssets (build-time manifest)
+      - GetCopyToOutputDirectoryItems (consumers via ProjectReference)
+      - GenerateNuspec (Pack — packaged staticwebassets/ tree)
+    Hooking only into Build leaves a hole for `dotnet pack` invoked with
+    no-build, and has historically produced .nupkg files with an empty
+    wwwroot in CI.
+  -->
   <Target
     Name="JsBuild"
-    BeforeTargets="Build"
+    BeforeTargets="Build;ResolveStaticWebAssetsConfiguration;ResolveProjectStaticWebAssets;GetCopyToOutputDirectoryItems;GenerateNuspec"
     Condition="Exists('package.json') And (Exists('node_modules') Or Exists('$(RepoRoot)node_modules')) And '@(JsSourceFiles)' != ''"
     Inputs="@(JsSourceFiles)"
     Outputs="$(JsBuildStamp)"
@@ -33,5 +44,29 @@
     <Exec Command="$(JsBuildCommand)" WorkingDirectory="$(MSBuildProjectDirectory)" />
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <Touch Files="$(JsBuildStamp)" AlwaysCreate="true" />
+  </Target>
+  <!--
+    The StaticWebAssets SDK evaluates `Content Include="wwwroot\**"` during
+    MSBuild item evaluation, which runs BEFORE any target executes. On a
+    clean checkout wwwroot/ doesn't exist yet, so Content has no entries by
+    the time ResolveProjectStaticWebAssets enumerates @(Content). Even if
+    JsBuild later populates wwwroot/ via Vite, the static-web-asset chain
+    has already locked in an empty file list.
+
+    Re-include wwwroot files into @(Content) after JsBuild has run, before
+    ResolveProjectStaticWebAssets fires, so the SDK sees the actual built
+    output. Mirrors the wildcard from the SDK's StaticAssets.ProjectSystem
+    props (Content Include="wwwroot\**").
+  -->
+  <Target
+    Name="ReincludeWwwrootContent"
+    AfterTargets="JsBuild"
+    BeforeTargets="ResolveProjectStaticWebAssets"
+    Condition="Exists('$(MSBuildProjectDirectory)\wwwroot')"
+  >
+    <ItemGroup>
+      <_WwwrootFiles Include="wwwroot\**" Exclude="@(Content);$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+      <Content Include="@(_WwwrootFiles)" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/scripts/verify-nupkg-static-assets.mjs
+++ b/scripts/verify-nupkg-static-assets.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Verify packed module .nupkgs contain their built static web assets.
+//
+// For every UI-shipping module (modules/*/src/*/ with a package.json next to
+// the .csproj), assert the corresponding `{Id}.{version}.nupkg` contains
+// `staticwebassets/{Id}.pages.js` (the SDK strips the `wwwroot/` prefix
+// when packaging) and at least one .mjs code-split chunk — that combination
+// matches the failure mode where 0.0.33 shipped only the .dll and content/.
+//
+// Usage: node scripts/verify-nupkg-static-assets.mjs <nupkg-dir>
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const nupkgDir = process.argv[2];
+if (!nupkgDir) {
+  console.error('Usage: verify-nupkg-static-assets.mjs <nupkg-dir>');
+  process.exit(2);
+}
+
+const modulesDir = join(repoRoot, 'modules');
+const moduleDirs = readdirSync(modulesDir)
+  .map((name) => join(modulesDir, name, 'src'))
+  .filter((p) => existsSync(p) && statSync(p).isDirectory())
+  .flatMap((srcDir) =>
+    readdirSync(srcDir)
+      .map((name) => join(srcDir, name))
+      .filter((p) => statSync(p).isDirectory()),
+  );
+
+const uiModules = moduleDirs.filter((dir) => {
+  const csproj = readdirSync(dir).find((f) => f.endsWith('.csproj'));
+  return csproj && existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'Pages', 'index.ts'));
+});
+
+if (uiModules.length === 0) {
+  console.error('No UI-shipping modules discovered under modules/.');
+  process.exit(2);
+}
+
+const nupkgs = readdirSync(nupkgDir).filter((f) => f.endsWith('.nupkg') && !f.endsWith('.symbols.nupkg'));
+
+let failures = 0;
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+for (const moduleDir of uiModules) {
+  const id = basename(moduleDir);
+  const matcher = new RegExp(`^${escapeRegExp(id)}\\.\\d+\\.\\d+\\.\\d+(?:[-+][\\w.+-]+)?\\.nupkg$`);
+  const nupkg = nupkgs.find((f) => matcher.test(f));
+  if (!nupkg) {
+    console.error(`FAIL ${id}: no matching .nupkg in ${nupkgDir}`);
+    failures++;
+    continue;
+  }
+
+  const listing = execFileSync('unzip', ['-Z1', join(nupkgDir, nupkg)], { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+
+  const pagesJs = `staticwebassets/${id}.pages.js`;
+  const hasPagesJs = listing.includes(pagesJs);
+  const hasMjsChunk = listing.some((p) => p.startsWith('staticwebassets/') && p.endsWith('.mjs'));
+  const hasBuildProps = listing.includes(`build/${id}.props`);
+
+  if (hasPagesJs && hasMjsChunk && hasBuildProps) {
+    console.log(`OK   ${id}: ${nupkg}`);
+  } else {
+    console.error(`FAIL ${id}: ${nupkg}`);
+    if (!hasPagesJs) console.error(`     missing ${pagesJs}`);
+    if (!hasMjsChunk) console.error('     no .mjs chunks under staticwebassets/');
+    if (!hasBuildProps) console.error(`     missing build/${id}.props`);
+    failures++;
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} module package(s) missing static web assets.`);
+  process.exit(1);
+}
+
+console.log(`\nVerified ${uiModules.length} module package(s).`);


### PR DESCRIPTION
## Summary

`SimpleModule.Users` 0.0.33 (and every other UI-shipping module) was published with an empty `staticwebassets/` tree, so consumers got a 404 for `/_content/SimpleModule.Users/SimpleModule.Users.pages.js` and the login page rendered blank. Two independent root causes; this PR fixes both, and adds a CI smoke test so the next regression of this shape is caught at PR time.

## Root causes

1. **Release workflow never built the JS.** `publish-nuget` ran `npm ci` then jumped straight to `dotnet pack`, with no `npm run build` in between. On a clean CI checkout each module's `wwwroot/` was empty when pack ran, so the SDK had nothing to package.

2. **`Microsoft.NET.Sdk.StaticWebAssets` evaluates `Content Include="wwwroot/**"` during MSBuild item evaluation, which runs before any target executes.** Even with the existing `JsBuild` MSBuild target (`BeforeTargets="Build"`), the SDK had already locked in an empty file list by the time Vite ran. So `dotnet pack` invoked outside the workflow (or after a `git clean`) would still produce an empty package — the workflow fix alone wasn't enough.

## Changes

### 1. `npm run build` before `dotnet pack` (release workflow)
Inserted between `npm ci` and `dotnet restore` in `.github/workflows/release.yml` so module `wwwroot/` directories are populated before pack runs. Belt-and-suspenders alongside the MSBuild fix below; also a perf win because the orchestrator builds modules in parallel.

### 2. MSBuild: pre-populate `@(Content)` from built `wwwroot/` (`modules/Directory.Build.targets`)

- Broadened `JsBuild`'s `BeforeTargets` to also fire before `ResolveStaticWebAssetsConfiguration`, `ResolveProjectStaticWebAssets`, `GetCopyToOutputDirectoryItems`, and `GenerateNuspec` — covers `dotnet pack` invoked outside the Build chain.
- Added a `ReincludeWwwrootContent` target (`AfterTargets="JsBuild" BeforeTargets="ResolveProjectStaticWebAssets"`) that re-adds `wwwroot/**` to `@(Content)` from inside MSBuild execution, after Vite has run. This is the actual fix for the cold-build case — without it, `dotnet pack` from a clean checkout still produces an empty `staticwebassets/` tree even with the workflow fix.

### 3. CI smoke job (`pack-smoke`) + verification script

- New `scripts/verify-nupkg-static-assets.mjs` discovers UI-shipping modules (`modules/*/src/*/` with a `package.json` next to a `.csproj` and a `Pages/index.ts`), then asserts each matching `.nupkg` contains:
  - `staticwebassets/{Id}.pages.js` (the SDK strips the `wwwroot/` prefix when packaging)
  - at least one `.mjs` code-split chunk under `staticwebassets/`
  - `build/{Id}.props` (the manifest plumbing consumers need to pick up the assets)
- New `pack-smoke` job in `.github/workflows/ci.yml` runs `dotnet pack` exactly the way release does, then runs the verifier — so the next time a module ships an empty package, CI fails before merge.

## Verification

Locally, with everything cleaned (`rm -rf wwwroot obj bin`):
- Cold pack of `SimpleModule.Users`: now 89 entries including `staticwebassets/SimpleModule.Users.pages.js`, all `.mjs` chunks, and `build/SimpleModule.Users.props`.
- Cold pack of `SimpleModule.Settings`: now 29 entries including `staticwebassets/SimpleModule.Settings.pages.js`, the smaller chunk set, and `build/SimpleModule.Settings.props`.
- Warm-cache repack: identical output, no duplicate Content items (verified the `Exclude="@(Content)"` guard works).
- Verifier passes for both packed modules; correctly fails when a module's `.nupkg` is missing (regression check).

## Test plan

- [ ] CI's new `pack-smoke` job runs `npm run build` + `dotnet pack` + verifier and reports green.
- [ ] On the next release, inspect a published module `.nupkg` (e.g. `SimpleModule.Users 0.0.34`) and confirm it contains `staticwebassets/SimpleModule.Users.pages.js`, the `.mjs` chunks, and `build/SimpleModule.Users.props`.
- [ ] Reference the new package version from a fresh consumer app and verify `/_content/SimpleModule.Users/SimpleModule.Users.pages.js` returns 200 and the login page renders end-to-end.