### PR TITLE
fix(cli): unblock fresh sm new project / sm new module builds

### DIFF
--- a/cli/SimpleModule.Cli/Commands/New/NewFeatureCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewFeatureCommand.cs
@@ -31,7 +31,7 @@ public sealed class NewFeatureCommand : Command<NewFeatureSettings>
         var httpMethod = settings.ResolveHttpMethod();
         var route = settings.ResolveRoute();
         var includeValidator = settings.ResolveIncludeValidator();
-        var singularName = ModuleTemplates.GetSingularName(moduleName);
+        var singularName = ModuleTemplates.GetEntityName(moduleName);
 
         var templates = new FeatureTemplates(solution);
         var ops = new List<(string Path, FileAction Action)>();

--- a/cli/SimpleModule.Cli/Commands/New/NewModuleCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewModuleCommand.cs
@@ -10,7 +10,7 @@ public sealed class NewModuleCommand : Command<NewModuleSettings>
     public override int Execute(CommandContext context, NewModuleSettings settings)
     {
         var moduleName = settings.ResolveName();
-        var singularName = ModuleTemplates.GetSingularName(moduleName);
+        var singularName = ModuleTemplates.GetEntityName(moduleName);
 
         var solution = SolutionContext.Discover();
         if (solution is null)

--- a/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
+++ b/cli/SimpleModule.Cli/Commands/New/NewProjectCommand.cs
@@ -77,7 +77,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
         var moduleTemplates = new ModuleTemplates(solution);
 
         const string moduleName = "Items";
-        var singularName = ModuleTemplates.GetSingularName(moduleName);
+        var singularName = ModuleTemplates.GetEntityName(moduleName);
 
         var hostDir = Path.Combine(rootDir, "src", $"{projectName}.Host");
         var modulesDir = Path.Combine(rootDir, "src", "modules");
@@ -121,7 +121,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
             )
         );
         File.WriteAllText(Path.Combine(rootDir, "biome.json"), projectTemplates.BiomeJson());
