### PR TITLE
fix: handle empty/error bodies in TokenTester token exchange

### DIFF
--- a/modules/Dashboard/src/SimpleModule.Dashboard/Pages/components/TokenTester.tsx
+++ b/modules/Dashboard/src/SimpleModule.Dashboard/Pages/components/TokenTester.tsx
@@ -88,7 +88,10 @@ export function TokenTester() {
       try {
         const res = await fetch('/connect/token', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
           body: new URLSearchParams({
             grant_type: 'authorization_code',
             client_id: 'simplemodule-client',
@@ -98,8 +101,16 @@ export function TokenTester() {
           }),
         });
 
-        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-        const data = await res.json();
+        const body = await res.text();
+        const data = body ? (JSON.parse(body) as Record<string, string>) : null;
+
+        if (!res.ok) {
+          const detail = data?.error_description ?? data?.error ?? body;
+          throw new Error(`${res.status} ${res.statusText}${detail ? ` - ${detail}` : ''}`);
+        }
+        if (!data?.access_token) {
+          throw new Error('Response did not contain an access_token');
+        }
         setToken(data.access_token);
       } catch (e: unknown) {
         alert(`Token exchange failed: ${e instanceof Error ? e.message : String(e)}`);


### PR DESCRIPTION
## Summary

Fixes the cryptic error `Token exchange failed: Failed to execute 'json' on 'Response': Unexpected end of JSON input` shown by the dashboard `TokenTester` after an OAuth callback.

## Root cause

In `modules/Dashboard/src/SimpleModule.Dashboard/Pages/components/TokenTester.tsx`, the `/connect/token` response was parsed via `await res.json()` unconditionally. Two failure modes:

1. **Empty body** (e.g. some non-2xx responses with no body) — `res.json()` itself throws `Unexpected end of JSON input`, which becomes the user-visible error.
2. **OpenIddict error JSON** (400 with `{ error, error_description }`) — the `!res.ok` branch threw `${res.status} ${res.statusText}` and discarded the body, hiding the actual reason for the failure (e.g. `invalid_grant`, PKCE mismatch, etc.).

## Change

- Read the response body as text once, then attempt `JSON.parse` only if non-empty.
- On `!res.ok`, surface `error_description` / `error` from the parsed body when available.
- On success, validate that `access_token` is present before using it.
- Add `Accept: application/json` to be explicit about the expected response type.

## Test plan

- [ ] Trigger the OAuth flow from the Dashboard "Get Token" button and confirm the access token decodes successfully.
- [ ] Force an error (e.g. tamper with the `state` or `code_verifier`) and confirm the alert now shows the OpenIddict `error_description` instead of the generic JSON-parse error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UspbaGgoTJhJsom3YPcFwH)_