### PR TITLE
fix(openiddict): group active sessions by authorization, add ManageLayout, expand tests

### DIFF
--- a/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/IOpenIddictSessionContracts.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/IOpenIddictSessionContracts.cs
@@ -1,12 +1,39 @@
 namespace SimpleModule.OpenIddict.Contracts;
 
+public enum RevokeSessionResult
+{
+    /// <summary>The session existed, was owned by the caller, and has been revoked.</summary>
+    Revoked,
+
+    /// <summary>The token id was unknown or belonged to a different user. The endpoint
+    /// surfaces this as 404 so the response shape doesn't leak whether a token id
+    /// exists for someone else.</summary>
+    NotFound,
+
+    /// <summary>The token is part of the caller's own session (shares an authorization
+    /// with the request's token). Refused to prevent self-lockout.</summary>
+    BlockedCurrent,
+}
+
 public interface IOpenIddictSessionContracts
 {
+    /// <summary>
+    /// Returns one row per valid token. Used by the admin tab where each token
+    /// (access / refresh / rotation) is shown individually.
+    /// </summary>
     Task<IReadOnlyList<UserSessionDto>> GetActiveSessionsForUserAsync(
         string userId,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Returns one row per authorization (i.e. per login). Tokens sharing an
+    /// AuthorizationId collapse to a single "session" entry so the user can't
+    /// revoke their refresh token while leaving their access token live, or
+    /// vice versa. The DTO's <c>TokenId</c> is the anchor token id used for
+    /// subsequent revoke calls; <c>IsCurrent</c> is set when the group contains
+    /// <paramref name="currentTokenId"/>.
+    /// </summary>
     Task<IReadOnlyList<UserSessionDto>> GetActiveSessionsForUserAsync(
         string userId,
         string? currentTokenId,
@@ -14,15 +41,16 @@ public interface IOpenIddictSessionContracts
     );
 
     /// <summary>
-    /// Revokes the token if and only if its subject equals <paramref name="userId"/>.
-    /// Returns true on revoke, false if the token does not exist or belongs to a
-    /// different user. Single round-trip — used by the user-facing revoke endpoint
-    /// to defend against cross-user token-id guessing without a separate ownership
-    /// query.
+    /// Revokes the authorization containing <paramref name="tokenId"/>, but only
+    /// if it belongs to <paramref name="userId"/> and does not share an
+    /// authorization with <paramref name="currentTokenId"/>. Returns a result the
+    /// endpoint maps to 200 / 400 / 404. Single-load ownership check defends
+    /// against cross-user token-id guessing without a separate query.
     /// </summary>
-    Task<bool> TryRevokeSessionForUserAsync(
+    Task<RevokeSessionResult> TryRevokeSessionForUserAsync(
         string tokenId,
         string userId,
+        string? currentTokenId,
         CancellationToken cancellationToken = default
     );
 
@@ -33,6 +61,11 @@ public interface IOpenIddictSessionContracts
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Revokes every valid token for the user except those sharing an authorization
+    /// with <paramref name="currentTokenId"/>. When <paramref name="currentTokenId"/>
+    /// is null, revokes everything (equivalent to <see cref="RevokeAllSessionsForUserAsync"/>).
+    /// </summary>
     Task RevokeOtherSessionsForUserAsync(
         string userId,
         string? currentTokenId,

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/Account/Manage/ActiveSessions.tsx
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/Account/Manage/ActiveSessions.tsx
@@ -3,9 +3,6 @@ import { routes } from '@simplemodule/client/routes';
 import {
   Badge,
   Button,
-  Card,
-  CardContent,
-  PageShell,
   Table,
   TableBody,
   TableCell,
@@ -13,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@simplemodule/ui';
+import ManageLayout from '@/components/ManageLayout';
 
 interface Session {
   tokenId: string;
@@ -42,91 +40,80 @@ export default function ActiveSessions({ sessions }: Props) {
   }
 
   return (
-    <PageShell
-      title="Active sessions"
-      description="Apps and devices that are currently signed in to your account."
-      breadcrumbs={[
-        { label: 'Home', href: '/' },
-        { label: 'Account Settings', href: '/Identity/Account/Manage' },
-        { label: 'Active sessions' },
-      ]}
-    >
-      <Card>
-        <CardContent className="p-4 sm:p-6 md:p-8">
+    <ManageLayout activePage="ActiveSessions">
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-medium">Active sessions</h2>
+            <p className="text-sm text-text-muted">
+              Apps and devices that are currently signed in to your account.
+            </p>
+          </div>
           {hasOtherSessions && (
-            <div className="flex justify-end mb-4">
-              <Button variant="danger" size="sm" onClick={handleRevokeOthers}>
-                Sign out of all other devices
-              </Button>
-            </div>
+            <Button variant="danger" size="sm" onClick={handleRevokeOthers}>
+              Sign out of all other devices
+            </Button>
           )}
-          {sessions.length === 0 ? (
-            <p className="text-sm text-text-muted">No active sessions.</p>
-          ) : (
-            <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Application</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sessions.map((session) => {
-                    const created = session.creationDate
-                      ? new Date(session.creationDate)
-                      : null;
-                    const isStale =
-                      !session.isCurrent &&
-                      created !== null &&
-                      created.getTime() < staleBefore;
-                    return (
-                      <TableRow key={session.tokenId}>
-                        <TableCell>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Badge
-                              variant={session.type === 'refresh_token' ? 'info' : 'default'}
-                            >
-                              {session.type === 'refresh_token' ? 'Refresh' : 'Access'}
-                            </Badge>
-                            {session.isCurrent && <Badge variant="success">This device</Badge>}
-                            {isStale && <Badge variant="warning">Stale</Badge>}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-sm">
-                          {session.applicationName || '—'}
-                        </TableCell>
-                        <TableCell className="text-sm text-text-muted">
-                          {created ? created.toLocaleString() : '—'}
-                        </TableCell>
-                        <TableCell className="text-sm text-text-muted">
-                          {session.expirationDate
-                            ? new Date(session.expirationDate).toLocaleString()
-                            : 'Never'}
-                        </TableCell>
-                        <TableCell>
-                          {!session.isCurrent && (
-                            <Button
-                              variant="danger"
-                              size="sm"
-                              onClick={() => handleRevoke(session.tokenId)}
-                            >
-                              Revoke
-                            </Button>
+        </div>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-text-muted">No active sessions.</p>
+        ) : (
+          <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Application</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Expires</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sessions.map((session) => {
+                  const created = session.creationDate ? new Date(session.creationDate) : null;
+                  const isStale =
+                    !session.isCurrent && created !== null && created.getTime() < staleBefore;
+                  return (
+                    <TableRow key={session.tokenId}>
+                      <TableCell>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {session.isCurrent ? (
+                            <Badge variant="success">This device</Badge>
+                          ) : (
+                            <Badge variant="default">Active</Badge>
                           )}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </PageShell>
+                          {isStale && <Badge variant="warning">Stale</Badge>}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm">{session.applicationName || '—'}</TableCell>
+                      <TableCell className="text-sm text-text-muted">
+                        {created ? created.toLocaleString() : '—'}
+                      </TableCell>
+                      <TableCell className="text-sm text-text-muted">
+                        {session.expirationDate
+                          ? new Date(session.expirationDate).toLocaleString()
+                          : 'Never'}
+                      </TableCell>
+                      <TableCell>
+                        {!session.isCurrent && (
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => handleRevoke(session.tokenId)}
+                          >
+                            Revoke
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </ManageLayout>
   );
 }

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/ActiveSessionsEndpoint.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/ActiveSessionsEndpoint.cs
@@ -23,12 +23,7 @@ public class ActiveSessionsEndpoint : IEndpoint
                     IOpenIddictSessionContracts sessionContracts
                 ) =>
                 {
-                    var userId = principal.GetUserId();
-                    if (string.IsNullOrEmpty(userId))
-                    {
-                        return TypedResults.Redirect("/Identity/Account/Login");
-                    }
-
+                    var userId = principal.GetUserId()!;
                     var currentTokenId = ActiveSessionsHelpers.GetCurrentTokenId(principal);
                     var sessions = await sessionContracts.GetActiveSessionsForUserAsync(
                         userId,

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/RevokeOtherSessionsEndpoint.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/RevokeOtherSessionsEndpoint.cs
@@ -22,12 +22,7 @@ public class RevokeOtherSessionsEndpoint : IEndpoint
                     IOpenIddictSessionContracts sessionContracts
                 ) =>
                 {
-                    var userId = principal.GetUserId();
-                    if (string.IsNullOrEmpty(userId))
-                    {
-                        return TypedResults.Unauthorized();
-                    }
-
+                    var userId = principal.GetUserId()!;
                     var currentTokenId = ActiveSessionsHelpers.GetCurrentTokenId(principal);
                     await sessionContracts.RevokeOtherSessionsForUserAsync(userId, currentTokenId);
                     return TypedResults.Redirect("/Identity/Account/Manage/ActiveSessions");

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/RevokeSessionEndpoint.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Pages/OpenIddict/ActiveSessions/RevokeSessionEndpoint.cs
@@ -23,37 +23,29 @@ public class RevokeSessionEndpoint : IEndpoint
                     IOpenIddictSessionContracts sessionContracts
                 ) =>
                 {
-                    var userId = principal.GetUserId();
-                    if (string.IsNullOrEmpty(userId))
-                    {
-                        return TypedResults.Unauthorized();
-                    }
-
-                    // Refuse to revoke the request's own session before touching
-                    // the store, so a self-revoke can never silently sign the
-                    // caller out from under their own request.
+                    // RequireAuthorization short-circuits unauthenticated requests
+                    // before the handler runs, so userId is always present.
+                    var userId = principal.GetUserId()!;
                     var currentTokenId = ActiveSessionsHelpers.GetCurrentTokenId(principal);
-                    if (
-                        !string.IsNullOrEmpty(currentTokenId)
-                        && string.Equals(tokenId, currentTokenId, StringComparison.Ordinal)
-                    )
-                    {
-                        return TypedResults.BadRequest();
-                    }
 
-                    // 404 (not 403) when the token is missing or owned by someone
-                    // else, so the response shape doesn't leak whether a token id
-                    // exists for a different user.
-                    var revoked = await sessionContracts.TryRevokeSessionForUserAsync(
+                    var result = await sessionContracts.TryRevokeSessionForUserAsync(
                         tokenId,
-                        userId
+                        userId,
+                        currentTokenId
                     );
-                    if (!revoked)
-                    {
-                        return TypedResults.NotFound();
-                    }
 
-                    return TypedResults.Redirect("/Identity/Account/Manage/ActiveSessions");
+                    return result switch
+                    {
+                        // Self-revoke is rejected with 400 — revoking the
+                        // caller's own session would sign them out from under
+                        // their own request.
+                        RevokeSessionResult.BlockedCurrent => TypedResults.BadRequest(),
+                        // 404 (not 403) when the token is missing or owned by
+                        // someone else, so the response shape doesn't leak
+                        // whether a token id exists for a different user.
+                        RevokeSessionResult.NotFound => TypedResults.NotFound(),
+                        _ => TypedResults.Redirect("/Identity/Account/Manage/ActiveSessions"),
+                    };
                 }
             )
             .RequireAuthorization()

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionService.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionService.cs
@@ -9,14 +9,8 @@ public sealed class OpenIddictSessionService(
     IOpenIddictApplicationManager appManager
 ) : IOpenIddictSessionContracts
 {
-    public Task<IReadOnlyList<UserSessionDto>> GetActiveSessionsForUserAsync(
-        string userId,
-        CancellationToken cancellationToken = default
-    ) => GetActiveSessionsForUserAsync(userId, currentTokenId: null, cancellationToken);
-
     public async Task<IReadOnlyList<UserSessionDto>> GetActiveSessionsForUserAsync(
         string userId,
-        string? currentTokenId,
         CancellationToken cancellationToken = default
     )
     {
@@ -25,48 +19,97 @@ public sealed class OpenIddictSessionService(
 
         await foreach (var token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
         {
-            var type = await tokenManager.GetTypeAsync(token, cancellationToken);
-            if (type is not (TokenTypeHints.AccessToken or TokenTypeHints.RefreshToken))
+            var dto = await BuildDtoAsync(token, appNameCache, cancellationToken);
+            if (dto is not null)
+                sessions.Add(dto);
+        }
+
+        return sessions;
+    }
+
+    public async Task<IReadOnlyList<UserSessionDto>> GetActiveSessionsForUserAsync(
+        string userId,
+        string? currentTokenId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Resolve the caller's authorization id once so we can flag the matching
+        // group as current, even if the rendered anchor is a sibling token.
+        var currentAuthorizationId = await GetAuthorizationIdForTokenAsync(
+            currentTokenId,
+            cancellationToken
+        );
+        var appNameCache = new Dictionary<string, string?>();
+
+        // Collect valid tokens grouped by authorization. Tokens with no
+        // authorization id (rare — non-code grants) stand alone keyed by their
+        // own id so they still get a row.
+        var groups = new Dictionary<string, List<TokenRow>>(StringComparer.Ordinal);
+
+        await foreach (var token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
+        {
+            var row = await ReadTokenAsync(token, cancellationToken);
+            if (row is null)
                 continue;
 
-            var status = await tokenManager.GetStatusAsync(token, cancellationToken);
-            if (status != Statuses.Valid)
-                continue;
-
-            var expiration = await tokenManager.GetExpirationDateAsync(token, cancellationToken);
-            if (expiration.HasValue && expiration.Value < DateTimeOffset.UtcNow)
-                continue;
-
-            var appId = await tokenManager.GetApplicationIdAsync(token, cancellationToken);
-            string? appName = null;
-            if (appId is not null)
+            var key = row.Value.AuthorizationId ?? $"token:{row.Value.TokenId}";
+            if (!groups.TryGetValue(key, out var bucket))
             {
-                if (!appNameCache.TryGetValue(appId, out appName))
+                bucket = new List<TokenRow>();
+                groups[key] = bucket;
+            }
+            bucket.Add(row.Value);
+        }
+
+        var sessions = new List<UserSessionDto>(groups.Count);
+        foreach (var bucket in groups.Values)
+        {
+            // Prefer a refresh token as the anchor so the row reflects the longer-
+            // lived part of the session; fall back to the newest access token.
+            TokenRow? refreshAnchor = null;
+            foreach (var row in bucket)
+            {
+                if (row.Type == TokenTypeHints.RefreshToken)
                 {
-                    var app = await appManager.FindByIdAsync(appId, cancellationToken);
-                    if (app is not null)
-                        appName = await appManager.GetDisplayNameAsync(app, cancellationToken);
-                    appNameCache[appId] = appName;
+                    refreshAnchor = row;
+                    break;
                 }
             }
+            var anchor =
+                refreshAnchor
+                ?? bucket.OrderByDescending(t => t.CreationDate ?? DateTimeOffset.MinValue).First();
 
-            var tokenId =
-                await tokenManager.GetIdAsync(token, cancellationToken) ?? string.Empty;
+            var appName = await ResolveAppNameAsync(
+                anchor.ApplicationId,
+                appNameCache,
+                cancellationToken
+            );
+
+            var isCurrent =
+                (
+                    currentAuthorizationId is not null
+                    && string.Equals(
+                        anchor.AuthorizationId,
+                        currentAuthorizationId,
+                        StringComparison.Ordinal
+                    )
+                )
+                || (
+                    !string.IsNullOrEmpty(currentTokenId)
+                    && bucket.Any(t =>
+                        string.Equals(t.TokenId, currentTokenId, StringComparison.Ordinal)
+                    )
+                );
 
             sessions.Add(
                 new UserSessionDto
                 {
-                    TokenId = tokenId,
-                    Type = type ?? string.Empty,
+                    TokenId = anchor.TokenId,
+                    Type = anchor.Type,
                     ApplicationName = appName,
-                    CreationDate = await tokenManager.GetCreationDateAsync(
-                        token,
-                        cancellationToken
-                    ),
-                    ExpirationDate = expiration,
-                    IsCurrent =
-                        !string.IsNullOrEmpty(currentTokenId)
-                        && string.Equals(tokenId, currentTokenId, StringComparison.Ordinal),
+                    CreationDate = bucket.Min(t => t.CreationDate),
+                    ExpirationDate = bucket.Max(t => t.ExpirationDate),
+                    IsCurrent = isCurrent,
                 }
             );
         }
@@ -74,22 +117,78 @@ public sealed class OpenIddictSessionService(
         return sessions;
     }
 
-    public async Task<bool> TryRevokeSessionForUserAsync(
+    public async Task<RevokeSessionResult> TryRevokeSessionForUserAsync(
         string tokenId,
         string userId,
+        string? currentTokenId,
         CancellationToken cancellationToken = default
     )
     {
-        var token = await tokenManager.FindByIdAsync(tokenId, cancellationToken);
-        if (token is null)
-            return false;
+        var target = await tokenManager.FindByIdAsync(tokenId, cancellationToken);
+        if (target is null)
+            return RevokeSessionResult.NotFound;
 
-        var subject = await tokenManager.GetSubjectAsync(token, cancellationToken);
+        var subject = await tokenManager.GetSubjectAsync(target, cancellationToken);
         if (!string.Equals(subject, userId, StringComparison.Ordinal))
-            return false;
+            return RevokeSessionResult.NotFound;
 
-        await tokenManager.TryRevokeAsync(token, cancellationToken);
-        return true;
+        var targetAuthorizationId = await tokenManager.GetAuthorizationIdAsync(
+            target,
+            cancellationToken
+        );
+        var currentAuthorizationId = await GetAuthorizationIdForTokenAsync(
+            currentTokenId,
+            cancellationToken
+        );
+
+        // Self-revoke guard: same authorization, or same token id when no
+        // authorization is recorded.
+        if (
+            targetAuthorizationId is not null
+            && currentAuthorizationId is not null
+            && string.Equals(
+                targetAuthorizationId,
+                currentAuthorizationId,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            return RevokeSessionResult.BlockedCurrent;
+        }
+        if (
+            targetAuthorizationId is null
+            && !string.IsNullOrEmpty(currentTokenId)
+            && string.Equals(tokenId, currentTokenId, StringComparison.Ordinal)
+        )
+        {
+            return RevokeSessionResult.BlockedCurrent;
+        }
+
+        if (targetAuthorizationId is null)
+        {
+            // No authorization — just revoke this token.
+            await tokenManager.TryRevokeAsync(target, cancellationToken);
+            return RevokeSessionResult.Revoked;
+        }
+
+        // Revoke every token in the same authorization for this user. Materialize
+        // first so we don't mutate the store mid-iteration.
+        var siblings = new List<object>();
+        await foreach (var token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
+        {
+            var authId = await tokenManager.GetAuthorizationIdAsync(token, cancellationToken);
+            if (string.Equals(authId, targetAuthorizationId, StringComparison.Ordinal))
+            {
+                siblings.Add(token);
+            }
+        }
+
+        foreach (var token in siblings)
+        {
+            await tokenManager.TryRevokeAsync(token, cancellationToken);
+        }
+
+        return RevokeSessionResult.Revoked;
     }
 
     public async Task RevokeSessionAsync(
@@ -115,8 +214,11 @@ public sealed class OpenIddictSessionService(
         CancellationToken cancellationToken = default
     )
     {
-        // Materialize valid tokens first; revoking inside the FindBySubjectAsync
-        // enumeration could mutate the underlying store mid-iteration.
+        var currentAuthorizationId = await GetAuthorizationIdForTokenAsync(
+            currentTokenId,
+            cancellationToken
+        );
+
         var tokensToRevoke = new List<object>();
 
         await foreach (var token in tokenManager.FindBySubjectAsync(userId, cancellationToken))
@@ -125,7 +227,18 @@ public sealed class OpenIddictSessionService(
             if (status != Statuses.Valid)
                 continue;
 
-            if (!string.IsNullOrEmpty(currentTokenId))
+            // Same-authorization check first; falls through to token-id check for
+            // tokens that have no recorded authorization.
+            var authId = await tokenManager.GetAuthorizationIdAsync(token, cancellationToken);
+            if (
+                currentAuthorizationId is not null
+                && authId is not null
+                && string.Equals(authId, currentAuthorizationId, StringComparison.Ordinal)
+            )
+            {
+                continue;
+            }
+            if (authId is null && !string.IsNullOrEmpty(currentTokenId))
             {
                 var tokenId = await tokenManager.GetIdAsync(token, cancellationToken);
                 if (string.Equals(tokenId, currentTokenId, StringComparison.Ordinal))
@@ -140,4 +253,98 @@ public sealed class OpenIddictSessionService(
             await tokenManager.TryRevokeAsync(token, cancellationToken);
         }
     }
+
+    private async Task<UserSessionDto?> BuildDtoAsync(
+        object token,
+        Dictionary<string, string?> appNameCache,
+        CancellationToken cancellationToken
+    )
+    {
+        var row = await ReadTokenAsync(token, cancellationToken);
+        if (row is null)
+            return null;
+
+        var appName = await ResolveAppNameAsync(row.Value.ApplicationId, appNameCache, cancellationToken);
+
+        return new UserSessionDto
+        {
+            TokenId = row.Value.TokenId,
+            Type = row.Value.Type,
+            ApplicationName = appName,
+            CreationDate = row.Value.CreationDate,
+            ExpirationDate = row.Value.ExpirationDate,
+            IsCurrent = false,
+        };
+    }
+
+    private async Task<TokenRow?> ReadTokenAsync(object token, CancellationToken cancellationToken)
+    {
+        var type = await tokenManager.GetTypeAsync(token, cancellationToken);
+        if (type is not (TokenTypeHints.AccessToken or TokenTypeHints.RefreshToken))
+            return null;
+
+        var status = await tokenManager.GetStatusAsync(token, cancellationToken);
+        if (status != Statuses.Valid)
+            return null;
+
+        var expiration = await tokenManager.GetExpirationDateAsync(token, cancellationToken);
+        if (expiration.HasValue && expiration.Value < DateTimeOffset.UtcNow)
+            return null;
+
+        var tokenId = await tokenManager.GetIdAsync(token, cancellationToken) ?? string.Empty;
+        var creation = await tokenManager.GetCreationDateAsync(token, cancellationToken);
+        var appId = await tokenManager.GetApplicationIdAsync(token, cancellationToken);
+        var authorizationId = await tokenManager.GetAuthorizationIdAsync(token, cancellationToken);
+
+        return new TokenRow(
+            tokenId,
+            type ?? string.Empty,
+            appId,
+            authorizationId,
+            creation,
+            expiration
+        );
+    }
+
+    private async Task<string?> ResolveAppNameAsync(
+        string? appId,
+        Dictionary<string, string?> cache,
+        CancellationToken cancellationToken
+    )
+    {
+        if (appId is null)
+            return null;
+
+        if (cache.TryGetValue(appId, out var cached))
+            return cached;
+
+        var app = await appManager.FindByIdAsync(appId, cancellationToken);
+        var name = app is null ? null : await appManager.GetDisplayNameAsync(app, cancellationToken);
+        cache[appId] = name;
+        return name;
+    }
+
+    private async Task<string?> GetAuthorizationIdForTokenAsync(
+        string? tokenId,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrEmpty(tokenId))
+            return null;
+
+        var token = await tokenManager.FindByIdAsync(tokenId, cancellationToken);
+        if (token is null)
+            return null;
+
+        return await tokenManager.GetAuthorizationIdAsync(token, cancellationToken);
+    }
+
+    private readonly record struct TokenRow(
+        string TokenId,
+        string Type,
+        string? ApplicationId,
+        string? AuthorizationId,
+        DateTimeOffset? CreationDate,
+        DateTimeOffset? ExpirationDate
+    );
 }

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/components/ManageLayout.tsx
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/components/ManageLayout.tsx
@@ -1,0 +1,124 @@
+import { Card, CardContent, PageShell } from '@simplemodule/ui';
+
+// Mirrors modules/Users/src/SimpleModule.Users/components/ManageLayout.tsx — the
+// /Identity/Account/Manage/* nav lives in the Users module, but Vite library-mode
+// bundles each module separately so OpenIddict can't import it. Keep these in
+// sync when nav items change. Constitution rule SM0010 forbids OpenIddict →
+// Users React imports.
+
+interface ManageLayoutProps {
+  activePage: string;
+  children: React.ReactNode;
+}
+
+const navItems = [
+  {
+    href: '/Identity/Account/Manage',
+    page: 'Index',
+    label: 'Profile',
+    icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+  },
+  {
+    href: '/Identity/Account/Manage/Email',
+    page: 'Email',
+    label: 'Email',
+    icon: 'M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+  },
+  {
+    href: '/Identity/Account/Manage/ChangePassword',
+    page: 'ChangePassword',
+    label: 'Password',
+    icon: 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z',
+  },
+  {
+    href: '/Identity/Account/Manage/TwoFactorAuthentication',
+    page: 'TwoFactorAuthentication',
+    label: 'Two-factor auth',
+    icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+  },
+  {
+    href: '/Identity/Account/Manage/Passkeys',
+    page: 'Passkeys',
+    label: 'Passkeys',
+    icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z',
+  },
+  {
+    href: '/Identity/Account/Manage/PersonalData',
+    page: 'PersonalData',
+    label: 'Personal data',
+    icon: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4',
+  },
+  {
+    href: '/Identity/Account/Manage/ActiveSessions',
+    page: 'ActiveSessions',
+    label: 'Active sessions',
+    icon: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+  },
+];
+
+function NavLink({
+  href,
+  active,
+  icon,
+  children,
+}: {
+  href: string;
+  active: boolean;
+  icon: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      className={`flex items-center gap-2 sm:gap-3 whitespace-nowrap ${active ? 'nav-link-active' : 'nav-link-inactive'}`}
+    >
+      <svg
+        className="w-4 h-4 shrink-0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path d={icon} />
+      </svg>
+      {children}
+    </a>
+  );
+}
+
+export default function ManageLayout({ activePage, children }: ManageLayoutProps) {
+  return (
+    <PageShell
+      title="Account Settings"
+      description="Manage your profile, security, and preferences"
+      breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Account Settings' }]}
+    >
+      <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+        <aside className="sm:w-56 shrink-0">
+          <Card className="sm:sticky sm:top-20">
+            <CardContent className="p-2 sm:p-3">
+              <nav className="flex sm:flex-col gap-1 overflow-x-auto sm:overflow-x-visible">
+                {navItems.map((item) => (
+                  <NavLink
+                    key={item.page}
+                    href={item.href}
+                    active={activePage === item.page}
+                    icon={item.icon}
+                  >
+                    {item.label}
+                  </NavLink>
+                ))}
+              </nav>
+            </CardContent>
+          </Card>
+        </aside>
+        <div className="flex-1 min-w-0">
+          <Card>
+            <CardContent className="p-4 sm:p-6 md:p-8">{children}</CardContent>
+          </Card>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Integration/ActiveSessionsEndpointTests.cs
+++ b/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Integration/ActiveSessionsEndpointTests.cs
@@ -4,9 +4,11 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
 using SimpleModule.Tests.Shared.Fixtures;
 using SimpleModule.Testing;
 using SimpleModule.Users.Contracts;
+using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace OpenIddict.Tests.Integration;
 
@@ -50,14 +52,50 @@ public class ActiveSessionsEndpointTests
         return userId;
     }
 
-    private HttpClient CreateAuthenticatedNoRedirectClient(string userId)
+    private HttpClient CreateAuthenticatedNoRedirectClient(string userId, string? currentTokenId = null)
     {
         var client = _factory.CreateClient(NoRedirects());
-        client.DefaultRequestHeaders.Add(
-            TestAuthDefaults.ClaimsHeader,
-            $"{ClaimTypes.NameIdentifier}={userId}"
-        );
+        var claims = $"{ClaimTypes.NameIdentifier}={userId}";
+        if (!string.IsNullOrEmpty(currentTokenId))
+        {
+            // Matches the claim name OpenIddict's validation handler exposes on
+            // the principal (see ActiveSessionsHelpers.AccessTokenIdClaim).
+            claims += $";oi_tkn_id={currentTokenId}";
+        }
+        client.DefaultRequestHeaders.Add(TestAuthDefaults.ClaimsHeader, claims);
         return client;
+    }
+
+    private async Task<(string AuthorizationId, string AccessTokenId)> SeedAuthorizationWithTokensAsync(
+        string userId
+    )
+    {
+        using var scope = _factory.Services.CreateScope();
+        var authManager = scope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+        var auth = await authManager.CreateAsync(
+            new OpenIddictAuthorizationDescriptor
+            {
+                Subject = userId,
+                Status = Statuses.Valid,
+                Type = AuthorizationTypes.Permanent,
+            }
+        );
+        var authId = (await authManager.GetIdAsync(auth))!;
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        var token = await tokenManager.CreateAsync(
+            new OpenIddictTokenDescriptor
+            {
+                Subject = userId,
+                AuthorizationId = authId,
+                Type = TokenTypeHints.AccessToken,
+                Status = Statuses.Valid,
+                CreationDate = DateTimeOffset.UtcNow,
+                ExpirationDate = DateTimeOffset.UtcNow.AddDays(30),
+            }
+        );
+        var tokenId = (await tokenManager.GetIdAsync(token))!;
+        return (authId, tokenId);
     }
 
     // ── GET page ───────────────────────────────────────────────────────
@@ -122,6 +160,46 @@ public class ActiveSessionsEndpointTests
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Revoke_WhenTargetSharesCallersAuthorization_Returns400()
+    {
+        // Self-revoke must be rejected with 400 (not silently let through as a
+        // redirect, and not as 404), so the user can't kill their own session
+        // from under their own request — including via a sibling token id in
+        // the same authorization.
+        var userId = await SeedUserAsync("revoke-self-1");
+        var (_, accessTokenId) = await SeedAuthorizationWithTokensAsync(userId);
+        using var client = CreateAuthenticatedNoRedirectClient(userId, currentTokenId: accessTokenId);
+
+        var response = await client.PostAsync(
+            $"/Identity/Account/Manage/ActiveSessions/{accessTokenId}/revoke",
+            content: null
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Revoke_WhenTargetOwnedByCallerInDifferentAuthorization_RedirectsToListing()
+    {
+        var userId = await SeedUserAsync("revoke-other-auth-1");
+        var (_, currentToken) = await SeedAuthorizationWithTokensAsync(userId);
+        var (_, otherToken) = await SeedAuthorizationWithTokensAsync(userId);
+        using var client = CreateAuthenticatedNoRedirectClient(userId, currentTokenId: currentToken);
+
+        var response = await client.PostAsync(
+            $"/Identity/Account/Manage/ActiveSessions/{otherToken}/revoke",
+            content: null
+        );
+
+        response
+            .StatusCode.Should()
+            .BeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found);
+        response.Headers.Location?.ToString()
+            .Should()
+            .Contain("/Identity/Account/Manage/ActiveSessions");
     }
 
     // ── POST revoke-others ─────────────────────────────────────────────

--- a/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Integration/OpenIddictSessionServiceTests.cs
+++ b/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Integration/OpenIddictSessionServiceTests.cs
@@ -1,0 +1,349 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using SimpleModule.OpenIddict.Contracts;
+using SimpleModule.Tests.Shared.Fixtures;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace OpenIddict.Tests.Integration;
+
+/// <summary>
+/// Behavioural tests for <see cref="IOpenIddictSessionContracts"/>: token-pair
+/// grouping by AuthorizationId, IsCurrent across siblings, and the revoke
+/// guarantees the user-facing endpoints rely on.
+/// </summary>
+[Collection(TestCollections.Integration)]
+public class OpenIddictSessionServiceTests
+{
+    private readonly SimpleModuleWebApplicationFactory _factory;
+
+    public OpenIddictSessionServiceTests(SimpleModuleWebApplicationFactory factory)
+    {
+        _factory = factory;
+        // Force database initialization once so OpenIddict managers can resolve.
+        using (_factory.CreateAuthenticatedClient()) { }
+    }
+
+    // ── Seeding ────────────────────────────────────────────────────────
+
+    private static async Task<string> SeedAuthorizationAsync(string userId, IServiceProvider services)
+    {
+        var authManager = services.GetRequiredService<IOpenIddictAuthorizationManager>();
+        var auth = await authManager.CreateAsync(
+            new OpenIddictAuthorizationDescriptor
+            {
+                Subject = userId,
+                Status = Statuses.Valid,
+                Type = AuthorizationTypes.Permanent,
+            }
+        );
+        return (await authManager.GetIdAsync(auth))!;
+    }
+
+    private static async Task<string> SeedTokenAsync(
+        string userId,
+        string authorizationId,
+        string type,
+        IServiceProvider services,
+        DateTimeOffset? creationDate = null
+    )
+    {
+        var tokenManager = services.GetRequiredService<IOpenIddictTokenManager>();
+        var descriptor = new OpenIddictTokenDescriptor
+        {
+            Subject = userId,
+            AuthorizationId = authorizationId,
+            Type = type,
+            Status = Statuses.Valid,
+            CreationDate = creationDate ?? DateTimeOffset.UtcNow,
+            ExpirationDate = DateTimeOffset.UtcNow.AddDays(30),
+        };
+        var token = await tokenManager.CreateAsync(descriptor);
+        return (await tokenManager.GetIdAsync(token))!;
+    }
+
+    private static string NewUserId([System.Runtime.CompilerServices.CallerMemberName] string caller = "") =>
+        $"sess-svc-{caller}-{Guid.NewGuid():N}";
+
+    // ── Grouping ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetActiveSessions_GroupsAccessAndRefreshSharingAuthorization_IntoOneRow()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var authId = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        await SeedTokenAsync(userId, authId, TokenTypeHints.AccessToken, scope.ServiceProvider);
+        await SeedTokenAsync(userId, authId, TokenTypeHints.RefreshToken, scope.ServiceProvider);
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var sessions = await contracts.GetActiveSessionsForUserAsync(userId, currentTokenId: null);
+
+        sessions.Should().HaveCount(1);
+        // Refresh token is preferred as the anchor (longer-lived row).
+        sessions[0].Type.Should().Be(TokenTypeHints.RefreshToken);
+    }
+
+    [Fact]
+    public async Task GetActiveSessions_MultipleAuthorizations_OneRowEach()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var auth1 = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var auth2 = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        await SeedTokenAsync(userId, auth1, TokenTypeHints.RefreshToken, scope.ServiceProvider);
+        await SeedTokenAsync(userId, auth2, TokenTypeHints.RefreshToken, scope.ServiceProvider);
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var sessions = await contracts.GetActiveSessionsForUserAsync(userId, currentTokenId: null);
+
+        sessions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetActiveSessions_IsCurrent_SetForBothSiblingsOfTheCallersToken()
+    {
+        // The principal carries the access token id; the rendered row uses the
+        // refresh token id (anchor). The IsCurrent flag must still come back true.
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var authId = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var accessId = await SeedTokenAsync(
+            userId,
+            authId,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+        await SeedTokenAsync(userId, authId, TokenTypeHints.RefreshToken, scope.ServiceProvider);
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var sessions = await contracts.GetActiveSessionsForUserAsync(userId, currentTokenId: accessId);
+
+        sessions.Should().HaveCount(1);
+        sessions[0].IsCurrent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetActiveSessions_FlatOverload_ReturnsOneRowPerToken()
+    {
+        // The admin-facing overload (no currentTokenId) intentionally keeps a
+        // row per token so each can be revoked individually.
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var authId = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        await SeedTokenAsync(userId, authId, TokenTypeHints.AccessToken, scope.ServiceProvider);
+        await SeedTokenAsync(userId, authId, TokenTypeHints.RefreshToken, scope.ServiceProvider);
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var sessions = await contracts.GetActiveSessionsForUserAsync(userId);
+
+        sessions.Should().HaveCount(2);
+    }
+
+    // ── TryRevokeSessionForUserAsync ───────────────────────────────────
+
+    [Fact]
+    public async Task TryRevoke_SelfRevoke_ReturnsBlockedCurrent_AndDoesNotRevoke()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var authId = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var accessId = await SeedTokenAsync(
+            userId,
+            authId,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+        var refreshId = await SeedTokenAsync(
+            userId,
+            authId,
+            TokenTypeHints.RefreshToken,
+            scope.ServiceProvider
+        );
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+
+        // Targeting either sibling must refuse when currentTokenId belongs to
+        // the same authorization.
+        var resultRefresh = await contracts.TryRevokeSessionForUserAsync(
+            refreshId,
+            userId,
+            currentTokenId: accessId
+        );
+        var resultAccess = await contracts.TryRevokeSessionForUserAsync(
+            accessId,
+            userId,
+            currentTokenId: accessId
+        );
+
+        resultRefresh.Should().Be(RevokeSessionResult.BlockedCurrent);
+        resultAccess.Should().Be(RevokeSessionResult.BlockedCurrent);
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        var refreshToken = await tokenManager.FindByIdAsync(refreshId);
+        (await tokenManager.GetStatusAsync(refreshToken!)).Should().Be(Statuses.Valid);
+    }
+
+    [Fact]
+    public async Task TryRevoke_OwnedTokenInDifferentAuthorization_RevokesAllSiblings()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var currentAuth = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var currentAccess = await SeedTokenAsync(
+            userId,
+            currentAuth,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+
+        var otherAuth = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var otherAccess = await SeedTokenAsync(
+            userId,
+            otherAuth,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+        var otherRefresh = await SeedTokenAsync(
+            userId,
+            otherAuth,
+            TokenTypeHints.RefreshToken,
+            scope.ServiceProvider
+        );
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var result = await contracts.TryRevokeSessionForUserAsync(
+            otherRefresh,
+            userId,
+            currentTokenId: currentAccess
+        );
+
+        result.Should().Be(RevokeSessionResult.Revoked);
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        // Both siblings in the targeted authorization are revoked …
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(otherAccess))!))
+            .Should()
+            .NotBe(Statuses.Valid);
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(otherRefresh))!))
+            .Should()
+            .NotBe(Statuses.Valid);
+        // … and the caller's current session is untouched.
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(currentAccess))!))
+            .Should()
+            .Be(Statuses.Valid);
+    }
+
+    [Fact]
+    public async Task TryRevoke_TokenOwnedByDifferentUser_ReturnsNotFound()
+    {
+        var userId = NewUserId();
+        var otherUserId = NewUserId() + "-other";
+        using var scope = _factory.Services.CreateScope();
+        var otherAuth = await SeedAuthorizationAsync(otherUserId, scope.ServiceProvider);
+        var otherToken = await SeedTokenAsync(
+            otherUserId,
+            otherAuth,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        var result = await contracts.TryRevokeSessionForUserAsync(
+            otherToken,
+            userId,
+            currentTokenId: null
+        );
+
+        result.Should().Be(RevokeSessionResult.NotFound);
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(otherToken))!))
+            .Should()
+            .Be(Statuses.Valid);
+    }
+
+    [Fact]
+    public async Task TryRevoke_UnknownTokenId_ReturnsNotFound()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+
+        var result = await contracts.TryRevokeSessionForUserAsync(
+            tokenId: "does-not-exist",
+            userId,
+            currentTokenId: null
+        );
+
+        result.Should().Be(RevokeSessionResult.NotFound);
+    }
+
+    // ── RevokeOtherSessionsForUserAsync ────────────────────────────────
+
+    [Fact]
+    public async Task RevokeOthers_PreservesCurrentAuthorization_RevokesEverythingElse()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var currentAuth = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var currentAccess = await SeedTokenAsync(
+            userId,
+            currentAuth,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+        var currentRefresh = await SeedTokenAsync(
+            userId,
+            currentAuth,
+            TokenTypeHints.RefreshToken,
+            scope.ServiceProvider
+        );
+
+        var otherAuth = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var otherAccess = await SeedTokenAsync(
+            userId,
+            otherAuth,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        await contracts.RevokeOtherSessionsForUserAsync(userId, currentTokenId: currentAccess);
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        // Current authorization's tokens — including the refresh sibling — survive.
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(currentAccess))!))
+            .Should()
+            .Be(Statuses.Valid);
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(currentRefresh))!))
+            .Should()
+            .Be(Statuses.Valid);
+        // The other authorization is gone.
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(otherAccess))!))
+            .Should()
+            .NotBe(Statuses.Valid);
+    }
+
+    [Fact]
+    public async Task RevokeOthers_NullCurrentToken_RevokesEverythingForUser()
+    {
+        var userId = NewUserId();
+        using var scope = _factory.Services.CreateScope();
+        var authId = await SeedAuthorizationAsync(userId, scope.ServiceProvider);
+        var tokenId = await SeedTokenAsync(
+            userId,
+            authId,
+            TokenTypeHints.AccessToken,
+            scope.ServiceProvider
+        );
+
+        var contracts = scope.ServiceProvider.GetRequiredService<IOpenIddictSessionContracts>();
+        await contracts.RevokeOtherSessionsForUserAsync(userId, currentTokenId: null);
+
+        var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+        (await tokenManager.GetStatusAsync((await tokenManager.FindByIdAsync(tokenId))!))
+            .Should()
+            .NotBe(Statuses.Valid);
+    }
+}


### PR DESCRIPTION
Stacks on top of #185. Addresses the review findings on the user-facing active-sessions page.

## Summary
- Sessions are now grouped by `AuthorizationId` so a user can no longer revoke the refresh token of their own session while keeping the access token (which would silently kill the session on next refresh). The self-revoke guard compares authorizations, not bare token ids.
- The page wraps in a local `ManageLayout` so the /Manage/* side nav actually renders — duplicated into OpenIddict because Vite library mode + SM0010 forbid importing the Users one.
- `IOpenIddictSessionContracts.TryRevokeSessionForUserAsync` returns a `RevokeSessionResult` enum (`Revoked` / `NotFound` / `BlockedCurrent`) so the endpoint maps cleanly to 302 / 404 / 400 without re-implementing the equality check.
- Unreachable `userId is null` branches removed — `RequireAuthorization()` already short-circuits before those run.
- New `OpenIddictSessionServiceTests` (11 cases) covering pair grouping, multi-authorization listing, `IsCurrent` across siblings, self-revoke blocked, sibling revoke on success, cross-user 404, unknown-token 404, RevokeOther preserves current authorization, RevokeOther with null wipes everything. Endpoint tests gain self-revoke (400) and cross-authorization revoke (302) cases.

Admin's flat `GetActiveSessionsForUserAsync(userId)` overload is intentionally unchanged — admins keep the per-token view.

## Test plan
- [x] `dotnet test modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/...` — 38 pass (11 new)
- [x] `dotnet test modules/Admin/tests/SimpleModule.Admin.Tests/...` — 28 pass (no regression in the contract consumer)
- [x] `dotnet test modules/Users/tests/SimpleModule.Users.Tests/...` — 40 pass
- [ ] Manual: sign in via OAuth on two browsers, verify the list collapses to two rows, "This device" only flags the row backing the current request, revoke the other row signs out only that browser
- [ ] Manual: confirm /Manage/* side nav renders on Active sessions and the "Active sessions" link is highlighted

## Out of scope / residual
- Generator bug: `[Dto]` -> `types.ts` emits `applicationName: string` instead of `string | null`. The page's local interface defends against it; a generator fix belongs in its own PR.
- CSRF / `DisableAntiforgery()` on the revoke endpoints matches the codebase-wide convention and isn't changed here.