### PR TITLE
fix: admin hub tiles + Pages/Index.tsx barrel collision detection

### DIFF
--- a/modules/Admin/src/SimpleModule.Admin/Pages/Admin/Hub.tsx
+++ b/modules/Admin/src/SimpleModule.Admin/Pages/Admin/Hub.tsx
@@ -124,7 +124,19 @@ function CardIcon({ icon }: { icon: string }) {
   );
 }
 
-export default function Hub() {
+interface HubProps {
+  availableUrls?: string[];
+}
+
+export default function Hub({ availableUrls }: HubProps) {
+  const available = new Set((availableUrls ?? []).map((u) => u.toLowerCase()));
+  const visibleGroups = groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((i) => available.has(i.url.toLowerCase())),
+    }))
+    .filter((group) => group.items.length > 0);
+
   return (
     <PageShell
       title="Administration"
@@ -132,7 +144,7 @@ export default function Hub() {
       breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin' }]}
     >
       <div className="space-y-8">
-        {groups.map((group) => (
+        {visibleGroups.map((group) => (
           <section key={group.title}>
             <h2 className="text-sm font-semibold uppercase tracking-wider text-text-muted mb-3">
               {group.title}

--- a/modules/Admin/src/SimpleModule.Admin/Pages/Admin/HubEndpoint.cs
+++ b/modules/Admin/src/SimpleModule.Admin/Pages/Admin/HubEndpoint.cs
@@ -10,9 +10,9 @@ public class HubEndpoint : IViewEndpoint
 {
     public const string Route = AdminConstants.Routes.Hub;
 
-    // Tile URLs whose presence we probe before rendering. Anything not in the
-    // app's endpoint table is filtered out so we don't surface 404 tiles when
-    // the corresponding peer module isn't installed.
+    // Must stay in sync with the `url` values in Hub.tsx's `groups`. URLs not
+    // present in the app's endpoint table are filtered out so the hub doesn't
+    // surface 404 tiles for peer modules that aren't installed.
     private static readonly string[] CandidateUrls =
     [
         "/admin/users",
@@ -30,25 +30,34 @@ public class HubEndpoint : IViewEndpoint
         "/settings/manage",
     ];
 
+    private string[]? _availableUrls;
+
     public void Map(IEndpointRouteBuilder app)
     {
         app.MapGet(
                 Route,
                 (EndpointDataSource endpointDataSource) =>
                 {
-                    var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var endpoint in endpointDataSource.Endpoints)
-                    {
-                        if (endpoint is RouteEndpoint route)
-                        {
-                            registered.Add("/" + route.RoutePattern.RawText?.TrimStart('/'));
-                        }
-                    }
-
-                    var availableUrls = CandidateUrls.Where(registered.Contains).ToArray();
-                    return Inertia.Render("Admin/Admin/Hub", new { availableUrls });
+                    _availableUrls ??= ComputeAvailableUrls(endpointDataSource);
+                    return Inertia.Render(
+                        "Admin/Admin/Hub",
+                        new { availableUrls = _availableUrls }
+                    );
                 }
             )
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
+    }
+
+    private static string[] ComputeAvailableUrls(EndpointDataSource endpointDataSource)
+    {
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var endpoint in endpointDataSource.Endpoints)
+        {
+            if (endpoint is RouteEndpoint route)
+            {
+                registered.Add("/" + route.RoutePattern.RawText?.TrimStart('/'));
+            }
+        }
+        return CandidateUrls.Where(registered.Contains).ToArray();
     }
 }

--- a/modules/Admin/src/SimpleModule.Admin/Pages/Admin/HubEndpoint.cs
+++ b/modules/Admin/src/SimpleModule.Admin/Pages/Admin/HubEndpoint.cs
@@ -10,9 +10,45 @@ public class HubEndpoint : IViewEndpoint
 {
     public const string Route = AdminConstants.Routes.Hub;
 
+    // Tile URLs whose presence we probe before rendering. Anything not in the
+    // app's endpoint table is filtered out so we don't surface 404 tiles when
+    // the corresponding peer module isn't installed.
+    private static readonly string[] CandidateUrls =
+    [
+        "/admin/users",
+        "/admin/roles",
+        "/openiddict/clients",
+        "/tenants/manage",
+        "/pages/manage",
+        "/email/templates",
+        "/email/history",
+        "/settings/menus",
+        "/feature-flags/manage",
+        "/rate-limiting/manage",
+        "/admin/jobs",
+        "/audit-logs/browse",
+        "/settings/manage",
+    ];
+
     public void Map(IEndpointRouteBuilder app)
     {
-        app.MapGet(Route, () => Inertia.Render("Admin/Admin/Hub"))
+        app.MapGet(
+                Route,
+                (EndpointDataSource endpointDataSource) =>
+                {
+                    var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var endpoint in endpointDataSource.Endpoints)
+                    {
+                        if (endpoint is RouteEndpoint route)
+                        {
+                            registered.Add("/" + route.RoutePattern.RawText?.TrimStart('/'));
+                        }
+                    }
+
+                    var availableUrls = CandidateUrls.Where(registered.Contains).ToArray();
+                    return Inertia.Render("Admin/Admin/Hub", new { availableUrls });
+                }
+            )
             .RequireAuthorization(policy => policy.RequireRole("Admin"));
     }
 }

--- a/packages/SimpleModule.Client/src/define-module-config.ts
+++ b/packages/SimpleModule.Client/src/define-module-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 import react from '@vitejs/plugin-react';
 import type { UserConfig } from 'vite';
@@ -18,8 +18,6 @@ import { defaultVendors } from './vite-plugin-vendor.ts';
  */
 function assertNoBarrelCollision(dir: string): void {
   const pagesDir = resolve(dir, 'Pages');
-  const barrelPath = resolve(pagesDir, 'index.ts');
-  if (!existsSync(barrelPath)) return;
 
   let entries: string[];
   try {
@@ -27,41 +25,34 @@ function assertNoBarrelCollision(dir: string): void {
   } catch {
     return;
   }
+  if (!entries.includes('index.ts')) return;
 
-  // Page filenames whose stem case-insensitively equals 'index' would collide
-  // with the barrel on case-insensitive filesystems.
-  const colliding = entries.filter((f) => /^index\.(tsx|jsx|js)$/i.test(f) && f !== 'index.ts');
-  if (colliding.length === 0) return;
+  const offending = entries.find((f) => /^index\.(tsx|jsx|js)$/i.test(f) && f !== 'index.ts');
+  if (!offending) return;
 
   let barrel: string;
   try {
-    barrel = readFileSync(barrelPath, 'utf8');
+    barrel = readFileSync(resolve(pagesDir, 'index.ts'), 'utf8');
   } catch {
     return;
   }
 
-  // Look for extension-less dynamic imports whose specifier case-insensitively
+  // Match extension-less dynamic imports whose specifier case-insensitively
   // resolves to the barrel itself (`import('./Index')` next to `index.ts`).
   // On case-insensitive filesystems Rolldown silently picks `./index.ts`
   // (the barrel) rather than the sibling `./Index.tsx`, producing a chunk
   // that re-exports the barrel and crashes at runtime.
-  const importRe = /import\(\s*['"]\.\/([A-Za-z0-9_-]+)['"]\s*\)/g;
-  for (const match of barrel.matchAll(importRe)) {
-    const specifier = match[1];
-    if (specifier.toLowerCase() !== 'index') continue;
-    const offending = colliding.find(
-      (f) => f.replace(/\.(tsx|jsx|js)$/i, '').toLowerCase() === specifier.toLowerCase(),
-    );
-    if (!offending) continue;
-    throw new Error(
-      `[@simplemodule/client] Pages/index.ts contains \`import('./${specifier}')\` which collides ` +
-        `with the barrel on case-insensitive filesystems (macOS/Windows). Rolldown will silently ` +
-        `emit a self-referential chunk and the page will fail at runtime with ` +
-        `"Cannot assign to property 'layout' of [object Module]".\n\n` +
-        `Fix: use the explicit file extension, e.g. \`import('./${offending}')\`, or rename ` +
-        `Pages/${offending} to a name that does not case-insensitively match 'index'.`,
-    );
-  }
+  if (!/import\(\s*['"]\.\/index['"]\s*\)/i.test(barrel)) return;
+
+  const specifier = offending.replace(/\.(tsx|jsx|js)$/i, '');
+  throw new Error(
+    `[@simplemodule/client] Pages/index.ts contains \`import('./${specifier}')\` which collides ` +
+      `with the barrel on case-insensitive filesystems (macOS/Windows). Rolldown will silently ` +
+      `emit a self-referential chunk and the page will fail at runtime with ` +
+      `"Cannot assign to property 'layout' of [object Module]".\n\n` +
+      `Fix: use the explicit file extension, e.g. \`import('./${offending}')\`, or rename ` +
+      `Pages/${offending} to a name that does not case-insensitively match 'index'.`,
+  );
 }
 
 /**

--- a/packages/SimpleModule.Client/src/define-module-config.ts
+++ b/packages/SimpleModule.Client/src/define-module-config.ts
@@ -1,8 +1,68 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 import react from '@vitejs/plugin-react';
 import type { UserConfig } from 'vite';
 import { defineConfig } from 'vite';
 import { defaultVendors } from './vite-plugin-vendor.ts';
+
+/**
+ * Detect the case-insensitive filesystem trap where `Pages/index.ts` (the
+ * framework-required barrel) sits next to a page like `Pages/Index.tsx` and
+ * the barrel uses an extension-less dynamic import (`() => import('./Index')`).
+ *
+ * On macOS/Windows, Rolldown resolves `./Index` back to `./index.ts` (the
+ * barrel itself), producing a self-referential chunk that throws at runtime
+ * with `Cannot assign to property 'layout' of [object Module]`.
+ *
+ * Throw early with a clear, actionable error.
+ */
+function assertNoBarrelCollision(dir: string): void {
+  const pagesDir = resolve(dir, 'Pages');
+  const barrelPath = resolve(pagesDir, 'index.ts');
+  if (!existsSync(barrelPath)) return;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(pagesDir);
+  } catch {
+    return;
+  }
+
+  // Page filenames whose stem case-insensitively equals 'index' would collide
+  // with the barrel on case-insensitive filesystems.
+  const colliding = entries.filter((f) => /^index\.(tsx|jsx|js)$/i.test(f) && f !== 'index.ts');
+  if (colliding.length === 0) return;
+
+  let barrel: string;
+  try {
+    barrel = readFileSync(barrelPath, 'utf8');
+  } catch {
+    return;
+  }
+
+  // Look for extension-less dynamic imports whose specifier case-insensitively
+  // resolves to the barrel itself (`import('./Index')` next to `index.ts`).
+  // On case-insensitive filesystems Rolldown silently picks `./index.ts`
+  // (the barrel) rather than the sibling `./Index.tsx`, producing a chunk
+  // that re-exports the barrel and crashes at runtime.
+  const importRe = /import\(\s*['"]\.\/([A-Za-z0-9_-]+)['"]\s*\)/g;
+  for (const match of barrel.matchAll(importRe)) {
+    const specifier = match[1];
+    if (specifier.toLowerCase() !== 'index') continue;
+    const offending = colliding.find(
+      (f) => f.replace(/\.(tsx|jsx|js)$/i, '').toLowerCase() === specifier.toLowerCase(),
+    );
+    if (!offending) continue;
+    throw new Error(
+      `[@simplemodule/client] Pages/index.ts contains \`import('./${specifier}')\` which collides ` +
+        `with the barrel on case-insensitive filesystems (macOS/Windows). Rolldown will silently ` +
+        `emit a self-referential chunk and the page will fail at runtime with ` +
+        `"Cannot assign to property 'layout' of [object Module]".\n\n` +
+        `Fix: use the explicit file extension, e.g. \`import('./${offending}')\`, or rename ` +
+        `Pages/${offending} to a name that does not case-insensitively match 'index'.`,
+    );
+  }
+}
 
 /**
  * Unified Vite config for SimpleModule modules.
@@ -20,6 +80,8 @@ import { defaultVendors } from './vite-plugin-vendor.ts';
  * ```
  */
 export function defineModuleConfig(dir: string): UserConfig {
+  assertNoBarrelCollision(dir);
+
   const name = basename(dir);
   const isDev = process.env.VITE_MODE !== 'prod';
 


### PR DESCRIPTION
Addresses two of the open issues raised in the recent downstream-feedback batch.

## #134 — Admin hub now hides tiles for unregistered modules

`/admin` rendered tiles for **Tenants**, **Pages**, **Email Templates / History**, **Menus**, **Feature Flags**, **Rate Limiting**, **Background Jobs**, and **Audit Logs** unconditionally. In a minimal install only **Users / Roles / OAuth Clients / App Settings** actually resolve — the other tiles 404'd, presenting the hub as if every peer module were installed.

`HubEndpoint` now injects `EndpointDataSource`, snapshots the set of registered route patterns, and passes only the URLs that resolve through to the React page. `Hub.tsx` filters card items against that set and drops empty groups.

Lightweight option-1 fix from the issue. The cleaner option-2 (each module contributes its own tile via a discoverable convention) is still on the table for follow-up — this PR keeps the change surface tiny while removing the broken UX.

## #131 — `defineModuleConfig` rejects the `Pages/Index.tsx` barrel-collision trap

A module with `Pages/Index.tsx` plus the framework-required `Pages/index.ts` barrel doing `() => import('./Index')` builds silently broken on macOS/Windows. Rolldown resolves `./Index` to the case-insensitive sibling `./index.ts` (the barrel itself), emits a self-referential chunk, and the page crashes at runtime with `Cannot assign to property 'layout' of [object Module]`.

`defineModuleConfig` now scans the barrel at config-evaluation time. If it contains an extension-less dynamic import whose specifier case-insensitively equals `index` and a colliding sibling page (e.g. `Index.tsx`) exists, it throws with an actionable message:

> Pages/index.ts contains `import('./Index')` which collides with the barrel on case-insensitive filesystems… Fix: use the explicit file extension, e.g. `import('./Index.tsx')`, or rename Pages/Index.tsx…

Verified the validator catches the trap and does not false-positive on the normal sibling case (`Pages/Browse.tsx` + `import('./Browse')`).

## Other open issues (not in this PR)

- **#137** (docs for `PermissionRegistryBuilder.AddPermissions`) — pure docs/template work; deferred.
- **#135** (CI smoke test for packed nupkg) — CI pipeline change; deferred.
- **#133** (publish `SimpleModule.Tests.Shared` to NuGet) — currently project-references `SimpleModule.Host` and ~20 module projects; non-trivial extraction needed before it can be safely packed. Deferred.
- **#130** (startup-time peer-module validator) — design-level work that warrants its own PR/discussion.

## Test plan

- [x] `dotnet build` of the Admin module succeeds.
- [x] `dotnet test modules/Admin/tests/SimpleModule.Admin.Tests` — 28 passed, 1 skipped.
- [x] Validator catches `Pages/Index.tsx` + `import('./Index')` (manual repro).
- [x] Validator does not false-positive on `Pages/Browse.tsx` + `import('./Browse')`.
- [x] `biome check` and `csharpier check` clean on changed files.
- [ ] Manual: load `/admin` in a minimal-install consumer to confirm only registered tiles render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gnnwj4wsCaGxHrW3px7B21)_