### PR TITLE
feat(users): self-service account unlock via email

### DIFF
--- a/modules/Email/src/SimpleModule.Email/EmailModule.cs
+++ b/modules/Email/src/SimpleModule.Email/EmailModule.cs
@@ -64,6 +64,7 @@ public class EmailModule : IModule, IModuleServices
 
         // Replace Identity's ConsoleEmailSender with a real one
         services.AddScoped<IEmailSender<ApplicationUser>, IdentityEmailSender>();
+        services.AddScoped<IAccountUnlockEmailSender, IdentityAccountUnlockEmailSender>();
 
         services.AddModuleJob<SendEmailJob>();
         services.AddModuleJob<RetryFailedEmailsJob>();

--- a/modules/Email/src/SimpleModule.Email/Services/IdentityAccountUnlockEmailSender.cs
+++ b/modules/Email/src/SimpleModule.Email/Services/IdentityAccountUnlockEmailSender.cs
@@ -1,0 +1,22 @@
+using SimpleModule.Email.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Email.Services;
+
+public class IdentityAccountUnlockEmailSender(IEmailContracts emailContracts)
+    : IAccountUnlockEmailSender
+{
+    public async Task SendUnlockLinkAsync(string email, string unlockLink)
+    {
+        await emailContracts.SendEmailAsync(
+            new SendEmailRequest
+            {
+                To = email,
+                Subject = "Unlock your account",
+                Body =
+                    $"""Your account has been locked due to multiple failed sign-in attempts. <a href="{unlockLink}">Click here to unlock your account</a>.""",
+                IsHtml = true,
+            }
+        );
+    }
+}

--- a/modules/Users/src/SimpleModule.Users.Contracts/Events/UserSelfUnlockedEvent.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/Events/UserSelfUnlockedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Users.Contracts.Events;
+
+public sealed record UserSelfUnlockedEvent(UserId UserId, string Email) : IEvent;

--- a/modules/Users/src/SimpleModule.Users.Contracts/IAccountUnlockEmailSender.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/IAccountUnlockEmailSender.cs
@@ -1,0 +1,6 @@
+namespace SimpleModule.Users.Contracts;
+
+public interface IAccountUnlockEmailSender
+{
+    Task SendUnlockLinkAsync(string email, string unlockLink);
+}

--- a/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
@@ -32,6 +32,9 @@ public static class UsersConstants
         public const string LoginWith2fa = "/LoginWith2fa";
         public const string LoginWithRecoveryCode = "/LoginWithRecoveryCode";
         public const string Lockout = "/Lockout";
