### PR TITLE
fix(settings): decode JSON-encoded values in settings UI

### DIFF
--- a/modules/Email/src/SimpleModule.Email/EmailModule.cs
+++ b/modules/Email/src/SimpleModule.Email/EmailModule.cs
@@ -81,7 +81,7 @@ public class EmailModule : IModule, IModuleServices
                     Description = "The email provider to use (Log, SMTP)",
                     Group = "Email",
                     Scope = SettingScope.System,
-                    DefaultValue = "Log",
+                    DefaultValue = "\"Log\"",
                     Type = SettingType.Text,
                 }
             )
@@ -93,7 +93,7 @@ public class EmailModule : IModule, IModuleServices
                     Description = "Default sender email address",
                     Group = "Email",
                     Scope = SettingScope.System,
-                    DefaultValue = "noreply@localhost",
+                    DefaultValue = "\"noreply@localhost\"",
                     Type = SettingType.Text,
                 }
             )
@@ -117,7 +117,7 @@ public class EmailModule : IModule, IModuleServices
                     Description = "Cron expression for retrying failed emails",
                     Group = "Email",
                     Scope = SettingScope.System,
-                    DefaultValue = "*/5 * * * *",
+                    DefaultValue = "\"*/5 * * * *\"",
                     Type = SettingType.Text,
                 }
             );

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModule.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModule.cs
@@ -70,7 +70,7 @@ public class FileStorageModule : IModule
                     "Comma-separated list of allowed file extensions (e.g., .jpg,.pdf,.zip).",
                 Group = "FileStorage",
                 Scope = SettingScope.Application,
-                DefaultValue = ".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip",
+                DefaultValue = "\".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip\"",
                 Type = SettingType.Text,
             }
         );

--- a/modules/Settings/src/SimpleModule.Settings/components/SettingField.tsx
+++ b/modules/Settings/src/SimpleModule.Settings/components/SettingField.tsx
@@ -17,16 +17,72 @@ interface SettingFieldProps {
   onSave: (key: string, value: string, scope: number) => Promise<void>;
 }
 