-        File.WriteAllText(Path.Combine(rootDir, "tsconfig.json"), projectTemplates.TsconfigJson());
+        File.WriteAllText(Path.Combine(rootDir, "tsconfig.json"), ProjectTemplates.TsconfigJson());
         var editorConfig = projectTemplates.EditorConfig();
         if (!string.IsNullOrEmpty(editorConfig))
         {
@@ -278,7 +278,7 @@ public sealed class NewProjectCommand : Command<NewProjectSettings>
         var testsSharedDir = Path.Combine(rootDir, "tests", $"{projectName}.Tests.Shared");
 
         const string moduleName = "Items";
-        var singularName = ModuleTemplates.GetSingularName(moduleName);
+        var singularName = ModuleTemplates.GetEntityName(moduleName);
 
         // Root config files
         Plan(Path.Combine(rootDir, $"{projectName}.slnx"));

--- a/cli/SimpleModule.Cli/Templates/FeatureTemplates.cs
+++ b/cli/SimpleModule.Cli/Templates/FeatureTemplates.cs
@@ -12,7 +12,7 @@ public sealed class FeatureTemplates
     {
         _solution = solution;
         _refModule = solution.ExistingModules.Count > 0 ? solution.ExistingModules[0] : null;
-        _refSingular = _refModule is not null ? ModuleTemplates.GetSingularName(_refModule) : null;
+        _refSingular = _refModule is not null ? ModuleTemplates.GetEntityName(_refModule) : null;
     }
 
     public string Endpoint(

--- a/cli/SimpleModule.Cli/Templates/HostTemplates.cs
+++ b/cli/SimpleModule.Cli/Templates/HostTemplates.cs
@@ -159,16 +159,47 @@ public sealed class HostTemplates
     /// Return a clean Styles/app.css with tailwindcss import, theme import,
     /// and @source directives for modules. Strip _scan/ import if present.
     /// </summary>
+    /// <remarks>
+    /// The embedded template lives in <c>template/SimpleModule.Host/Styles/</c> and uses
+    /// monorepo-relative paths (<c>../../../packages/...</c>, <c>../../../modules/...</c>).
+    /// In a scaffolded project the layout is <c>src/&lt;Project&gt;.Host/Styles/</c>, so:
+    /// <list type="bullet">
+    /// <item>Framework packages live in <c>node_modules/@simplemodule/*</c> at the project root
+    /// (3 ups from Styles/) — installed via npm.</item>
+    /// <item>Modules live at <c>src/modules/</c> (2 ups from Styles/).</item>
+    /// </list>
+    /// We rewrite each <c>@import</c>/<c>@source</c> directive directly rather than blindly
+    /// rewriting path prefixes, since the original substrings overlap.
+    /// </remarks>
     public static string AppCss()
     {
         var lines = EmbeddedResourceReader.ReadTemplateLines("Templates.Host.Styles.app.css");
         lines.RemoveAll(line => line.Contains("_scan/", StringComparison.Ordinal));
 
-        // Replace module source paths for new project structure (template/ → src/)
-        var result = string.Join(Environment.NewLine, lines);
-        result = result.Replace("../../modules/", "../../../modules/", StringComparison.Ordinal);
+        var result = new List<string>(lines.Count);
+        foreach (var line in lines)
+        {
+            var rewritten = line.Replace(
+                    "../../../packages/SimpleModule.Theme.Default/theme.css",
+                    "../../../node_modules/@simplemodule/theme-default/theme.css",
+                    StringComparison.Ordinal
+                )
+                .Replace(
+                    "../../../packages/SimpleModule.UI/",
+                    "../../../node_modules/@simplemodule/ui/",
+                    StringComparison.Ordinal
+                )
+                .Replace(
+                    "../../../packages/SimpleModule.Client/",
+                    "../../../node_modules/@simplemodule/client/",
+                    StringComparison.Ordinal
+                )
+                .Replace("../../../modules/", "../../modules/", StringComparison.Ordinal);
 
-        return result;
+            result.Add(rewritten);
+        }
+
+        return string.Join(Environment.NewLine, result);
     }
 
     /// <summary>

--- a/cli/SimpleModule.Cli/Templates/ModuleTemplates.cs
+++ b/cli/SimpleModule.Cli/Templates/ModuleTemplates.cs
@@ -16,7 +16,7 @@ public sealed class ModuleTemplates
             solution is not null && solution.ExistingModules.Count > 0
                 ? solution.ExistingModules[0]
                 : null;
-        _refSingular = _refModule is not null ? GetSingularName(_refModule) : null;
+        _refSingular = _refModule is not null ? GetEntityName(_refModule) : null;
         _otherModuleNames =
             _refModule is not null && solution is not null
                 ? solution
@@ -34,11 +34,14 @@ public sealed class ModuleTemplates
         var refPath = RefContractsPath($"{_refModule}.Contracts.csproj");
         if (refPath is null)
         {
-            return FallbackContractsCsproj();
+            return FallbackContractsCsproj(moduleName);
         }
 
-        return ReplaceFrameworkProjectRefs(
-            TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName)
+        return EnsureAssemblyName(
+            ReplaceFrameworkProjectRefs(
+                TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName)
+            ),
+            $"SimpleModule.{moduleName}.Contracts"
         );
     }
 
@@ -53,8 +56,11 @@ public sealed class ModuleTemplates
         // Strip references to other modules and non-essential packages
         var stripPatterns = _otherModuleNames.Select(m => m).Append("Bogus").ToList();
 
-        return ReplaceFrameworkProjectRefs(
-            TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName, stripPatterns)
+        return EnsureAssemblyName(
+            ReplaceFrameworkProjectRefs(
+                TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName, stripPatterns)
+            ),
+            $"SimpleModule.{moduleName}"
         );
     }
 
@@ -67,8 +73,11 @@ public sealed class ModuleTemplates
         }
 
         var stripPatterns = _otherModuleNames.ToList();
-        return ReplaceFrameworkProjectRefs(
-            TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName, stripPatterns)
+        return EnsureAssemblyName(
+            ReplaceFrameworkProjectRefs(
+                TemplateExtractor.TransformCsproj(refPath, _refModule!, moduleName, stripPatterns)
+            ),
+            $"SimpleModule.{moduleName}.Tests"
         );
     }
 
