### PR TITLE
fix(openiddict): restore OAuth endpoints in dashboard and swagger

### DIFF
--- a/modules/Dashboard/src/SimpleModule.Dashboard/Pages/components/TokenTester.tsx
+++ b/modules/Dashboard/src/SimpleModule.Dashboard/Pages/components/TokenTester.tsx
@@ -121,7 +121,7 @@ export function TokenTester() {
       response_type: 'code',
       client_id: 'simplemodule-client',
       redirect_uri: `${window.location.origin}/oauth-callback`,
-      scope: 'openid profile email',
+      scope: 'openid profile email roles',
       state,
       code_challenge: challenge,
       code_challenge_method: 'S256',

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/OpenIddictModuleConstants.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/OpenIddictModuleConstants.cs
@@ -12,7 +12,7 @@ public static class OpenIddictModuleConstants
         public const string ClientsCreate = "/clients/create";
         public const string ClientsEdit = "/clients/{id}/edit";
 
-        // View route — registered via ConfigureEndpoints (escape hatch)
+        // OAuth callback (registered as a top-level IEndpoint, not under ViewPrefix)
         public const string OAuthCallback = "/oauth-callback";
 
         // Connect routes (also in ConnectRouteConstants)

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Endpoints/Connect/OAuthCallbackEndpoint.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Endpoints/Connect/OAuthCallbackEndpoint.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.OpenIddict.Contracts;
+
+namespace SimpleModule.OpenIddict.Endpoints.Connect;
+
+[AllowAnonymous]
+public class OAuthCallbackEndpoint : IEndpoint
+{
+    public const string Route = OpenIddictModuleConstants.Routes.OAuthCallback;
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(Route, () => Inertia.Render("OpenIddict/OAuthCallback"));
+}

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Hosting/OpenIddictSwaggerContributor.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Hosting/OpenIddictSwaggerContributor.cs
@@ -33,6 +33,7 @@ internal sealed class OpenIddictSwaggerGenSetup : IConfigureOptions<SwaggerGenOp
                             { AuthConstants.OpenIdScope, "OpenID" },
                             { AuthConstants.ProfileScope, "Profile" },
                             { AuthConstants.EmailScope, "Email" },
+                            { AuthConstants.RolesScope, "Roles" },
                         },
                     },
                 },
@@ -55,6 +56,7 @@ internal sealed class OpenIddictSwaggerGenSetup : IConfigureOptions<SwaggerGenOp
                         AuthConstants.OpenIdScope,
                         AuthConstants.ProfileScope,
                         AuthConstants.EmailScope,
+                        AuthConstants.RolesScope,
                     ]
                 },
             };

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,7 +5,6 @@ using Microsoft.Extensions.Options;
 using SimpleModule.Core;
 using SimpleModule.Core.Authorization;
 using SimpleModule.Core.Hosting;
-using SimpleModule.Core.Inertia;
 using SimpleModule.Database;
 using SimpleModule.OpenIddict.Contracts;
 using SimpleModule.OpenIddict.Hosting;
@@ -116,13 +113,6 @@ public class OpenIddictModule : IModule
         services.AddTransient<IConfigureOptions<SwaggerUIOptions>, OpenIddictSwaggerUISetup>();
         services.AddSingleton<IHostDbContextContributor, OpenIddictDbContextContributor>();
         OpenIddictAuthSetup.AddSmartAuthentication(services);
-    }
-
-    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
-    {
-        endpoints
-            .MapGet("/oauth-callback", () => Inertia.Render("OpenIddict/OAuthCallback"))
-            .AllowAnonymous();
     }
 
     // Menu items removed — accessible via Admin hub page

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -312,6 +312,7 @@ export const routes = {
     api: {
       authorization: () => '/connect/authorize' as const,
       logout: () => '/connect/endsession' as const,
+      oAuthCallback: () => '/oauth-callback' as const,
       token: () => '/connect/token' as const,
       userinfo: () => '/connect/userinfo' as const,
     },


### PR DESCRIPTION
## Summary

OAuth was completely broken in the dashboard's TokenTester and in Swagger UI because `/connect/authorize`, `/connect/token`, `/connect/userinfo`, and `/connect/endsession` were never being mapped — they returned `404`.

### Root cause

The source generator (`framework/SimpleModule.Generator/Emitters/EndpointExtensionsEmitter.cs:35`) treats `IModule.ConfigureEndpoints` as an escape hatch and **skips auto-registration of every `IEndpoint`** in the module when it's present:

```csharp
if (module.Endpoints.Length == 0 || module.HasConfigureEndpoints)
    continue;
```

`OpenIddictModule.ConfigureEndpoints` only mapped `/oauth-callback`, which silently disabled the four `Endpoints/Connect/*` registrations. Inspecting the generated `EndpointExtensions.g.cs` confirmed only the manual `ConfigureEndpoints` call survived for OpenIddict.

### Fix

- Move `/oauth-callback` to a normal `IEndpoint` (`OAuthCallbackEndpoint`) decorated with `[AllowAnonymous]`. The module has no `RoutePrefix`, so the generator maps it (and the four connect endpoints) at the app root, exactly as before.
- Delete `ConfigureEndpoints` from `OpenIddictModule` so auto-discovery resumes.
- Add the `roles` scope to the Swagger OAuth security definition + requirement so it matches what OpenIddict registers and what the access token contains.
- Request `roles` from the dashboard `TokenTester` for parity.

### Verification

Started the host on `https://localhost:5001` and confirmed:

| Endpoint | Before | After |
| --- | --- | --- |
| `/connect/authorize` | `404` (HTML fallback) | `302` redirect to `/Identity/Account/Login` |
| `/connect/token` (password grant, valid creds) | `404` | `200` with real `access_token` JWT |
| `/oauth-callback` | `200` | `200` |
| `/swagger/v1/swagger.json` scopes | `openid, profile, email` | `openid, profile, email, roles` |

Generated `EndpointExtensions.g.cs` now contains the expected mappings:

```
new ...Endpoints.Connect.AuthorizationEndpoint().Map(app);
new ...Endpoints.Connect.LogoutEndpoint().Map(app);
{ var _eg = app.MapGroup(""); _eg.AllowAnonymous(); new ...OAuthCallbackEndpoint().Map(_eg); }
new ...Endpoints.Connect.TokenEndpoint().Map(app);
new ...Endpoints.Connect.UserinfoEndpoint().Map(app);
```

## Test plan

- [ ] `dotnet build` succeeds with 0 warnings/errors
- [ ] Run the host, open `https://localhost:5001/swagger`, click **Authorize**, complete the flow, and confirm a token is acquired
- [ ] Run the host, open the dashboard, click **Get Token** in TokenTester, log in, and confirm the access token decodes with `role` claims included
- [ ] Verify `/oauth-callback` still renders the Inertia page after a successful authorization redirect

---
_Generated by [Claude Code](https://claude.ai/code/session_019yw8j9U4cpC6Tht5bFovFP)_