+const SettingTypes = {
+  Text: 0,
+  Number: 1,
+  Bool: 2,
+  Json: 3,
+} as const;
+
+function decodeForDisplay(stored: string, type: number): string {
+  if (stored === '') return '';
+  try {
+    const parsed = JSON.parse(stored);
+    switch (type) {
+      case SettingTypes.Text:
+        return typeof parsed === 'string' ? parsed : stored;
+      case SettingTypes.Number:
+        return typeof parsed === 'number' ? String(parsed) : stored;
+      case SettingTypes.Bool:
+        return typeof parsed === 'boolean' ? String(parsed) : stored;
+      case SettingTypes.Json:
+        return JSON.stringify(parsed, null, 2);
+      default:
+        return stored;
+    }
+  } catch {
+    return stored;
+  }
+}
+
+function encodeForStorage(input: string, type: number): string {
+  switch (type) {
+    case SettingTypes.Text:
+      return JSON.stringify(input);
+    case SettingTypes.Number: {
+      const num = Number(input);
+      return Number.isFinite(num) && input.trim() !== '' ? String(num) : JSON.stringify(input);
+    }
+    case SettingTypes.Bool:
+      return input === 'true' ? 'true' : 'false';
+    case SettingTypes.Json:
+      return input;
+    default:
+      return input;
+  }
+}
+
 export default function SettingField({ definition, currentValue, onSave }: SettingFieldProps) {
-  const initial = currentValue ?? definition.defaultValue ?? '';
+  const storedRaw = currentValue ?? definition.defaultValue ?? '';
+  const initial = decodeForDisplay(storedRaw, definition.type);
   const [value, setValue] = useState(initial);
   const [saving, setSaving] = useState(false);
+  const [jsonError, setJsonError] = useState<string | null>(null);
   const hasChanged = value !== initial;
 
   const handleSave = async () => {
+    if (definition.type === SettingTypes.Json) {
+      try {
+        JSON.parse(value);
+        setJsonError(null);
+      } catch (err) {
+        setJsonError(err instanceof Error ? err.message : 'Invalid JSON');
+        return;
+      }
+    }
     setSaving(true);
     try {
-      await onSave(definition.key, value, definition.scope);
+      await onSave(definition.key, encodeForStorage(value, definition.type), definition.scope);
     } finally {
       setSaving(false);
     }
@@ -34,26 +90,46 @@ export default function SettingField({ definition, currentValue, onSave }: Setti
 
   const renderInput = () => {
     switch (definition.type) {
-      case 0: // Text
-        return <Input value={value} onChange={(e) => setValue(e.target.value)} />;
-      case 1: // Number
-        return <Input type="number" value={value} onChange={(e) => setValue(e.target.value)} />;
-      case 2: // Bool
+      case SettingTypes.Text:
+        return (
+          <Input id={definition.key} value={value} onChange={(e) => setValue(e.target.value)} />
+        );
+      case SettingTypes.Number:
+        return (
+          <Input
+            id={definition.key}
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      case SettingTypes.Bool:
         return (
           <Switch
+            id={definition.key}
             checked={value === 'true'}
+            disabled={saving}
             onCheckedChange={(checked) => {
               const newVal = String(checked);
               setValue(newVal);
-              onSave(definition.key, newVal, definition.scope);
+              setSaving(true);
+              onSave(
+                definition.key,
+                encodeForStorage(newVal, definition.type),
+                definition.scope,
+              ).finally(() => setSaving(false));
             }}
           />
         );
-      case 3: // Json
+      case SettingTypes.Json:
         return (
           <Textarea
+            id={definition.key}
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) => {
+              setValue(e.target.value);
+              if (jsonError) setJsonError(null);
+            }}
             rows={4}
             className="font-mono text-sm"
           />
@@ -69,7 +145,8 @@ export default function SettingField({ definition, currentValue, onSave }: Setti
         <p className="text-sm text-muted-foreground">{definition.description}</p>
       )}
       {renderInput()}
-      {definition.type !== 2 && hasChanged && (
+      {jsonError && <p className="text-sm text-destructive">{jsonError}</p>}
+      {definition.type !== SettingTypes.Bool && hasChanged && (
         <Button size="sm" onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
         </Button>

--- a/modules/Settings/src/SimpleModule.Settings/components/SettingField.tsx
+++ b/modules/Settings/src/SimpleModule.Settings/components/SettingField.tsx
@@ -1,21 +1,5 @@
 import { Button, Input, Switch, Textarea } from '@simplemodule/ui';
-import { useState } from 'react';
-
-interface SettingDefinition {
-  key: string;
-  displayName: string;
-  description?: string;
-  group?: string;
-  scope: number;
-  defaultValue?: string;
-  type: number;
-}
-
-interface SettingFieldProps {
-  definition: SettingDefinition;
-  currentValue?: string | null;
-  onSave: (key: string, value: string, scope: number) => Promise<void>;
-}
+import { useMemo, useState } from 'react';
 
 const SettingTypes = {
   Text: 0,
@@ -24,7 +8,25 @@ const SettingTypes = {
   Json: 3,
 } as const;
 
-function decodeForDisplay(stored: string, type: number): string {
+type SettingType = (typeof SettingTypes)[keyof typeof SettingTypes];
+
+interface SettingDefinition {
+  key: string;
+  displayName: string;
+  description?: string;
+  group?: string;
+  scope: number;
+  defaultValue?: string;
+  type: SettingType;
+}
+
+interface SettingFieldProps {
+  definition: SettingDefinition;
+  currentValue?: string | null;
+  onSave: (key: string, value: string, scope: number) => Promise<void>;
+}
+
+function decodeForDisplay(stored: string, type: SettingType): string {
   if (stored === '') return '';
   try {
     const parsed = JSON.parse(stored);
@@ -45,7 +47,7 @@ function decodeForDisplay(stored: string, type: number): string {
   }
 }
 
-function encodeForStorage(input: string, type: number): string {
+function encodeForStorage(input: string, type: SettingType): string {
   switch (type) {
     case SettingTypes.Text:
       return JSON.stringify(input);
@@ -64,16 +66,19 @@ function encodeForStorage(input: string, type: number): string {
 
 export default function SettingField({ definition, currentValue, onSave }: SettingFieldProps) {
   const storedRaw = currentValue ?? definition.defaultValue ?? '';
-  const initial = decodeForDisplay(storedRaw, definition.type);
+  const initial = useMemo(
+    () => decodeForDisplay(storedRaw, definition.type),
+    [storedRaw, definition.type],
+  );
   const [value, setValue] = useState(initial);
   const [saving, setSaving] = useState(false);
   const [jsonError, setJsonError] = useState<string | null>(null);
   const hasChanged = value !== initial;
 
-  const handleSave = async () => {
+  const performSave = async (rawInput: string) => {
     if (definition.type === SettingTypes.Json) {
       try {
-        JSON.parse(value);
+        JSON.parse(rawInput);
         setJsonError(null);
       } catch (err) {
         setJsonError(err instanceof Error ? err.message : 'Invalid JSON');
@@ -82,7 +87,7 @@ export default function SettingField({ definition, currentValue, onSave }: Setti
     }
     setSaving(true);
     try {
-      await onSave(definition.key, encodeForStorage(value, definition.type), definition.scope);
+      await onSave(definition.key, encodeForStorage(rawInput, definition.type), definition.scope);
     } finally {
       setSaving(false);
     }
@@ -112,12 +117,7 @@ export default function SettingField({ definition, currentValue, onSave }: Setti
             onCheckedChange={(checked) => {
               const newVal = String(checked);
               setValue(newVal);
-              setSaving(true);
-              onSave(
-                definition.key,
-                encodeForStorage(newVal, definition.type),
-                definition.scope,
-              ).finally(() => setSaving(false));
+              void performSave(newVal);
             }}
           />
         );
@@ -147,7 +147,7 @@ export default function SettingField({ definition, currentValue, onSave }: Setti
       {renderInput()}
       {jsonError && <p className="text-sm text-destructive">{jsonError}</p>}
       {definition.type !== SettingTypes.Bool && hasChanged && (
-        <Button size="sm" onClick={handleSave} disabled={saving}>
+        <Button size="sm" onClick={() => performSave(value)} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
         </Button>
       )}


### PR DESCRIPTION
## Summary

Setting values are stored JSON-encoded (e.g. `"\"SimpleModule\""`, `"true"`, `"42"`) so `SettingsService.GetSettingAsync<T>()` can `JsonSerializer.Deserialize<T>` them. The React `SettingField` rendered the raw stored string, so:

- Text settings showed up wrapped in literal double quotes (`"SimpleModule"` instead of `SimpleModule`).
- Saving from the UI sent the unencoded value back, breaking the round-trip and making typed reads fail silently.

## Changes

`modules/Settings/src/SimpleModule.Settings/components/SettingField.tsx`:

- `decodeForDisplay(stored, type)` — parses the stored JSON and returns the human-readable form per `SettingType` (Text → string, Number → numeric string, Bool → `true`/`false`, JSON → pretty-printed).
- `encodeForStorage(input, type)` — re-encodes the user input as JSON before sending to the API so the round-trip survives.
- Bool toggle now goes through the same encoder.
- JSON type validates input via `JSON.parse` before save and surfaces the parser error inline instead of silently posting invalid JSON.
- Inputs now expose `id={definition.key}` so the existing `<label htmlFor>` in `SettingGroup`/`UserSettings` actually associates with the control.

Falls back to the raw stored string if `JSON.parse` fails (handles legacy unencoded data already in the DB).

## Test plan

- [ ] `npm run check` passes (biome + typecheck + page validation).
- [ ] `dotnet test modules/Settings/...` — 27 existing settings tests pass.
- [ ] Manually load `/settings` (admin) and `/settings/me` (user); verify text fields render unquoted, toggles reflect the boolean state, JSON area shows pretty-printed JSON.
- [ ] Edit and save each type; reload the page and confirm the value persists and renders correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VW1dGhM82iodbgJsk39vun)_