### PR TITLE
feat(ui): add margin to Card component

### DIFF
--- a/packages/SimpleModule.UI/components/card.tsx
+++ b/packages/SimpleModule.UI/components/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        'bg-surface border border-border rounded-2xl p-5 transition-all duration-200 hover:border-border-strong',
+        'bg-surface border border-border rounded-2xl p-5 m-2 transition-all duration-200 hover:border-border-strong',
         className,
       )}
       {...props}

--- a/packages/SimpleModule.UI/registry/templates/card.tsx
+++ b/packages/SimpleModule.UI/registry/templates/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        'bg-surface border border-border rounded-2xl p-5 transition-all duration-200 hover:border-border-strong',
+        'bg-surface border border-border rounded-2xl p-5 m-2 transition-all duration-200 hover:border-border-strong',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Add `m-2` (8px) margin to the `Card` root in `packages/SimpleModule.UI/components/card.tsx` and the matching template at `packages/SimpleModule.UI/registry/templates/card.tsx`.
- Padding (`p-5`) was already present and left unchanged.

## Test plan
- [ ] Visually verify cards render with 8px outer margin and existing 20px inner padding.
- [ ] Confirm no layout regressions in pages that consume `Card` (Settings, AuditLogs, FeatureFlags, BackgroundJobs, etc.).


---
_Generated by [Claude Code](https://claude.ai/code/session_013GCrkCZxr7z325YkCpvxMp)_