### PR TITLE
feat(cli): add `sm skill` commands for managing Claude skills

### DIFF
--- a/cli/SimpleModule.Cli/Commands/Skill/SkillAddCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillAddCommand.cs
@@ -1,0 +1,117 @@
+using SimpleModule.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillAddCommand : AsyncCommand<SkillAddSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, SkillAddSettings settings)
+    {
+        var solution = SolutionContext.Discover();
+        if (solution is null)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]No .slnx file found. Run this command from inside a SimpleModule project.[/]"
+            );
+            return 1;
+        }
+
+        var name = settings.ResolveName();
+        var skillDir = SkillWriter.GetSkillDirectory(solution.RootPath, name);
+
+        if (Directory.Exists(skillDir) && !settings.Force && !settings.DryRun)
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]Skill '{Markup.Escape(name)}' already exists at {Markup.Escape(Path.GetRelativePath(solution.RootPath, skillDir))}. Use --force to overwrite or 'sm skill update' to refresh.[/]"
+            );
+            return 1;
+        }
+
+        SkillSource source;
+        FetchedSkill fetched;
+
+        if (string.IsNullOrWhiteSpace(settings.Source))
+        {
+            source = new SkillSource(SkillSourceType.Scaffold, "scaffold");
+            fetched = SkillWriter.BuildScaffold(name, settings.Description);
+            AnsiConsole.MarkupLine($"[blue]Scaffolding new skill '{Markup.Escape(name)}'.[/]");
+        }
+        else
+        {
+            source = SkillSource.Parse(settings.Source!);
+            AnsiConsole.MarkupLine(
+                $"[blue]Fetching skill '{Markup.Escape(name)}' from {Markup.Escape(source.Type.ToString().ToLowerInvariant())} source '{Markup.Escape(source.CanonicalSource)}'...[/]"
+            );
+
+            try
+            {
+                using var fetcher = new HttpClient();
+                var skillFetcher = new SkillFetcher(fetcher);
+                fetched = await skillFetcher.FetchAsync(source).ConfigureAwait(false);
+            }
+            catch (HttpRequestException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Failed to fetch skill: {Markup.Escape(ex.Message)}[/]"
+                );
+                return 1;
+            }
+            catch (IOException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Failed to fetch skill: {Markup.Escape(ex.Message)}[/]"
+                );
+                return 1;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Failed to fetch skill: {Markup.Escape(ex.Message)}[/]"
+                );
+                return 1;
+            }
+        }
+
+        if (settings.DryRun)
+        {
+            AnsiConsole.MarkupLine("[yellow]Dry run — no files will be written.[/]");
+            foreach (var file in fetched.Files)
+            {
+                var rel = Path.GetRelativePath(
+                    solution.RootPath,
+                    Path.Combine(skillDir, file.RelativePath)
+                );
+                AnsiConsole.MarkupLine($"  [green]CREATE[/] {Markup.Escape(rel)}");
+            }
+
+            AnsiConsole.MarkupLine(
+                $"  [green]UPDATE[/] {Markup.Escape(SkillsLockFile.FileName)} (entry '{Markup.Escape(name)}')"
+            );
+            return 0;
+        }
+
+        var written = SkillWriter.WriteFiles(skillDir, fetched.Files, replace: settings.Force);
+        foreach (var path in written)
+        {
+            var rel = Path.GetRelativePath(solution.RootPath, Path.Combine(skillDir, path));
+            AnsiConsole.MarkupLine($"  [green]CREATE[/] {Markup.Escape(rel)}");
+        }
+
+        var lockFile = SkillsLockFile.Load(solution.RootPath);
+        lockFile.Skills[name] = new SkillsLockEntry
+        {
+            Source = source.CanonicalSource,
+            SourceType = source.SourceTypeId,
+            Ref = source.Ref,
+            ComputedHash = fetched.ComputedHash,
+        };
+        lockFile.Save(solution.RootPath);
+
+        AnsiConsole.MarkupLine($"  [green]UPDATE[/] {Markup.Escape(SkillsLockFile.FileName)}");
+        AnsiConsole.MarkupLine(
+            $"\n[green]Skill '{Markup.Escape(name)}' added.[/] [dim]({fetched.Files.Count} file(s), hash {fetched.ComputedHash[..8]})[/]"
+        );
+        return 0;
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillAddCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillAddCommand.cs
@@ -46,23 +46,7 @@ public sealed class SkillAddCommand : AsyncCommand<SkillAddSettings>
 
             try
             {
-                using var fetcher = new HttpClient();
-                var skillFetcher = new SkillFetcher(fetcher);
-                fetched = await skillFetcher.FetchAsync(source).ConfigureAwait(false);
-            }
-            catch (HttpRequestException ex)
-            {
-                AnsiConsole.MarkupLine(
-                    $"[red]Failed to fetch skill: {Markup.Escape(ex.Message)}[/]"
-                );
-                return 1;
-            }
-            catch (IOException ex)
-            {
-                AnsiConsole.MarkupLine(
-                    $"[red]Failed to fetch skill: {Markup.Escape(ex.Message)}[/]"
-                );
-                return 1;
+                fetched = await new SkillFetcher().FetchAsync(source).ConfigureAwait(false);
             }
             catch (InvalidOperationException ex)
             {

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillAddSettings.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillAddSettings.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillAddSettings : CommandSettings
+{
+    [CommandArgument(0, "[name]")]
+    [Description("Skill name in kebab-case (e.g. shadcn, react-expert)")]
+    public string? Name { get; set; }
+
+    [CommandOption("--source <SOURCE>")]
+    [Description(
+        "Source for the skill. GitHub: 'owner/repo' optionally followed by '/path' and '@ref'. Local: a directory path. Omit to scaffold a new template."
+    )]
+    public string? Source { get; set; }
+
+    [CommandOption("--description <TEXT>")]
+    [Description("Description used when scaffolding a new skill (only when --source is omitted).")]
+    public string? Description { get; set; }
+
+    [CommandOption("--force")]
+    [Description("Overwrite the skill directory if it already exists.")]
+    public bool Force { get; set; }
+
+    [CommandOption("--dry-run")]
+    [Description("Show what would be written without modifying any files.")]
+    public bool DryRun { get; set; }
+
+    public string ResolveName()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            Name = AnsiConsole.Ask<string>("Skill name (kebab-case):");
+        }
+
+        Name = SkillNameValidator.Normalize(Name);
+        if (!SkillNameValidator.IsValid(Name))
+        {
+            throw new InvalidOperationException(SkillNameValidator.ValidationMessage(Name));
+        }
+
+        return Name;
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillFetcher.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillFetcher.cs
@@ -1,0 +1,279 @@
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed record FetchedSkill(IReadOnlyList<FetchedSkillFile> Files, string ComputedHash);
+
+public sealed class FetchedSkillFile
+{
+    public FetchedSkillFile(string relativePath, byte[] content)
+    {
+        RelativePath = relativePath;
+        _content = content;
+    }
+
+    private readonly byte[] _content;
+
+    public string RelativePath { get; }
+
+    public byte[] GetContent() => _content;
+
+    public int Length => _content.Length;
+}
+
+public sealed class SkillFetcher
+{
+    private const string GitHubApiBase = "https://api.github.com";
+    private const string UserAgent = "SimpleModule.Cli";
+
+    private readonly HttpClient _http;
+
+    public SkillFetcher(HttpClient? http = null)
+    {
+        _http = http ?? new HttpClient();
+        if (_http.DefaultRequestHeaders.UserAgent.Count == 0)
+        {
+            _http.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
+        }
+
+        if (_http.DefaultRequestHeaders.Accept.Count == 0)
+        {
+            _http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        }
+
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        if (!string.IsNullOrWhiteSpace(token) && _http.DefaultRequestHeaders.Authorization is null)
+        {
+            _http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+
+    public async Task<FetchedSkill> FetchAsync(
+        SkillSource source,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return source.Type switch
+        {
+            SkillSourceType.GitHub => await FetchGitHubAsync(source, cancellationToken)
+                .ConfigureAwait(false),
+            SkillSourceType.Local => FetchLocal(source),
+            SkillSourceType.Scaffold => throw new InvalidOperationException(
+                "Scaffold sources are produced inline; not fetched."
+            ),
+            _ => throw new NotSupportedException($"Source type {source.Type} is not supported."),
+        };
+    }
+
+    private static FetchedSkill FetchLocal(SkillSource source)
+    {
+        var path = source.LocalPath ?? throw new InvalidOperationException("Missing local path.");
+        var fullPath = Path.GetFullPath(path);
+
+        if (!Directory.Exists(fullPath))
+        {
+            throw new DirectoryNotFoundException($"Local skill source not found: {fullPath}");
+        }
+
+        var files = new List<FetchedSkillFile>();
+        foreach (var file in Directory.EnumerateFiles(fullPath, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(fullPath, file)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            var bytes = File.ReadAllBytes(file);
+            files.Add(new FetchedSkillFile(relative, bytes));
+        }
+
+        return new FetchedSkill(files, ComputeHash(files));
+    }
+
+    private async Task<FetchedSkill> FetchGitHubAsync(
+        SkillSource source,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrEmpty(source.Owner) || string.IsNullOrEmpty(source.Repo))
+        {
+            throw new InvalidOperationException("GitHub source requires owner and repo.");
+        }
+
+        var refName =
+            source.Ref
+            ?? await ResolveDefaultBranchAsync(source.Owner!, source.Repo!, cancellationToken)
+                .ConfigureAwait(false);
+
+        var basePath = source.Path ?? string.Empty;
+        var files = new List<FetchedSkillFile>();
+        await CollectFilesAsync(
+                source.Owner!,
+                source.Repo!,
+                basePath,
+                refName,
+                basePath,
+                files,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (files.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No files found at github://{source.Owner}/{source.Repo}/{basePath}@{refName}"
+            );
+        }
+
+        return new FetchedSkill(files, ComputeHash(files));
+    }
+
+    private async Task<string> ResolveDefaultBranchAsync(
+        string owner,
+        string repo,
+        CancellationToken cancellationToken
+    )
+    {
+        var url = $"{GitHubApiBase}/repos/{owner}/{repo}";
+        using var response = await _http
+            .GetAsync(new Uri(url, UriKind.Absolute), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Failed to resolve default branch for {owner}/{repo}: HTTP {(int)response.StatusCode}"
+            );
+        }
+
+        var doc = await response
+            .Content.ReadFromJsonAsync<JsonElement>(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return doc.TryGetProperty("default_branch", out var branch)
+            ? branch.GetString() ?? "main"
+            : "main";
+    }
+
+    private async Task CollectFilesAsync(
+        string owner,
+        string repo,
+        string apiPath,
+        string refName,
+        string basePath,
+        List<FetchedSkillFile> files,
+        CancellationToken cancellationToken
+    )
+    {
+        var encodedPath = string.IsNullOrEmpty(apiPath)
+            ? string.Empty
+            : "/" + Uri.EscapeDataString(apiPath).Replace("%2F", "/", StringComparison.Ordinal);
+        var url =
+            $"{GitHubApiBase}/repos/{owner}/{repo}/contents{encodedPath}"
+            + $"?ref={Uri.EscapeDataString(refName)}";
+
+        using var response = await _http
+            .GetAsync(new Uri(url, UriKind.Absolute), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Failed to fetch {url}: HTTP {(int)response.StatusCode}"
+            );
+        }
+
+        var entries = await response
+            .Content.ReadFromJsonAsync<JsonElement>(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entries.ValueKind == JsonValueKind.Object)
+        {
+            // Single file response — wrap in an array-like flow
+            await ProcessEntryAsync(
+                    owner,
+                    repo,
+                    refName,
+                    basePath,
+                    entries,
+                    files,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (entries.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException(
+                $"Unexpected response shape for {url}: {entries.ValueKind}"
+            );
+        }
+
+        foreach (var entry in entries.EnumerateArray())
+        {
+            await ProcessEntryAsync(owner, repo, refName, basePath, entry, files, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task ProcessEntryAsync(
+        string owner,
+        string repo,
+        string refName,
+        string basePath,
+        JsonElement entry,
+        List<FetchedSkillFile> files,
+        CancellationToken cancellationToken
+    )
+    {
+        var type = entry.GetProperty("type").GetString();
+        var path = entry.GetProperty("path").GetString() ?? string.Empty;
+
+        var relative =
+            string.IsNullOrEmpty(basePath) ? path
+            : path.StartsWith(basePath + "/", StringComparison.Ordinal)
+                ? path[(basePath.Length + 1)..]
+            : path == basePath ? Path.GetFileName(path)
+            : path;
+
+        if (string.Equals(type, "file", StringComparison.Ordinal))
+        {
+            var downloadUrl = entry.TryGetProperty("download_url", out var dl)
+                ? dl.GetString()
+                : null;
+            if (string.IsNullOrEmpty(downloadUrl))
+            {
+                return;
+            }
+
+            var bytes = await _http
+                .GetByteArrayAsync(new Uri(downloadUrl!, UriKind.Absolute), cancellationToken)
+                .ConfigureAwait(false);
+            files.Add(new FetchedSkillFile(relative.Replace('\\', '/'), bytes));
+            return;
+        }
+
+        if (string.Equals(type, "dir", StringComparison.Ordinal))
+        {
+            await CollectFilesAsync(owner, repo, path, refName, basePath, files, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    public static string ComputeHash(IEnumerable<FetchedSkillFile> files)
+    {
+        var sb = new StringBuilder();
+        foreach (var file in files.OrderBy(f => f.RelativePath, StringComparer.Ordinal))
+        {
+            var fileHash = SHA256.HashData(file.GetContent());
+            sb.Append(file.RelativePath)
+                .Append(':')
+                .Append(Convert.ToHexString(fileHash))
+                .Append('\n');
+        }
+
+        var combined = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(combined).ToLowerInvariant();
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillFetcher.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillFetcher.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
@@ -9,19 +10,17 @@ public sealed record FetchedSkill(IReadOnlyList<FetchedSkillFile> Files, string 
 
 public sealed class FetchedSkillFile
 {
+    private readonly byte[] _content;
+
     public FetchedSkillFile(string relativePath, byte[] content)
     {
         RelativePath = relativePath;
         _content = content;
     }
 
-    private readonly byte[] _content;
-
     public string RelativePath { get; }
 
     public byte[] GetContent() => _content;
-
-    public int Length => _content.Length;
 }
 
 public sealed class SkillFetcher
@@ -29,44 +28,74 @@ public sealed class SkillFetcher
     private const string GitHubApiBase = "https://api.github.com";
     private const string UserAgent = "SimpleModule.Cli";
 
+    // Shared HttpClient avoids socket exhaustion across repeated fetches; matches NuGetVersionResolver's pattern.
+    private static readonly HttpClient SharedHttpClient = CreateHttpClient();
+
     private readonly HttpClient _http;
 
     public SkillFetcher(HttpClient? http = null)
     {
-        _http = http ?? new HttpClient();
-        if (_http.DefaultRequestHeaders.UserAgent.Count == 0)
-        {
-            _http.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
-        }
-
-        if (_http.DefaultRequestHeaders.Accept.Count == 0)
-        {
-            _http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
-        }
-
-        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-        if (!string.IsNullOrWhiteSpace(token) && _http.DefaultRequestHeaders.Authorization is null)
-        {
-            _http.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-        }
+        _http = http ?? SharedHttpClient;
     }
 
+    private static HttpClient CreateHttpClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                token
+            );
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// Fetches the skill content from its source. Wraps transport, IO, and JSON
+    /// failures into <see cref="InvalidOperationException"/> so callers only need
+    /// a single catch arm.
+    /// </summary>
     public async Task<FetchedSkill> FetchAsync(
         SkillSource source,
         CancellationToken cancellationToken = default
     )
     {
-        return source.Type switch
+        try
         {
-            SkillSourceType.GitHub => await FetchGitHubAsync(source, cancellationToken)
-                .ConfigureAwait(false),
-            SkillSourceType.Local => FetchLocal(source),
-            SkillSourceType.Scaffold => throw new InvalidOperationException(
-                "Scaffold sources are produced inline; not fetched."
-            ),
-            _ => throw new NotSupportedException($"Source type {source.Type} is not supported."),
-        };
+            return source.Type switch
+            {
+                SkillSourceType.GitHub => await FetchGitHubAsync(source, cancellationToken)
+                    .ConfigureAwait(false),
+                SkillSourceType.Local => FetchLocal(source),
+                SkillSourceType.Scaffold => throw new InvalidOperationException(
+                    "Scaffold sources are produced inline; not fetched."
+                ),
+                _ => throw new NotSupportedException(
+                    $"Source type {source.Type} is not supported."
+                ),
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException(ex.Message, ex);
+        }
+        catch (IOException ex)
+        {
+            throw new InvalidOperationException(ex.Message, ex);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to parse response from skill source: {ex.Message}",
+                ex
+            );
+        }
     }
 
     private static FetchedSkill FetchLocal(SkillSource source)
@@ -189,7 +218,6 @@ public sealed class SkillFetcher
 
         if (entries.ValueKind == JsonValueKind.Object)
         {
-            // Single file response — wrap in an array-like flow
             await ProcessEntryAsync(
                     owner,
                     repo,

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillListCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillListCommand.cs
@@ -1,0 +1,82 @@
+using SimpleModule.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillListCommand : Command<SkillListSettings>
+{
+    public override int Execute(CommandContext context, SkillListSettings settings)
+    {
+        var solution = SolutionContext.Discover();
+        if (solution is null)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]No .slnx file found. Run this command from inside a SimpleModule project.[/]"
+            );
+            return 1;
+        }
+
+        var lockFile = SkillsLockFile.Load(solution.RootPath);
+        var skillsRoot = SkillWriter.GetSkillsRoot(solution.RootPath);
+
+        var onDisk = Directory.Exists(skillsRoot)
+            ? Directory
+                .GetDirectories(skillsRoot)
+                .Select(Path.GetFileName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Cast<string>()
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var allNames = lockFile
+            .Skills.Keys.Concat(onDisk)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (allNames.Count == 0)
+        {
+            AnsiConsole.MarkupLine(
+                "[yellow]No skills found.[/] Add one with [green]sm skill add <name> --source <owner/repo>[/]."
+            );
+            return 0;
+        }
+
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Skill");
+        table.AddColumn("Source");
+        table.AddColumn("Ref");
+        table.AddColumn("Hash");
+        table.AddColumn("Status");
+
+        foreach (var name in allNames)
+        {
+            lockFile.Skills.TryGetValue(name, out var entry);
+            var hasFolder = onDisk.Contains(name);
+            var status = (entry, hasFolder) switch
+            {
+                (not null, true) => "[green]tracked[/]",
+                (not null, false) => "[red]missing[/]",
+                (null, true) => "[yellow]untracked[/]",
+                _ => "—",
+            };
+
+            table.AddRow(
+                $"[green]{Markup.Escape(name)}[/]",
+                Markup.Escape(entry?.Source ?? "—"),
+                Markup.Escape(entry?.Ref ?? "—"),
+                Markup.Escape(
+                    string.IsNullOrEmpty(entry?.ComputedHash) ? "—" : entry.ComputedHash[..8]
+                ),
+                status
+            );
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine(
+            $"\n[dim]{allNames.Count} skill(s) in {Markup.Escape(Path.GetRelativePath(solution.RootPath, skillsRoot))}[/]"
+        );
+        return 0;
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillListSettings.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillListSettings.cs
@@ -1,0 +1,5 @@
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillListSettings : CommandSettings { }

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillNameValidator.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillNameValidator.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public static partial class SkillNameValidator
+{
+    [GeneratedRegex(
+        "^[a-z0-9][a-z0-9-]{0,63}$",
+        RegexOptions.Singleline,
+        matchTimeoutMilliseconds: 1000
+    )]
+    private static partial Regex ValidNameRegex();
+
+    public static bool IsValid(string name) =>
+        !string.IsNullOrWhiteSpace(name) && ValidNameRegex().IsMatch(name);
+
+    public static string Normalize(string name) => name.Trim().ToLowerInvariant();
+
+    public static string ValidationMessage(string name) =>
+        $"Skill name '{name}' is invalid. Use lowercase letters, digits, and hyphens (max 64 chars), starting with a letter or digit.";
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillSource.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillSource.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public enum SkillSourceType
+{
+    GitHub,
+    Local,
+    Scaffold,
+}
+
+public sealed partial record SkillSource(
+    SkillSourceType Type,
+    string Raw,
+    string? Owner = null,
+    string? Repo = null,
+    string? Path = null,
+    string? Ref = null,
+    string? LocalPath = null
+)
+{
+    [GeneratedRegex(
+        @"^(?<owner>[A-Za-z0-9][A-Za-z0-9-_.]*)/(?<repo>[A-Za-z0-9][A-Za-z0-9-_.]*)(?:/(?<path>[^@\s]+?))?(?:@(?<ref>[^\s]+))?$",
+        RegexOptions.Singleline,
+        matchTimeoutMilliseconds: 1000
+    )]
+    private static partial Regex GitHubSourceRegex();
+
+    public string SourceTypeId =>
+        Type switch
+        {
+            SkillSourceType.GitHub => "github",
+            SkillSourceType.Local => "local",
+            SkillSourceType.Scaffold => "scaffold",
+            _ => "unknown",
+        };
+
+    public string CanonicalSource =>
+        Type switch
+        {
+            SkillSourceType.GitHub => Path is null ? $"{Owner}/{Repo}" : $"{Owner}/{Repo}/{Path}",
+            SkillSourceType.Local => LocalPath ?? Raw,
+            SkillSourceType.Scaffold => "scaffold",
+            _ => Raw,
+        };
+
+    public static SkillSource Parse(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new ArgumentException("Source cannot be empty.", nameof(raw));
+        }
+
+        // Local path (absolute, relative-with-dot, or contains a directory separator that isn't owner/repo)
+        if (
+            System.IO.Path.IsPathRooted(raw)
+            || raw.StartsWith("./", StringComparison.Ordinal)
+            || raw.StartsWith("../", StringComparison.Ordinal)
+            || raw.StartsWith(".\\", StringComparison.Ordinal)
+            || raw.StartsWith("..\\", StringComparison.Ordinal)
+        )
+        {
+            return new SkillSource(SkillSourceType.Local, raw, LocalPath: raw);
+        }
+
+        var match = GitHubSourceRegex().Match(raw);
+        if (match.Success)
+        {
+            return new SkillSource(
+                SkillSourceType.GitHub,
+                raw,
+                Owner: match.Groups["owner"].Value,
+                Repo: match.Groups["repo"].Value,
+                Path: match.Groups["path"].Success ? match.Groups["path"].Value.TrimEnd('/') : null,
+                Ref: match.Groups["ref"].Success ? match.Groups["ref"].Value : null
+            );
+        }
+
+        // Fall back to treating as a local path
+        return new SkillSource(SkillSourceType.Local, raw, LocalPath: raw);
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillSource.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillSource.cs
@@ -19,6 +19,10 @@ public sealed partial record SkillSource(
     string? LocalPath = null
 )
 {
+    public const string TypeIdGitHub = "github";
+    public const string TypeIdLocal = "local";
+    public const string TypeIdScaffold = "scaffold";
+
     [GeneratedRegex(
         @"^(?<owner>[A-Za-z0-9][A-Za-z0-9-_.]*)/(?<repo>[A-Za-z0-9][A-Za-z0-9-_.]*)(?:/(?<path>[^@\s]+?))?(?:@(?<ref>[^\s]+))?$",
         RegexOptions.Singleline,
@@ -29,9 +33,9 @@ public sealed partial record SkillSource(
     public string SourceTypeId =>
         Type switch
         {
-            SkillSourceType.GitHub => "github",
-            SkillSourceType.Local => "local",
-            SkillSourceType.Scaffold => "scaffold",
+            SkillSourceType.GitHub => TypeIdGitHub,
+            SkillSourceType.Local => TypeIdLocal,
+            SkillSourceType.Scaffold => TypeIdScaffold,
             _ => "unknown",
         };
 

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateCommand.cs
@@ -48,18 +48,25 @@ public sealed class SkillUpdateCommand : AsyncCommand<SkillUpdateSettings>
             targets = [name];
         }
 
-        using var http = new HttpClient();
-        var fetcher = new SkillFetcher(http);
+        var fetcher = new SkillFetcher();
 
         var changed = 0;
         var unchanged = 0;
         var failed = 0;
 
+        var refOverride = !string.IsNullOrWhiteSpace(settings.Name) ? settings.Ref : null;
+
         foreach (var name in targets)
         {
             var entry = lockFile.Skills[name];
 
-            if (string.Equals(entry.SourceType, "scaffold", StringComparison.OrdinalIgnoreCase))
+            if (
+                string.Equals(
+                    entry.SourceType,
+                    SkillSource.TypeIdScaffold,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
             {
                 AnsiConsole.MarkupLine(
                     $"  [yellow]SKIP[/] {Markup.Escape(name)} (scaffolded; no remote source to update)"
@@ -81,43 +88,21 @@ public sealed class SkillUpdateCommand : AsyncCommand<SkillUpdateSettings>
                 continue;
             }
 
-            if (
-                source.Type == SkillSourceType.GitHub
-                && !string.IsNullOrWhiteSpace(settings.Ref)
-                && !string.IsNullOrWhiteSpace(settings.Name)
-            )
+            // CanonicalSource strips @ref, so source.Ref is null after Parse — restore it
+            // from the explicit --ref override (when targeting one skill) or the lock entry.
+            if (source.Type == SkillSourceType.GitHub)
             {
-                source = source with { Ref = settings.Ref };
-            }
-            else if (
-                source.Type == SkillSourceType.GitHub
-                && string.IsNullOrEmpty(source.Ref)
-                && !string.IsNullOrEmpty(entry.Ref)
-            )
-            {
-                source = source with { Ref = entry.Ref };
+                var resolvedRef = !string.IsNullOrWhiteSpace(refOverride) ? refOverride : entry.Ref;
+                if (!string.IsNullOrEmpty(resolvedRef))
+                {
+                    source = source with { Ref = resolvedRef };
+                }
             }
 
             FetchedSkill fetched;
             try
             {
                 fetched = await fetcher.FetchAsync(source).ConfigureAwait(false);
-            }
-            catch (HttpRequestException ex)
-            {
-                AnsiConsole.MarkupLine(
-                    $"  [red]FAIL[/] {Markup.Escape(name)} — {Markup.Escape(ex.Message)}"
-                );
-                failed++;
-                continue;
-            }
-            catch (IOException ex)
-            {
-                AnsiConsole.MarkupLine(
-                    $"  [red]FAIL[/] {Markup.Escape(name)} — {Markup.Escape(ex.Message)}"
-                );
-                failed++;
-                continue;
             }
             catch (InvalidOperationException ex)
             {

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateCommand.cs
@@ -1,0 +1,197 @@
+using SimpleModule.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillUpdateCommand : AsyncCommand<SkillUpdateSettings>
+{
+    public override async Task<int> ExecuteAsync(
+        CommandContext context,
+        SkillUpdateSettings settings
+    )
+    {
+        var solution = SolutionContext.Discover();
+        if (solution is null)
+        {
+            AnsiConsole.MarkupLine(
+                "[red]No .slnx file found. Run this command from inside a SimpleModule project.[/]"
+            );
+            return 1;
+        }
+
+        var lockFile = SkillsLockFile.Load(solution.RootPath);
+        if (lockFile.Skills.Count == 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[yellow]No skills tracked in {SkillsLockFile.FileName}. Use 'sm skill add' first.[/]"
+            );
+            return 0;
+        }
+
+        IEnumerable<string> targets;
+        if (string.IsNullOrWhiteSpace(settings.Name))
+        {
+            targets = lockFile.Skills.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase);
+        }
+        else
+        {
+            var name = SkillNameValidator.Normalize(settings.Name);
+            if (!lockFile.Skills.ContainsKey(name))
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Skill '{Markup.Escape(name)}' is not tracked in {SkillsLockFile.FileName}.[/]"
+                );
+                return 1;
+            }
+
+            targets = [name];
+        }
+
+        using var http = new HttpClient();
+        var fetcher = new SkillFetcher(http);
+
+        var changed = 0;
+        var unchanged = 0;
+        var failed = 0;
+
+        foreach (var name in targets)
+        {
+            var entry = lockFile.Skills[name];
+
+            if (string.Equals(entry.SourceType, "scaffold", StringComparison.OrdinalIgnoreCase))
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [yellow]SKIP[/] {Markup.Escape(name)} (scaffolded; no remote source to update)"
+                );
+                continue;
+            }
+
+            SkillSource source;
+            try
+            {
+                source = SkillSource.Parse(entry.Source);
+            }
+            catch (ArgumentException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [red]FAIL[/] {Markup.Escape(name)} — invalid source: {Markup.Escape(ex.Message)}"
+                );
+                failed++;
+                continue;
+            }
+
+            if (
+                source.Type == SkillSourceType.GitHub
+                && !string.IsNullOrWhiteSpace(settings.Ref)
+                && !string.IsNullOrWhiteSpace(settings.Name)
+            )
+            {
+                source = source with { Ref = settings.Ref };
+            }
+            else if (
+                source.Type == SkillSourceType.GitHub
+                && string.IsNullOrEmpty(source.Ref)
+                && !string.IsNullOrEmpty(entry.Ref)
+            )
+            {
+                source = source with { Ref = entry.Ref };
+            }
+
+            FetchedSkill fetched;
+            try
+            {
+                fetched = await fetcher.FetchAsync(source).ConfigureAwait(false);
+            }
+            catch (HttpRequestException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [red]FAIL[/] {Markup.Escape(name)} — {Markup.Escape(ex.Message)}"
+                );
+                failed++;
+                continue;
+            }
+            catch (IOException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [red]FAIL[/] {Markup.Escape(name)} — {Markup.Escape(ex.Message)}"
+                );
+                failed++;
+                continue;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [red]FAIL[/] {Markup.Escape(name)} — {Markup.Escape(ex.Message)}"
+                );
+                failed++;
+                continue;
+            }
+
+            var sameHash = string.Equals(
+                fetched.ComputedHash,
+                entry.ComputedHash,
+                StringComparison.OrdinalIgnoreCase
+            );
+
+            if (sameHash)
+            {
+                AnsiConsole.MarkupLine($"  [dim]OK[/]   {Markup.Escape(name)} (up to date)");
+                unchanged++;
+                continue;
+            }
+
+            if (settings.Check)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [yellow]DRIFT[/] {Markup.Escape(name)} (recorded {entry.ComputedHash[..8]} → remote {fetched.ComputedHash[..8]})"
+                );
+                changed++;
+                continue;
+            }
+
+            if (settings.DryRun)
+            {
+                AnsiConsole.MarkupLine(
+                    $"  [yellow]CHANGE[/] {Markup.Escape(name)} ({fetched.Files.Count} file(s), new hash {fetched.ComputedHash[..8]})"
+                );
+                changed++;
+                continue;
+            }
+
+            var skillDir = SkillWriter.GetSkillDirectory(solution.RootPath, name);
+            SkillWriter.WriteFiles(skillDir, fetched.Files, replace: true);
+
+            entry.ComputedHash = fetched.ComputedHash;
+            entry.Source = source.CanonicalSource;
+            entry.SourceType = source.SourceTypeId;
+            entry.Ref = source.Ref ?? entry.Ref;
+
+            AnsiConsole.MarkupLine(
+                $"  [green]UPDATED[/] {Markup.Escape(name)} ({fetched.Files.Count} file(s), hash {fetched.ComputedHash[..8]})"
+            );
+            changed++;
+        }
+
+        if (!settings.DryRun && !settings.Check && changed > 0)
+        {
+            lockFile.Save(solution.RootPath);
+            AnsiConsole.MarkupLine(
+                $"\n[green]{changed} updated[/], {unchanged} unchanged, {failed} failed."
+            );
+        }
+        else
+        {
+            AnsiConsole.MarkupLine(
+                $"\n[dim]{changed} would change, {unchanged} unchanged, {failed} failed.[/]"
+            );
+        }
+
+        if (settings.Check && changed > 0)
+        {
+            return 2;
+        }
+
+        return failed > 0 ? 1 : 0;
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateSettings.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillUpdateSettings.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillUpdateSettings : CommandSettings
+{
+    [CommandArgument(0, "[name]")]
+    [Description("Skill name to update. Omit to update every skill in skills-lock.json.")]
+    public string? Name { get; set; }
+
+    [CommandOption("--ref <REF>")]
+    [Description(
+        "Override the GitHub ref (branch, tag, or SHA) used when re-fetching. Applies only to the named skill."
+    )]
+    public string? Ref { get; set; }
+
+    [CommandOption("--check")]
+    [Description("Report drift between recorded hashes and remote sources without writing files.")]
+    public bool Check { get; set; }
+
+    [CommandOption("--dry-run")]
+    [Description("Show what would change without modifying any files.")]
+    public bool DryRun { get; set; }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillWriter.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillWriter.cs
@@ -1,0 +1,80 @@
+namespace SimpleModule.Cli.Commands.Skill;
+
+public static class SkillWriter
+{
+    public static string GetSkillsRoot(string solutionRoot) =>
+        Path.Combine(solutionRoot, ".claude", "skills");
+
+    public static string GetSkillDirectory(string solutionRoot, string skillName) =>
+        Path.Combine(GetSkillsRoot(solutionRoot), skillName);
+
+    public static IReadOnlyList<string> WriteFiles(
+        string skillDirectory,
+        IReadOnlyList<FetchedSkillFile> files,
+        bool replace
+    )
+    {
+        if (replace && Directory.Exists(skillDirectory))
+        {
+            Directory.Delete(skillDirectory, recursive: true);
+        }
+
+        Directory.CreateDirectory(skillDirectory);
+
+        var written = new List<string>();
+        foreach (var file in files)
+        {
+            var relative = file.RelativePath.Replace('\\', '/').TrimStart('/');
+            var fullPath = Path.GetFullPath(Path.Combine(skillDirectory, relative));
+            var skillDirFull = Path.GetFullPath(skillDirectory);
+            if (
+                !fullPath.StartsWith(
+                    skillDirFull + Path.DirectorySeparatorChar,
+                    StringComparison.Ordinal
+                ) && !string.Equals(fullPath, skillDirFull, StringComparison.Ordinal)
+            )
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to write outside skill directory: {fullPath}"
+                );
+            }
+
+            var parent = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(parent))
+            {
+                Directory.CreateDirectory(parent);
+            }
+
+            File.WriteAllBytes(fullPath, file.GetContent());
+            written.Add(relative);
+        }
+
+        return written;
+    }
+
+    public static FetchedSkill BuildScaffold(string skillName, string? description)
+    {
+        var trimmedDescription = string.IsNullOrWhiteSpace(description)
+            ? $"Describe when Claude should use the '{skillName}' skill."
+            : description!.Trim();
+
+        var skillMd = $$"""
+            ---
+            name: {{skillName}}
+            description: >
+              {{trimmedDescription}}
+            ---
+
+            # {{skillName}}
+
+            Replace this with guidance for the skill. Document when it should be used,
+            the conventions to follow, and any references that elaborate on subtopics.
+            """;
+
+        var files = new List<FetchedSkillFile>
+        {
+            new("SKILL.md", System.Text.Encoding.UTF8.GetBytes(skillMd)),
+        };
+        return new FetchedSkill(files, SkillFetcher.ComputeHash(files));
+    }
+}

--- a/cli/SimpleModule.Cli/Commands/Skill/SkillsLockFile.cs
+++ b/cli/SimpleModule.Cli/Commands/Skill/SkillsLockFile.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SimpleModule.Cli.Commands.Skill;
+
+public sealed class SkillsLockFile
+{
+    public const string FileName = "skills-lock.json";
+    public const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [JsonPropertyName("version")]
+    public int Version { get; set; } = CurrentVersion;
+
+    [JsonPropertyName("skills")]
+    public Dictionary<string, SkillsLockEntry> Skills { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public static string GetPath(string solutionRoot) => Path.Combine(solutionRoot, FileName);
+
+    public static SkillsLockFile Load(string solutionRoot)
+    {
+        var path = GetPath(solutionRoot);
+        if (!File.Exists(path))
+        {
+            return new SkillsLockFile();
+        }
+
+        var json = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new SkillsLockFile();
+        }
+
+        var loaded = JsonSerializer.Deserialize<SkillsLockFile>(json, SerializerOptions);
+        return loaded ?? new SkillsLockFile();
+    }
+
+    public void Save(string solutionRoot)
+    {
+        Version = CurrentVersion;
+        var path = GetPath(solutionRoot);
+        var ordered = new SkillsLockFile { Version = Version };
+        foreach (var key in Skills.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+        {
+            ordered.Skills[key] = Skills[key];
+        }
+
+        var json = JsonSerializer.Serialize(ordered, SerializerOptions);
+        File.WriteAllText(path, json + Environment.NewLine);
+    }
+}
+
+public sealed class SkillsLockEntry
+{
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceType")]
+    public string SourceType { get; set; } = string.Empty;
+
+    [JsonPropertyName("ref")]
+    public string? Ref { get; set; }
+
+    [JsonPropertyName("computedHash")]
+    public string ComputedHash { get; set; } = string.Empty;
+}

--- a/cli/SimpleModule.Cli/Program.cs
+++ b/cli/SimpleModule.Cli/Program.cs
@@ -3,6 +3,7 @@ using SimpleModule.Cli.Commands.Doctor;
 using SimpleModule.Cli.Commands.Install;
 using SimpleModule.Cli.Commands.List;
 using SimpleModule.Cli.Commands.New;
+using SimpleModule.Cli.Commands.Skill;
 using SimpleModule.Cli.Commands.Version;
 using Spectre.Console.Cli;
 
@@ -19,6 +20,8 @@ app.Configure(config =>
     config.AddExample("dev");
     config.AddExample("list");
     config.AddExample("doctor", "--fix");
+    config.AddExample("skill", "add", "shadcn", "--source", "shadcn/ui/skills/shadcn");
+    config.AddExample("skill", "update");
 
     config.AddBranch(
         "new",
@@ -60,6 +63,29 @@ app.Configure(config =>
     config
         .AddCommand<DoctorCommand>("doctor")
         .WithDescription("Validate project structure and conventions");
+
+    config.AddBranch(
+        "skill",
+        skillBranch =>
+        {
+            skillBranch.SetDescription("Manage Claude skills under .claude/skills");
+            skillBranch
+                .AddCommand<SkillAddCommand>("add")
+                .WithDescription("Add a Claude skill (from GitHub, a local path, or a scaffold)")
+                .WithExample("skill", "add", "shadcn", "--source", "shadcn/ui/skills/shadcn")
+                .WithExample("skill", "add", "my-skill")
+                .WithExample("skill", "add", "team-skill", "--source", "./skills/team-skill");
+            skillBranch
+                .AddCommand<SkillUpdateCommand>("update")
+                .WithDescription("Re-fetch tracked skills and refresh skills-lock.json")
+                .WithExample("skill", "update")
+                .WithExample("skill", "update", "shadcn", "--ref", "main")
+                .WithExample("skill", "update", "--check");
+            skillBranch
+                .AddCommand<SkillListCommand>("list")
+                .WithDescription("List installed Claude skills and their tracked sources");
+        }
+    );
 
     config.AddCommand<VersionCommand>("version").WithDescription("Print the sm CLI version");
 });


### PR DESCRIPTION
## Summary

Adds a new `sm skill` command branch to the CLI for managing Claude skills under `.claude/skills`, with the install state tracked in `skills-lock.json` (the file already existed in the repo without any tooling backing it).

### Commands

- **`sm skill add <name> [--source <src>] [--description <text>] [--force] [--dry-run]`** — Adds a skill to the project. Without `--source`, scaffolds a minimal `SKILL.md`. With `--source` it accepts:
  - GitHub: `owner/repo`, `owner/repo/path`, `owner/repo/path@ref` (branch / tag / SHA)
  - Local directory: any absolute or `./` / `../` path
- **`sm skill update [name] [--ref <ref>] [--check] [--dry-run]`** — Re-fetches skills tracked in `skills-lock.json` and refreshes their content + computed hash. Without a name, updates every tracked non-scaffold skill. `--check` reports drift without writing. Returns exit code 2 when drift is detected (useful for CI).
- **`sm skill list`** — Tabular view of installed skills, their source, ref, hash, and `tracked` / `untracked` / `missing` status.

### Implementation notes

- `SkillsLockFile` round-trips the existing `skills-lock.json` schema (`version`, `skills{ source, sourceType, ref?, computedHash }`).
- `SkillFetcher` uses the GitHub Contents API (`api.github.com/repos/.../contents/...`) and falls back to the repo's `default_branch` when no ref is given. Honors `GITHUB_TOKEN` for higher rate limits.
- Hashing is SHA-256 over a sorted `path:hash` manifest, so identical content produces a stable hash regardless of fetch order.
- `SkillWriter` refuses to write outside the target skill directory (path-traversal guard) and creates a self-contained scaffold for new skills.

## Test plan

- [x] `dotnet build cli/SimpleModule.Cli/SimpleModule.Cli.csproj` — clean build (TreatWarningsAsErrors).
- [x] `dotnet csharpier check` — formatting matches project standard.
- [x] `sm skill --help`, `sm skill add --help`, `sm skill update --help` render correctly.
- [x] `sm skill add tmp-test-skill --description "..."` — scaffolds `.claude/skills/tmp-test-skill/SKILL.md` and updates `skills-lock.json`.
- [x] `sm skill add tmp-test-skill --description "..." --dry-run` — prints planned changes without writing.
- [x] `sm skill list` — shows existing on-disk skills as `untracked` and the existing `shadcn` lock entry as `missing` (since its directory isn't present).
- [x] `sm skill update --check` — gracefully reports network failures (e.g., GitHub rate-limit 403) without crashing.
- [ ] End-to-end fetch from GitHub once a real skill repo is reachable from the test environment (currently rate-limited locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV9TACy8v2Ud4uGuKjogW6)_