@@ -459,7 +468,7 @@ public sealed class ModuleTemplates
         // Find the class declaration and simplify constructor params
         // Keep only the DbContext param, remove cross-module and infrastructure deps
         var crossModuleTypes = _otherModuleNames
-            .Select(m => $"I{GetSingularName(m)}")
+            .Select(m => $"I{GetEntityName(m)}")
             .Append("IMessageBus")
             .Append("ILogger<")
             .ToList();
@@ -689,6 +698,19 @@ public sealed class ModuleTemplates
         return pluralName;
     }
 
+    /// <summary>
+    /// Derives the entity type name for a module. Normally this is the singular form,
+    /// but when the singular equals the module name (e.g. "PageBuilder", "Marketplace"),
+    /// the entity would collide with the module's namespace, so an "Item" suffix is added.
+    /// </summary>
+    public static string GetEntityName(string moduleName)
+    {
+        var singular = GetSingularName(moduleName);
+        return string.Equals(singular, moduleName, StringComparison.Ordinal)
+            ? $"{moduleName}Item"
+            : singular;
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────
 
     private string? RefContractsPath(string relativePath)
@@ -777,6 +799,50 @@ public sealed class ModuleTemplates
         }
 
         return string.Join(Environment.NewLine, TemplateExtractor.CollapseBlankLines(result));
+    }
+
+    /// <summary>
+    /// Ensures the csproj content has explicit RootNamespace and AssemblyName set to the
+    /// expected SimpleModule.&lt;Module&gt; convention. This guards against the analyzer's SM0052
+    /// (assembly naming) and SM0053 (matching contracts assembly) checks when the csproj
+    /// filename and namespace prefix don't naturally agree.
+    /// </summary>
+    private static string EnsureAssemblyName(string csprojContent, string expectedName)
+    {
+        var hasAssembly = csprojContent.Contains("<AssemblyName>", StringComparison.Ordinal);
+        var hasRoot = csprojContent.Contains("<RootNamespace>", StringComparison.Ordinal);
+
+        if (hasAssembly && hasRoot)
+        {
+            return csprojContent;
+        }
+
+        var lines = csprojContent.Split(["\r\n", "\n"], StringSplitOptions.None).ToList();
+        var firstPropGroupIdx = lines.FindIndex(l =>
+            l.TrimStart().StartsWith("<PropertyGroup", StringComparison.Ordinal)
+        );
+
+        if (firstPropGroupIdx < 0)
+        {
+            return csprojContent;
+        }
+
+        var indent = "    ";
+        var insertAt = firstPropGroupIdx + 1;
+        var toInsert = new List<string>();
+
+        if (!hasRoot)
+        {
+            toInsert.Add($"{indent}<RootNamespace>{expectedName}</RootNamespace>");
+        }
+
+        if (!hasAssembly)
+        {
+            toInsert.Add($"{indent}<AssemblyName>{expectedName}</AssemblyName>");
+        }
+
+        lines.InsertRange(insertAt, toInsert);
+        return string.Join(Environment.NewLine, lines);
     }
 
     private List<string> OtherModuleStripPatterns()
@@ -871,8 +937,20 @@ public sealed class ModuleTemplates
     public static string TsconfigJson() =>
         """
             {
-              "extends": "@simplemodule/tsconfig/base",
+              "$schema": "https://json.schemastore.org/tsconfig",
               "compilerOptions": {
+                "target": "ES2022",
+                "module": "ESNext",
+                "moduleResolution": "bundler",
+                "jsx": "react-jsx",
+                "strict": true,
+                "esModuleInterop": true,
+                "skipLibCheck": true,
+                "forceConsistentCasingInFileNames": true,
+                "resolveJsonModule": true,
+                "isolatedModules": true,
+                "noEmit": true,
+                "allowImportingTsExtensions": true,
                 "paths": {
                   "@/*": ["./*"]
                 }
@@ -882,12 +960,14 @@ public sealed class ModuleTemplates
 
     // ── Fallback templates (when no reference module exists) ────────
 
-    private static string FallbackContractsCsproj() =>
-        """
+    private static string FallbackContractsCsproj(string moduleName) =>
+        $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
                 <TargetFramework>net10.0</TargetFramework>
                 <OutputType>Library</OutputType>