+        public const string SendUnlockEmail = "/SendUnlockEmail";
+        public const string SendUnlockEmailConfirmation = "/SendUnlockEmailConfirmation";
+        public const string UnlockAccount = "/UnlockAccount";
         public const string AccessDenied = "/AccessDenied";
         public const string Error = "/Error";
         public const string RegisterConfirmation = "/RegisterConfirmation";

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@inertiajs/react';
 import { Card, CardContent, Container } from '@simplemodule/ui';
 
 export default function Lockout() {
@@ -8,8 +9,19 @@ export default function Lockout() {
           <Card>
             <CardContent className="p-8">
               <h1 className="text-xl font-bold text-danger mb-2">Locked out</h1>
-              <p className="text-sm text-danger">
+              <p className="text-sm text-danger mb-4">
                 This account has been locked out, please try again later.
+              </p>
+              <hr className="mb-4" />
+              <p className="text-sm text-text-muted">
+                You can also{' '}
+                <Link
+                  href="/Identity/Account/SendUnlockEmail"
+                  className="text-primary underline hover:no-underline"
+                >
+                  receive an unlock link by email
+                </Link>
+                .
               </p>
             </CardContent>
           </Card>

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmail.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmail.tsx
@@ -1,0 +1,55 @@
+import { router } from '@inertiajs/react';
+import {
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+} from '@simplemodule/ui';
+
+export default function SendUnlockEmail() {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    router.post('/Identity/Account/SendUnlockEmail', formData);
+  }
+
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1 className="text-xl font-bold mb-2">Unlock your account</h1>
+              <p className="text-sm text-text-muted mb-6">
+                Enter your email to receive an unlock link.
+              </p>
+              <hr className="mb-6" />
+              <form onSubmit={handleSubmit}>
+                <FieldGroup>
+                  <Field>
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      name="email"
+                      type="email"
+                      required
+                      autoComplete="username"
+                      placeholder="name@example.com"
+                    />
+                  </Field>
+                  <Button type="submit" className="w-full">
+                    Send Unlock Link
+                  </Button>
+                </FieldGroup>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmation.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmation.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, Container } from '@simplemodule/ui';
+
+export default function SendUnlockEmailConfirmation() {
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1 className="text-xl font-bold mb-4">Check your email</h1>
+              <p className="text-sm">
+                If an account with that email exists and is currently locked, we've sent an unlock
+                link. Please check your email.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmationEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmationEndpoint.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class SendUnlockEmailConfirmationEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.SendUnlockEmailConfirmation;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Route, () => Inertia.Render("Users/Account/SendUnlockEmailConfirmation"))
+            .AllowAnonymous();
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Core.RateLimiting;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class SendUnlockEmailEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.SendUnlockEmail;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Route, () => Inertia.Render("Users/Account/SendUnlockEmail")).AllowAnonymous();
+
+        app.MapPost(
+                Route,
+                async (
+                    [FromForm] string email,
+                    UserManager<ApplicationUser> userManager,
+                    IAccountUnlockEmailSender unlockEmailSender,
+                    HttpContext context
+                ) =>
+                {
+                    var user = await userManager.FindByEmailAsync(email);
+                    if (user is not null && await userManager.IsLockedOutAsync(user))
+                    {
+                        var code = await userManager.GenerateUserTokenAsync(
+                            user,
+                            TokenOptions.DefaultProvider,
+                            "AccountUnlock"
+                        );
+                        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+                        var request = context.Request;
+                        var baseUrl = $"{request.Scheme}://{request.Host}";
+                        var callbackUrl =
+                            $"{baseUrl}{UsersConstants.ViewPrefix}{UsersConstants.Routes.UnlockAccount}?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(code)}";
+
+                        await unlockEmailSender.SendUnlockLinkAsync(email, callbackUrl);
+                    }
+
+                    // Always redirect to confirmation — don't reveal whether the email exists or is locked
+                    return TypedResults.Redirect(
+                        $"{UsersConstants.ViewPrefix}{UsersConstants.Routes.SendUnlockEmailConfirmation}"
+                    );
+                }
+            )
+            .AllowAnonymous()
+            .DisableAntiforgery()
+            .RateLimit("auth-strict");
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@inertiajs/react';
+import { Button, Card, CardContent, Container } from '@simplemodule/ui';
+
+interface Props {
+  success: boolean;
+  message: string;
+}
+
+export default function UnlockAccount({ success, message }: Props) {
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1
+                className={`text-xl font-bold mb-4 ${success ? 'text-success' : 'text-danger'}`}
+              >
+                {success ? 'Account unlocked' : 'Unlock failed'}
+              </h1>
+              <p className="text-sm mb-6">{message}</p>
+              {success && (
+                <Link href="/Identity/Account/Login">
+                  <Button className="w-full">Sign in</Button>
+                </Link>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Users.Contracts;
+using SimpleModule.Users.Contracts.Events;
+using Wolverine;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class UnlockAccountEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.UnlockAccount;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                Route,
+                async Task<IResult> (
+                    [FromQuery] string? userId,
+                    [FromQuery] string? code,
+                    UserManager<ApplicationUser> userManager,
+                    IMessageBus bus
+                ) =>
+                {
+                    if (userId is null || code is null)
+                    {
+                        return TypedResults.Redirect("/");
+                    }
+
+                    var user = await userManager.FindByIdAsync(userId);
+                    if (user is null)
+                    {
+                        return Inertia.Render(
+                            "Users/Account/UnlockAccount",
+                            new { success = false, message = "Unable to unlock account." }
+                        );
+                    }
+
+                    var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+                    var isValid = await userManager.VerifyUserTokenAsync(
+                        user,
+                        TokenOptions.DefaultProvider,
+                        "AccountUnlock",
+                        decodedCode
+                    );
+
+                    if (!isValid)
+                    {
+                        return Inertia.Render(
+                            "Users/Account/UnlockAccount",
+                            new
+                            {
+                                success = false,
+                                message = "Invalid or expired unlock link.",
+                            }
+                        );
+                    }
+
+                    user.LockoutEnd = null;
+                    user.AccessFailedCount = 0;
+                    await userManager.UpdateAsync(user);
+                    await userManager.UpdateSecurityStampAsync(user);
+
+                    await bus.PublishAsync(
+                        new UserSelfUnlockedEvent(
+                            UserId.From(user.Id),
+                            user.Email ?? string.Empty
+                        )
+                    );
+
+                    return Inertia.Render(
+                        "Users/Account/UnlockAccount",
+                        new
+                        {
+                            success = true,
+                            message = "Your account has been unlocked successfully.",
+                        }
+                    );
+                }
+            )
+            .AllowAnonymous();
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/index.ts
+++ b/modules/Users/src/SimpleModule.Users/Pages/index.ts
@@ -14,6 +14,10 @@ export const pages: Record<string, unknown> = {
   'Users/Account/LoginWith2fa': () => import('./Account/LoginWith2fa'),
   'Users/Account/LoginWithRecoveryCode': () => import('./Account/LoginWithRecoveryCode'),
   'Users/Account/Lockout': () => import('./Account/Lockout'),
+  'Users/Account/SendUnlockEmail': () => import('./Account/SendUnlockEmail'),
+  'Users/Account/SendUnlockEmailConfirmation': () =>
+    import('./Account/SendUnlockEmailConfirmation'),
+  'Users/Account/UnlockAccount': () => import('./Account/UnlockAccount'),
   'Users/Account/AccessDenied': () => import('./Account/AccessDenied'),
   'Users/Account/Error': () => import('./Account/Error'),
   'Users/Account/ExternalLogin': () => import('./Account/ExternalLogin'),

--- a/modules/Users/src/SimpleModule.Users/Services/ConsoleAccountUnlockEmailSender.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/ConsoleAccountUnlockEmailSender.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Services;
+
+public partial class ConsoleAccountUnlockEmailSender(
+    ILogger<ConsoleAccountUnlockEmailSender> logger
+) : IAccountUnlockEmailSender
+{
+    public Task SendUnlockLinkAsync(string email, string unlockLink)
+    {
+        LogUnlockLink(logger, email, unlockLink);
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Account unlock for {Email}: {Link}")]
+    private static partial void LogUnlockLink(ILogger logger, string email, string link);
+}

--- a/modules/Users/src/SimpleModule.Users/UsersModule.cs
+++ b/modules/Users/src/SimpleModule.Users/UsersModule.cs
@@ -80,6 +80,7 @@ public class UsersModule : IModule
 
         services.AddHostedService<UserSeedService>();
         services.AddSingleton<IEmailSender<ApplicationUser>, ConsoleEmailSender>();
+        services.AddSingleton<IAccountUnlockEmailSender, ConsoleAccountUnlockEmailSender>();
     }
 
     public void ConfigurePermissions(PermissionRegistryBuilder builder)

--- a/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
+++ b/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Tests.Shared.Fixtures;
+using SimpleModule.Users.Contracts;
+
+namespace Users.Tests.Integration;
+
+[Collection(TestCollections.Integration)]
+public class AccountUnlockEndpointTests
+{
+    private readonly SimpleModuleWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public AccountUnlockEndpointTests(SimpleModuleWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+            }
+        );
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_UnknownEmail_RedirectsToConfirmation()
+    {
+        using var content = new FormUrlEncodedContent(
+            [new KeyValuePair<string, string>("email", "nonexistent@example.com")]
+        );
+
+        var response = await _client.PostAsync(
+            "/Identity/Account/SendUnlockEmail",
+            content
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should()
+            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_LockedUser_RedirectsToConfirmation()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "locked-unlock-test@example.com",
+            Email = "locked-unlock-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Locked User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+        await userManager.SetLockoutEnabledAsync(user, true);
+        await userManager.SetLockoutEndDateAsync(
+            user,
+            DateTimeOffset.UtcNow.AddHours(1)
+        );
+
+        using var content = new FormUrlEncodedContent(
+            [new KeyValuePair<string, string>("email", user.Email)]
+        );
+
+        var response = await _client.PostAsync(
+            "/Identity/Account/SendUnlockEmail",
+            content
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should()
+            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+    }
+
+    [Fact]
+    public async Task UnlockAccount_MissingParams_RedirectsToHome()
+    {
+        var response = await _client.GetAsync("/Identity/Account/UnlockAccount");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().Be("/");
+    }
+
+    [Fact]
+    public async Task UnlockAccount_InvalidUserId_ReturnsPage()
+    {
+        var response = await _client.GetAsync(
+            "/Identity/Account/UnlockAccount?userId=nonexistent&code=bogus"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task UnlockAccount_InvalidToken_ReturnsPage()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "invalid-token-test@example.com",
+            Email = "invalid-token-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Token Test User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+
+        var tamperedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("tampered-token"));
+        var response = await _client.GetAsync(
+            $"/Identity/Account/UnlockAccount?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(tamperedCode)}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task UnlockAccount_ValidToken_UnlocksUser()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "valid-unlock-test@example.com",
+            Email = "valid-unlock-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Valid Unlock User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+        await userManager.SetLockoutEnabledAsync(user, true);
+        await userManager.SetLockoutEndDateAsync(
+            user,
+            DateTimeOffset.UtcNow.AddHours(1)
+        );
+
+        // Generate a valid unlock token
+        var code = await userManager.GenerateUserTokenAsync(
+            user,
+            TokenOptions.DefaultProvider,
+            "AccountUnlock"
+        );
+        var encodedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+        var response = await _client.GetAsync(
+            $"/Identity/Account/UnlockAccount?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(encodedCode)}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify the user is actually unlocked
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyManager =
+            verifyScope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var updatedUser = await verifyManager.FindByIdAsync(user.Id);
+        updatedUser.Should().NotBeNull();
+        (await verifyManager.IsLockedOutAsync(updatedUser!)).Should().BeFalse();
+        updatedUser!.AccessFailedCount.Should().Be(0);
+    }
+}

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -88,19 +88,16 @@ export const routes = {
   },
   tenants: {
     api: {
-      deleteTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      deleteTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       getTenantFeatures: (id: string | number) => `/api/tenants/${id}/features`,
-      setTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      setTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       addHost: (id: string | number) => `/api/tenants/${id}/hosts`,
       changeStatus: (id: string | number) => `/api/tenants/${id}/status`,
       create: () => '/api/tenants' as const,
       delete: (id: string | number) => `/api/tenants/${id}`,
       getAll: () => '/api/tenants' as const,
       getById: (id: string | number) => `/api/tenants/${id}`,
-      removeHost: (id: string | number, hostId: string | number) =>
-        `/api/tenants/${id}/hosts/${hostId}`,
+      removeHost: (id: string | number, hostId: string | number) => `/api/tenants/${id}/hosts/${hostId}`,
       update: (id: string | number) => `/api/tenants/${id}`,
     },
     views: {
@@ -157,7 +154,10 @@ export const routes = {
       resetAuthenticator: () => '/Identity/Account/Manage/ResetAuthenticator' as const,
       resetPasswordConfirmation: () => '/Identity/Account/ResetPasswordConfirmation' as const,
       resetPassword: () => '/Identity/Account/ResetPassword' as const,
+      sendUnlockEmailConfirmation: () => '/Identity/Account/SendUnlockEmailConfirmation' as const,
+      sendUnlockEmail: () => '/Identity/Account/SendUnlockEmail' as const,
       twoFactorAuthentication: () => '/Identity/Account/Manage/TwoFactorAuthentication' as const,
+      unlockAccount: () => '/Identity/Account/UnlockAccount' as const,
       changePassword: () => '/Identity/Account/Manage/ChangePassword' as const,
       deletePersonalData: () => '/Identity/Account/Manage/DeletePersonalData' as const,
       email: () => '/Identity/Account/Manage/Email' as const,
@@ -205,8 +205,7 @@ export const routes = {
   admin: {
     api: {
       adminRoles: () => '/admin/roles' as const,
-      adminSessions: (id: string | number, tokenId: string | number) =>
-        `/admin/users/${id}/sessions/${tokenId}`,
+      adminSessions: (id: string | number, tokenId: string | number) => `/admin/users/${id}/sessions/${tokenId}`,
       adminUsers: () => '/admin/users' as const,
     },
     views: {
@@ -220,3 +219,4 @@ export const routes = {
     },
   },
 } as const;
+


### PR DESCRIPTION
## Summary

- Adds a self-service unlock flow so locked-out users can request an unlock link by email instead of waiting or contacting an admin
- Lockout page now offers a "receive an unlock link by email" option
- Token-based unlock with security stamp rotation (single-use links)
- Rate-limited via `auth-strict` policy, no account enumeration leak
- Audit event (`UserSelfUnlockedEvent`) emitted on successful self-unlock

## Test plan

- [x] `dotnet build` — no errors or warnings
- [x] `dotnet test --filter "AccountUnlock"` — 6 integration tests pass:
  - Unknown email → generic confirmation (no enumeration leak)
  - Locked user → generic confirmation + email sent
  - Missing params → redirect to home
  - Invalid userId → error page
  - Tampered token → error page
  - Valid token → account unlocked, lockout cleared, access failed count reset
- [x] All 46 existing Users tests still pass

Closes #181