+                <RootNamespace>SimpleModule.{moduleName}.Contracts</RootNamespace>
+                <AssemblyName>SimpleModule.{moduleName}.Contracts</AssemblyName>
               </PropertyGroup>
               <ItemGroup>
                 <PackageReference Include="SimpleModule.Core" />
@@ -901,6 +981,8 @@ public sealed class ModuleTemplates
               <PropertyGroup>
                 <TargetFramework>net10.0</TargetFramework>
                 <OutputType>Library</OutputType>
+                <RootNamespace>SimpleModule.{moduleName}</RootNamespace>
+                <AssemblyName>SimpleModule.{moduleName}</AssemblyName>
               </PropertyGroup>
               <ItemGroup>
                 <FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -918,6 +1000,8 @@ public sealed class ModuleTemplates
                 <TargetFramework>net10.0</TargetFramework>
                 <IsPackable>false</IsPackable>
                 <OutputType>Exe</OutputType>
+                <RootNamespace>SimpleModule.{moduleName}.Tests</RootNamespace>
+                <AssemblyName>SimpleModule.{moduleName}.Tests</AssemblyName>
               </PropertyGroup>
               <ItemGroup>
                 <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/cli/SimpleModule.Cli/Templates/ProjectTemplates.cs
+++ b/cli/SimpleModule.Cli/Templates/ProjectTemplates.cs
@@ -261,39 +261,12 @@ public sealed class ProjectTemplates
         return content;
     }
 
-    public string TsconfigJson()
+    public static string TsconfigJson()
     {
-        if (_solution is null)
-        {
-            return FallbackTsconfigJson();
-        }
-
-        var path = Path.Combine(_solution.RootPath, "tsconfig.json");
-        if (!File.Exists(path))
-        {
-            return FallbackTsconfigJson();
-        }
-
-        var content = File.ReadAllText(path);
-
-        // Remove the SimpleModule.UI registry templates exclude entry
-        content = content.Replace(
-            ", \"src/SimpleModule.UI/registry/templates\"",
-            "",
-            StringComparison.Ordinal
-        );
-        content = content.Replace(
-            "\"src/SimpleModule.UI/registry/templates\", ",
-            "",
-            StringComparison.Ordinal
-        );
-        content = content.Replace(
-            "\"src/SimpleModule.UI/registry/templates\"",
-            "",
-            StringComparison.Ordinal
-        );
-
-        return content;
+        // The root tsconfig in the monorepo extends "@simplemodule/tsconfig/base", which
+        // isn't published to npm. Always emit a self-contained tsconfig for scaffolded
+        // projects so npm install + tsc work without that package.
+        return FallbackTsconfigJson();
     }
 
     public string EditorConfig()
@@ -713,7 +686,6 @@ public sealed class ProjectTemplates
         string clientDep;
         string uiDep;
         string themeDep;
-        string tsconfigDep;
 
         if (frameworkPackagesPath is not null)
         {
@@ -721,14 +693,12 @@ public sealed class ProjectTemplates
             clientDep = $"\"file:{pkgPath}/SimpleModule.Client\"";
             uiDep = $"\"file:{pkgPath}/SimpleModule.UI\"";
             themeDep = $"\"file:{pkgPath}/SimpleModule.Theme.Default\"";
-            tsconfigDep = $"\"file:{pkgPath}/SimpleModule.TsConfig\"";
         }
         else
         {
             clientDep = $"\"^{frameworkVersion}\"";
             uiDep = $"\"^{frameworkVersion}\"";
             themeDep = $"\"^{frameworkVersion}\"";
-            tsconfigDep = $"\"^{frameworkVersion}\"";
         }
 
         return $$"""
@@ -750,6 +720,7 @@ public sealed class ProjectTemplates
               },
               "devDependencies": {
                 "@biomejs/biome": "^2.4.10",
+                "@tailwindcss/cli": "^4.2.2",
                 "@tailwindcss/vite": "^4.2.2",
                 "@types/react": "^19.0.0",
                 "@types/react-dom": "^19.0.0",
@@ -763,7 +734,6 @@ public sealed class ProjectTemplates
                 "@simplemodule/client": {{clientDep}},
                 "@simplemodule/ui": {{uiDep}},
                 "@simplemodule/theme-default": {{themeDep}},
-                "@simplemodule/tsconfig": {{tsconfigDep}},
                 "esbuild": "^0.27.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
@@ -815,6 +785,7 @@ public sealed class ProjectTemplates
     private static string FallbackTsconfigJson() =>
         """
             {
+              "$schema": "https://json.schemastore.org/tsconfig",
               "compilerOptions": {
                 "target": "ES2022",
                 "module": "ESNext",
@@ -826,7 +797,8 @@ public sealed class ProjectTemplates
                 "forceConsistentCasingInFileNames": true,
                 "resolveJsonModule": true,
                 "isolatedModules": true,
-                "noEmit": true
+                "noEmit": true,
+                "allowImportingTsExtensions": true
               },
               "exclude": ["node_modules", "**/wwwroot/**"]
             }


### PR DESCRIPTION
## Summary

Fixes the five open scaffolding gaps that prevent a freshly-scaffolded SimpleModule project from building cleanly.

Closes #148, #149, #150, #151, #152.

### Per-issue changes

- **#148 — entity name collides with module namespace.** When the singular form of the module name equals the module name itself (e.g. `PageBuilder`, `Marketplace`, `Map`), the generated entity class shadows the `SimpleModule.<Name>` namespace and fails CS0118. Added `ModuleTemplates.GetEntityName(moduleName)` which returns `GetSingularName(moduleName)` when it differs, otherwise `${moduleName}Item`. Wired into `NewModuleCommand`, `NewProjectCommand`, `NewFeatureCommand`, and the reference-template lookups in `ModuleTemplates`/`FeatureTemplates`. `GetSingularName` itself is unchanged so existing tests still pass.

- **#149 — assembly name doesn't match SM0052/SM0053 expectations.** Generated module/contracts/test csproj filenames are `<Name>.csproj`, but the analyzer expects assemblies named `SimpleModule.<Name>`. Added a `ProjectGroup` post-process that injects explicit `<RootNamespace>` and `<AssemblyName>` properties when missing, plus baked them into the fallback templates. The csproj filename stays the same so existing structure tests keep passing.

- **#150 — `@simplemodule/tsconfig` not on npm.** Removed the `@simplemodule/tsconfig` dependency from the generated root `package.json`. Replaced the `extends "@simplemodule/tsconfig/base"` in both the root and per-module `tsconfig.json` with the equivalent inlined `compilerOptions`. `npm install` now succeeds against a clean scaffold.

- **#151 — missing `@tailwindcss/cli`.** Added `@tailwindcss/cli` to the generated root `package.json` `devDependencies` (alongside `@tailwindcss/vite`). The Tailwind v4 split means the `tailwindcss` package no longer ships a standalone bin, so `SimpleModule.Hosting.targets` was failing with exit code 127.

- **#152 — `Styles/app.css` monorepo-relative paths.** Rewrote `HostTemplates.AppCss()` to do explicit per-directive substitution rather than blind prefix replacement (the old `../../modules/` → `../../../modules/` rewrite produced an off-by-one `../../../../modules/`). Generated app.css now uses `node_modules/@simplemodule/{theme-default,ui,client}` (3 ups from `Styles/`) and `../../modules/**` (2 ups), matching the actual scaffolded layout.

## Verification

- `dotnet test` for `SimpleModule.Cli.Tests`: **128/128 passing**, including `ScaffoldedProject_DotnetBuildSucceeds` (the slow end-to-end scaffold + `dotnet build` against the live source generator).
- Manual `sm new project Repro` against this branch produces a `package.json` without `@simplemodule/tsconfig`, with `@tailwindcss/cli`, and a `Styles/app.css` whose paths resolve from `src/<Name>.Host/Styles/`.
- Manual `sm new module PageBuilder` in that scaffolded project produces `PageBuilderItem` entity (no namespace collision) and module/contracts csprojs with explicit `<RootNamespace>SimpleModule.PageBuilder</RootNamespace>` / `<AssemblyName>SimpleModule.PageBuilder</AssemblyName>`.

## Test plan

- [ ] CI green on `claude/github-issues-IGNzY`.
- [ ] After release, repro the original five issues against the next published `SimpleModule.Cli` and confirm they no longer reproduce.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LjeKSZF5xAHHn7C6sWAeRJ)_