### PR TITLE
feat(users): add self-service account unlock via email

### DIFF
--- a/modules/Email/src/SimpleModule.Email/EmailModule.cs
+++ b/modules/Email/src/SimpleModule.Email/EmailModule.cs
@@ -64,6 +64,7 @@ public class EmailModule : IModule, IModuleServices
 
         // Replace Identity's ConsoleEmailSender with a real one
         services.AddScoped<IEmailSender<ApplicationUser>, IdentityEmailSender>();
+        services.AddScoped<IAccountUnlockEmailSender, IdentityAccountUnlockEmailSender>();
 
         services.AddModuleJob<SendEmailJob>();
         services.AddModuleJob<RetryFailedEmailsJob>();

--- a/modules/Email/src/SimpleModule.Email/Services/IdentityAccountUnlockEmailSender.cs
+++ b/modules/Email/src/SimpleModule.Email/Services/IdentityAccountUnlockEmailSender.cs
@@ -1,0 +1,22 @@
+using SimpleModule.Email.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Email.Services;
+
+public class IdentityAccountUnlockEmailSender(IEmailContracts emailContracts)
+    : IAccountUnlockEmailSender
+{
+    public async Task SendUnlockLinkAsync(string email, string unlockLink)
+    {
+        await emailContracts.SendEmailAsync(
+            new SendEmailRequest
+            {
+                To = email,
+                Subject = "Unlock your account",
+                Body =
+                    $"""Your account has been locked due to multiple failed sign-in attempts. <a href="{unlockLink}">Click here to unlock your account</a>.""",
+                IsHtml = true,
+            }
+        );
+    }
+}

--- a/modules/Users/src/SimpleModule.Users.Contracts/Events/UserSelfUnlockedEvent.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/Events/UserSelfUnlockedEvent.cs
@@ -1,0 +1,5 @@
+using SimpleModule.Core.Events;
+
+namespace SimpleModule.Users.Contracts.Events;
+
+public sealed record UserSelfUnlockedEvent(UserId UserId, string Email) : IEvent;

--- a/modules/Users/src/SimpleModule.Users.Contracts/IAccountUnlockEmailSender.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/IAccountUnlockEmailSender.cs
@@ -1,0 +1,6 @@
+namespace SimpleModule.Users.Contracts;
+
+public interface IAccountUnlockEmailSender
+{
+    Task SendUnlockLinkAsync(string email, string unlockLink);
+}

--- a/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
@@ -53,4 +53,9 @@ public static class UsersConstants
         public const string ResetAuthenticator = "/Manage/ResetAuthenticator";
         public const string GenerateRecoveryCodes = "/Manage/GenerateRecoveryCodes";
     }
+
+    public static class TokenPurposes
+    {
+        public const string AccountUnlock = "AccountUnlock";
+    }
 }

--- a/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
+++ b/modules/Users/src/SimpleModule.Users.Contracts/UsersConstants.cs
@@ -32,6 +32,9 @@ public static class UsersConstants
         public const string LoginWith2fa = "/LoginWith2fa";
         public const string LoginWithRecoveryCode = "/LoginWithRecoveryCode";
         public const string Lockout = "/Lockout";
+        public const string SendUnlockEmail = "/SendUnlockEmail";
+        public const string SendUnlockEmailConfirmation = "/SendUnlockEmailConfirmation";
+        public const string UnlockAccount = "/UnlockAccount";
         public const string AccessDenied = "/AccessDenied";
         public const string Error = "/Error";
         public const string RegisterConfirmation = "/RegisterConfirmation";

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@inertiajs/react';
+import { routes } from '@simplemodule/client/routes';
 import { Card, CardContent, Container } from '@simplemodule/ui';
 
 export default function Lockout() {
@@ -16,7 +17,7 @@ export default function Lockout() {
               <p className="text-sm text-text-muted">
                 You can also{' '}
                 <Link
-                  href="/Identity/Account/SendUnlockEmail"
+                  href={routes.users.views.sendUnlockEmail()}
                   className="text-primary underline hover:no-underline"
                 >
                   receive an unlock link by email

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/Lockout.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@inertiajs/react';
 import { Card, CardContent, Container } from '@simplemodule/ui';
 
 export default function Lockout() {
@@ -8,8 +9,19 @@ export default function Lockout() {
           <Card>
             <CardContent className="p-8">
               <h1 className="text-xl font-bold text-danger mb-2">Locked out</h1>
-              <p className="text-sm text-danger">
+              <p className="text-sm text-danger mb-4">
                 This account has been locked out, please try again later.
+              </p>
+              <hr className="mb-4" />
+              <p className="text-sm text-text-muted">
+                You can also{' '}
+                <Link
+                  href="/Identity/Account/SendUnlockEmail"
+                  className="text-primary underline hover:no-underline"
+                >
+                  receive an unlock link by email
+                </Link>
+                .
               </p>
             </CardContent>
           </Card>

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmail.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmail.tsx
@@ -1,0 +1,55 @@
+import { router } from '@inertiajs/react';
+import {
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+} from '@simplemodule/ui';
+
+export default function SendUnlockEmail() {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    router.post('/Identity/Account/SendUnlockEmail', formData);
+  }
+
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1 className="text-xl font-bold mb-2">Unlock your account</h1>
+              <p className="text-sm text-text-muted mb-6">
+                Enter your email to receive an unlock link.
+              </p>
+              <hr className="mb-6" />
+              <form onSubmit={handleSubmit}>
+                <FieldGroup>
+                  <Field>
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      name="email"
+                      type="email"
+                      required
+                      autoComplete="username"
+                      placeholder="name@example.com"
+                    />
+                  </Field>
+                  <Button type="submit" className="w-full">
+                    Send Unlock Link
+                  </Button>
+                </FieldGroup>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmation.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmation.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, Container } from '@simplemodule/ui';
+
+export default function SendUnlockEmailConfirmation() {
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1 className="text-xl font-bold mb-4">Check your email</h1>
+              <p className="text-sm">
+                If an account with that email exists and is currently locked, we've sent an unlock
+                link. Please check your email.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmationEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailConfirmationEndpoint.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class SendUnlockEmailConfirmationEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.SendUnlockEmailConfirmation;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Route, () => Inertia.Render("Users/Account/SendUnlockEmailConfirmation"))
+            .AllowAnonymous();
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
@@ -30,12 +30,16 @@ public class SendUnlockEmailEndpoint : IViewEndpoint
                 ) =>
                 {
                     var user = await userManager.FindByEmailAsync(email);
-                    if (user is not null && await userManager.IsLockedOutAsync(user))
+                    if (
+                        user is not null
+                        && await userManager.IsEmailConfirmedAsync(user)
+                        && await userManager.IsLockedOutAsync(user)
+                    )
                     {
                         var code = await userManager.GenerateUserTokenAsync(
                             user,
                             TokenOptions.DefaultProvider,
-                            "AccountUnlock"
+                            UsersConstants.TokenPurposes.AccountUnlock
                         );
                         code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
 

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/SendUnlockEmailEndpoint.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Core.RateLimiting;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class SendUnlockEmailEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.SendUnlockEmail;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Route, () => Inertia.Render("Users/Account/SendUnlockEmail")).AllowAnonymous();
+
+        app.MapPost(
+                Route,
+                async (
+                    [FromForm] string email,
+                    UserManager<ApplicationUser> userManager,
+                    IAccountUnlockEmailSender unlockEmailSender,
+                    HttpContext context
+                ) =>
+                {
+                    var user = await userManager.FindByEmailAsync(email);
+                    if (user is not null && await userManager.IsLockedOutAsync(user))
+                    {
+                        var code = await userManager.GenerateUserTokenAsync(
+                            user,
+                            TokenOptions.DefaultProvider,
+                            "AccountUnlock"
+                        );
+                        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+                        var request = context.Request;
+                        var baseUrl = $"{request.Scheme}://{request.Host}";
+                        var callbackUrl =
+                            $"{baseUrl}{UsersConstants.ViewPrefix}{UsersConstants.Routes.UnlockAccount}?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(code)}";
+
+                        await unlockEmailSender.SendUnlockLinkAsync(email, callbackUrl);
+                    }
+
+                    // Always redirect to confirmation — don't reveal whether the email exists or is locked
+                    return TypedResults.Redirect(
+                        $"{UsersConstants.ViewPrefix}{UsersConstants.Routes.SendUnlockEmailConfirmation}"
+                    );
+                }
+            )
+            .AllowAnonymous()
+            .DisableAntiforgery()
+            .RateLimit("auth-strict");
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
@@ -13,9 +13,7 @@ export default function UnlockAccount({ success, message }: Props) {
         <div className="w-full max-w-md">
           <Card>
             <CardContent className="p-8">
-              <h1
-                className={`text-xl font-bold mb-4 ${success ? 'text-success' : 'text-danger'}`}
-              >
+              <h1 className={`text-xl font-bold mb-4 ${success ? 'text-success' : 'text-danger'}`}>
                 {success ? 'Account unlocked' : 'Unlock failed'}
               </h1>
               <p className="text-sm mb-6">{message}</p>

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccount.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@inertiajs/react';
+import { Button, Card, CardContent, Container } from '@simplemodule/ui';
+
+interface Props {
+  success: boolean;
+  message: string;
+}
+
+export default function UnlockAccount({ success, message }: Props) {
+  return (
+    <Container size="sm">
+      <div className="flex items-center justify-center min-h-[calc(100vh-12rem)]">
+        <div className="w-full max-w-md">
+          <Card>
+            <CardContent className="p-8">
+              <h1
+                className={`text-xl font-bold mb-4 ${success ? 'text-success' : 'text-danger'}`}
+              >
+                {success ? 'Account unlocked' : 'Unlock failed'}
+              </h1>
+              <p className="text-sm mb-6">{message}</p>
+              {success && (
+                <Link href="/Identity/Account/Login">
+                  <Button className="w-full">Sign in</Button>
+                </Link>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
@@ -1,10 +1,11 @@
+using System.Buffers;
+using System.Buffers.Text;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.WebUtilities;
 using SimpleModule.Core;
 using SimpleModule.Core.Inertia;
 using SimpleModule.Users.Contracts;
@@ -16,6 +17,8 @@ namespace SimpleModule.Users.Pages.Account;
 public class UnlockAccountEndpoint : IViewEndpoint
 {
     public const string Route = UsersConstants.Routes.UnlockAccount;
+
+    private const string ComponentName = "Users/Account/UnlockAccount";
 
     public void Map(IEndpointRouteBuilder app)
     {
@@ -33,33 +36,42 @@ public class UnlockAccountEndpoint : IViewEndpoint
                         return TypedResults.Redirect("/");
                     }
 
+                    static IResult InvalidLink() =>
+                        Inertia.Render(
+                            ComponentName,
+                            new { success = false, message = "Invalid or expired unlock link." }
+                        );
+
                     var user = await userManager.FindByIdAsync(userId);
                     if (user is null)
                     {
-                        return Inertia.Render(
-                            "Users/Account/UnlockAccount",
-                            new { success = false, message = "Unable to unlock account." }
-                        );
+                        return InvalidLink();
                     }
 
-                    var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+                    var decodeBuffer = new byte[Base64Url.GetMaxDecodedLength(code.Length)];
+                    var decodeStatus = Base64Url.DecodeFromChars(
+                        code,
+                        decodeBuffer,
+                        out _,
+                        out var bytesWritten,
+                        isFinalBlock: true
+                    );
+                    if (decodeStatus != OperationStatus.Done)
+                    {
+                        return InvalidLink();
+                    }
+                    var decodedCode = Encoding.UTF8.GetString(decodeBuffer, 0, bytesWritten);
+
                     var isValid = await userManager.VerifyUserTokenAsync(
                         user,
                         TokenOptions.DefaultProvider,
-                        "AccountUnlock",
+                        UsersConstants.TokenPurposes.AccountUnlock,
                         decodedCode
                     );
 
                     if (!isValid)
                     {
-                        return Inertia.Render(
-                            "Users/Account/UnlockAccount",
-                            new
-                            {
-                                success = false,
-                                message = "Invalid or expired unlock link.",
-                            }
-                        );
+                        return InvalidLink();
                     }
 
                     user.LockoutEnd = null;
@@ -68,14 +80,11 @@ public class UnlockAccountEndpoint : IViewEndpoint
                     await userManager.UpdateSecurityStampAsync(user);
 
                     await bus.PublishAsync(
-                        new UserSelfUnlockedEvent(
-                            UserId.From(user.Id),
-                            user.Email ?? string.Empty
-                        )
+                        new UserSelfUnlockedEvent(UserId.From(user.Id), user.Email ?? string.Empty)
                     );
 
                     return Inertia.Render(
-                        "Users/Account/UnlockAccount",
+                        ComponentName,
                         new
                         {
                             success = true,

--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using SimpleModule.Core;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Users.Contracts;
+using SimpleModule.Users.Contracts.Events;
+using Wolverine;
+
+namespace SimpleModule.Users.Pages.Account;
+
+public class UnlockAccountEndpoint : IViewEndpoint
+{
+    public const string Route = UsersConstants.Routes.UnlockAccount;
+
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                Route,
+                async Task<IResult> (
+                    [FromQuery] string? userId,
+                    [FromQuery] string? code,
+                    UserManager<ApplicationUser> userManager,
+                    IMessageBus bus
+                ) =>
+                {
+                    if (userId is null || code is null)
+                    {
+                        return TypedResults.Redirect("/");
+                    }
+
+                    var user = await userManager.FindByIdAsync(userId);
+                    if (user is null)
+                    {
+                        return Inertia.Render(
+                            "Users/Account/UnlockAccount",
+                            new { success = false, message = "Unable to unlock account." }
+                        );
+                    }
+
+                    var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+                    var isValid = await userManager.VerifyUserTokenAsync(
+                        user,
+                        TokenOptions.DefaultProvider,
+                        "AccountUnlock",
+                        decodedCode
+                    );
+
+                    if (!isValid)
+                    {
+                        return Inertia.Render(
+                            "Users/Account/UnlockAccount",
+                            new
+                            {
+                                success = false,
+                                message = "Invalid or expired unlock link.",
+                            }
+                        );
+                    }
+
+                    user.LockoutEnd = null;
+                    user.AccessFailedCount = 0;
+                    await userManager.UpdateAsync(user);
+                    await userManager.UpdateSecurityStampAsync(user);
+
+                    await bus.PublishAsync(
+                        new UserSelfUnlockedEvent(
+                            UserId.From(user.Id),
+                            user.Email ?? string.Empty
+                        )
+                    );
+
+                    return Inertia.Render(
+                        "Users/Account/UnlockAccount",
+                        new
+                        {
+                            success = true,
+                            message = "Your account has been unlocked successfully.",
+                        }
+                    );
+                }
+            )
+            .AllowAnonymous();
+    }
+}

--- a/modules/Users/src/SimpleModule.Users/Pages/index.ts
+++ b/modules/Users/src/SimpleModule.Users/Pages/index.ts
@@ -14,6 +14,10 @@ export const pages: Record<string, unknown> = {
   'Users/Account/LoginWith2fa': () => import('./Account/LoginWith2fa'),
   'Users/Account/LoginWithRecoveryCode': () => import('./Account/LoginWithRecoveryCode'),
   'Users/Account/Lockout': () => import('./Account/Lockout'),
+  'Users/Account/SendUnlockEmail': () => import('./Account/SendUnlockEmail'),
+  'Users/Account/SendUnlockEmailConfirmation': () =>
+    import('./Account/SendUnlockEmailConfirmation'),
+  'Users/Account/UnlockAccount': () => import('./Account/UnlockAccount'),
   'Users/Account/AccessDenied': () => import('./Account/AccessDenied'),
   'Users/Account/Error': () => import('./Account/Error'),
   'Users/Account/ExternalLogin': () => import('./Account/ExternalLogin'),

--- a/modules/Users/src/SimpleModule.Users/Services/ConsoleAccountUnlockEmailSender.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/ConsoleAccountUnlockEmailSender.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Users.Services;
+
+public partial class ConsoleAccountUnlockEmailSender(
+    ILogger<ConsoleAccountUnlockEmailSender> logger
+) : IAccountUnlockEmailSender
+{
+    public Task SendUnlockLinkAsync(string email, string unlockLink)
+    {
+        LogUnlockLink(logger, email, unlockLink);
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Account unlock for {Email}: {Link}")]
+    private static partial void LogUnlockLink(ILogger logger, string email, string link);
+}

--- a/modules/Users/src/SimpleModule.Users/UsersModule.cs
+++ b/modules/Users/src/SimpleModule.Users/UsersModule.cs
@@ -80,6 +80,7 @@ public class UsersModule : IModule
 
         services.AddHostedService<UserSeedService>();
         services.AddSingleton<IEmailSender<ApplicationUser>, ConsoleEmailSender>();
+        services.AddSingleton<IAccountUnlockEmailSender, ConsoleAccountUnlockEmailSender>();
     }
 
     public void ConfigurePermissions(PermissionRegistryBuilder builder)

--- a/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
+++ b/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
@@ -1,9 +1,12 @@
 using System.Net;
 using System.Text;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using SimpleModule.Tests.Shared.Fixtures;
 using SimpleModule.Users.Contracts;
 
@@ -19,62 +22,194 @@ public class AccountUnlockEndpointTests
     {
         _factory = factory;
         _client = factory.CreateClient(
-            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false }
+        );
+    }
+
+    private sealed class RecordingUnlockEmailSender : IAccountUnlockEmailSender
+    {
+        public List<(string Email, string Link)> Calls { get; } = new();
+
+        public Task SendUnlockLinkAsync(string email, string unlockLink)
+        {
+            Calls.Add((email, unlockLink));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SendUnlockTestContext : IDisposable
+    {
+        public required WebApplicationFactory<Program> Factory { get; init; }
+        public required HttpClient Client { get; init; }
+        public required RecordingUnlockEmailSender Sender { get; init; }
+
+        public void Dispose() => Client.Dispose();
+    }
+
+    private SendUnlockTestContext CreateTestContext()
+    {
+        var recorder = new RecordingUnlockEmailSender();
+        var customFactory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
             {
-                AllowAutoRedirect = false,
-            }
+                services.RemoveAll<IAccountUnlockEmailSender>();
+                services.AddSingleton<IAccountUnlockEmailSender>(recorder);
+            })
         );
+        return new SendUnlockTestContext
+        {
+            Factory = customFactory,
+            Client = customFactory.CreateClient(
+                new WebApplicationFactoryClientOptions { AllowAutoRedirect = false }
+            ),
+            Sender = recorder,
+        };
     }
 
-    [Fact]
-    public async Task SendUnlockEmail_UnknownEmail_RedirectsToConfirmation()
+    private static async Task<ApplicationUser> CreateUserAsync(
+        WebApplicationFactory<Program> factory,
+        string email,
+        bool emailConfirmed,
+        bool locked
+    )
     {
-        using var content = new FormUrlEncodedContent(
-            [new KeyValuePair<string, string>("email", "nonexistent@example.com")]
-        );
-
-        var response = await _client.PostAsync(
-            "/Identity/Account/SendUnlockEmail",
-            content
-        );
-
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-        response.Headers.Location!.OriginalString.Should()
-            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
-    }
-
-    [Fact]
-    public async Task SendUnlockEmail_LockedUser_RedirectsToConfirmation()
-    {
-        await using var scope = _factory.Services.CreateAsyncScope();
+        await using var scope = factory.Services.CreateAsyncScope();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
         var user = new ApplicationUser
         {
-            UserName = "locked-unlock-test@example.com",
-            Email = "locked-unlock-test@example.com",
-            EmailConfirmed = true,
-            DisplayName = "Locked User",
+            UserName = email,
+            Email = email,
+            EmailConfirmed = emailConfirmed,
+            DisplayName = email,
         };
         await userManager.CreateAsync(user, "TestPass1234!");
-        await userManager.SetLockoutEnabledAsync(user, true);
-        await userManager.SetLockoutEndDateAsync(
-            user,
-            DateTimeOffset.UtcNow.AddHours(1)
-        );
 
-        using var content = new FormUrlEncodedContent(
-            [new KeyValuePair<string, string>("email", user.Email)]
-        );
+        if (locked)
+        {
+            await userManager.SetLockoutEnabledAsync(user, true);
+            await userManager.SetLockoutEndDateAsync(user, DateTimeOffset.UtcNow.AddHours(1));
+        }
 
-        var response = await _client.PostAsync(
-            "/Identity/Account/SendUnlockEmail",
-            content
-        );
+        return user;
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_Get_RendersForm()
+    {
+        var response = await _client.GetAsync("/Identity/Account/SendUnlockEmail");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendUnlockEmailConfirmation_Get_RendersPage()
+    {
+        var response = await _client.GetAsync("/Identity/Account/SendUnlockEmailConfirmation");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_UnknownEmail_RedirectsAndDoesNotSend()
+    {
+        using var ctx = CreateTestContext();
+
+        using var content = new FormUrlEncodedContent([
+            new KeyValuePair<string, string>("email", "nonexistent@example.com"),
+        ]);
+
+        var response = await ctx.Client.PostAsync("/Identity/Account/SendUnlockEmail", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-        response.Headers.Location!.OriginalString.Should()
+        response
+            .Headers.Location!.OriginalString.Should()
             .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+        ctx.Sender.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_LockedUser_SendsUnlockLink()
+    {
+        using var ctx = CreateTestContext();
+
+        var email = $"locked-{Guid.NewGuid():N}@example.com";
+        await CreateUserAsync(ctx.Factory, email, emailConfirmed: true, locked: true);
+
+        using var content = new FormUrlEncodedContent([
+            new KeyValuePair<string, string>("email", email),
+        ]);
+
+        var response = await ctx.Client.PostAsync("/Identity/Account/SendUnlockEmail", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response
+            .Headers.Location!.OriginalString.Should()
+            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+
+        ctx.Sender.Calls.Should().ContainSingle();
+        ctx.Sender.Calls[0].Email.Should().Be(email);
+        ctx.Sender.Calls[0].Link.Should().Contain("/Identity/Account/UnlockAccount");
+        ctx.Sender.Calls[0].Link.Should().Contain("userId=");
+        ctx.Sender.Calls[0].Link.Should().Contain("code=");
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_UnlockedUser_DoesNotSend()
+    {
+        using var ctx = CreateTestContext();
+
+        var email = $"healthy-{Guid.NewGuid():N}@example.com";
+        await CreateUserAsync(ctx.Factory, email, emailConfirmed: true, locked: false);
+
+        using var content = new FormUrlEncodedContent([
+            new KeyValuePair<string, string>("email", email),
+        ]);
+
+        var response = await ctx.Client.PostAsync("/Identity/Account/SendUnlockEmail", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        ctx.Sender.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_UnconfirmedEmail_DoesNotSend()
+    {
+        using var ctx = CreateTestContext();
+
+        var email = $"unconfirmed-{Guid.NewGuid():N}@example.com";
+        await CreateUserAsync(ctx.Factory, email, emailConfirmed: false, locked: true);
+
+        using var content = new FormUrlEncodedContent([
+            new KeyValuePair<string, string>("email", email),
+        ]);
+
+        var response = await ctx.Client.PostAsync("/Identity/Account/SendUnlockEmail", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        ctx.Sender.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_ExceedsRateLimit_Returns429()
+    {
+        using var ctx = CreateTestContext();
+
+        // "auth-strict" allows 10 requests per minute per IP; the 11th must be 429.
+        HttpStatusCode? lastStatus = null;
+        for (var i = 0; i < 11; i++)
+        {
+            using var content = new FormUrlEncodedContent([
+                new KeyValuePair<string, string>("email", $"ratelimit-{i}@example.com"),
+            ]);
+            using var response = await ctx.Client.PostAsync(
+                "/Identity/Account/SendUnlockEmail",
+                content
+            );
+            lastStatus = response.StatusCode;
+        }
+
+        lastStatus.Should().Be(HttpStatusCode.TooManyRequests);
     }
 
     [Fact]
@@ -97,19 +232,32 @@ public class AccountUnlockEndpointTests
     }
 
     [Fact]
+    public async Task UnlockAccount_MalformedBase64Code_ReturnsPage()
+    {
+        var user = await CreateUserAsync(
+            _factory,
+            $"malformed-{Guid.NewGuid():N}@example.com",
+            emailConfirmed: true,
+            locked: true
+        );
+
+        // "@@@" is not valid base64url and would throw FormatException without the guard.
+        var response = await _client.GetAsync(
+            $"/Identity/Account/UnlockAccount?userId={Uri.EscapeDataString(user.Id)}&code=%40%40%40"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task UnlockAccount_InvalidToken_ReturnsPage()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-
-        var user = new ApplicationUser
-        {
-            UserName = "invalid-token-test@example.com",
-            Email = "invalid-token-test@example.com",
-            EmailConfirmed = true,
-            DisplayName = "Token Test User",
-        };
-        await userManager.CreateAsync(user, "TestPass1234!");
+        var user = await CreateUserAsync(
+            _factory,
+            $"invalid-token-{Guid.NewGuid():N}@example.com",
+            emailConfirmed: true,
+            locked: false
+        );
 
         var tamperedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("tampered-token"));
         var response = await _client.GetAsync(
@@ -122,28 +270,17 @@ public class AccountUnlockEndpointTests
     [Fact]
     public async Task UnlockAccount_ValidToken_UnlocksUser()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = $"valid-unlock-{Guid.NewGuid():N}@example.com";
+        var user = await CreateUserAsync(_factory, email, emailConfirmed: true, locked: true);
 
-        var user = new ApplicationUser
-        {
-            UserName = "valid-unlock-test@example.com",
-            Email = "valid-unlock-test@example.com",
-            EmailConfirmed = true,
-            DisplayName = "Valid Unlock User",
-        };
-        await userManager.CreateAsync(user, "TestPass1234!");
-        await userManager.SetLockoutEnabledAsync(user, true);
-        await userManager.SetLockoutEndDateAsync(
-            user,
-            DateTimeOffset.UtcNow.AddHours(1)
-        );
-
-        // Generate a valid unlock token
+        await using var setupScope = _factory.Services.CreateAsyncScope();
+        var userManager = setupScope.ServiceProvider.GetRequiredService<
+            UserManager<ApplicationUser>
+        >();
         var code = await userManager.GenerateUserTokenAsync(
             user,
             TokenOptions.DefaultProvider,
-            "AccountUnlock"
+            UsersConstants.TokenPurposes.AccountUnlock
         );
         var encodedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
 
@@ -153,10 +290,10 @@ public class AccountUnlockEndpointTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        // Verify the user is actually unlocked
         await using var verifyScope = _factory.Services.CreateAsyncScope();
-        var verifyManager =
-            verifyScope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var verifyManager = verifyScope.ServiceProvider.GetRequiredService<
+            UserManager<ApplicationUser>
+        >();
         var updatedUser = await verifyManager.FindByIdAsync(user.Id);
         updatedUser.Should().NotBeNull();
         (await verifyManager.IsLockedOutAsync(updatedUser!)).Should().BeFalse();

--- a/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
+++ b/modules/Users/tests/SimpleModule.Users.Tests/Integration/AccountUnlockEndpointTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Tests.Shared.Fixtures;
+using SimpleModule.Users.Contracts;
+
+namespace Users.Tests.Integration;
+
+[Collection(TestCollections.Integration)]
+public class AccountUnlockEndpointTests
+{
+    private readonly SimpleModuleWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public AccountUnlockEndpointTests(SimpleModuleWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+            }
+        );
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_UnknownEmail_RedirectsToConfirmation()
+    {
+        using var content = new FormUrlEncodedContent(
+            [new KeyValuePair<string, string>("email", "nonexistent@example.com")]
+        );
+
+        var response = await _client.PostAsync(
+            "/Identity/Account/SendUnlockEmail",
+            content
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should()
+            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+    }
+
+    [Fact]
+    public async Task SendUnlockEmail_LockedUser_RedirectsToConfirmation()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "locked-unlock-test@example.com",
+            Email = "locked-unlock-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Locked User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+        await userManager.SetLockoutEnabledAsync(user, true);
+        await userManager.SetLockoutEndDateAsync(
+            user,
+            DateTimeOffset.UtcNow.AddHours(1)
+        );
+
+        using var content = new FormUrlEncodedContent(
+            [new KeyValuePair<string, string>("email", user.Email)]
+        );
+
+        var response = await _client.PostAsync(
+            "/Identity/Account/SendUnlockEmail",
+            content
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should()
+            .Contain("/Identity/Account/SendUnlockEmailConfirmation");
+    }
+
+    [Fact]
+    public async Task UnlockAccount_MissingParams_RedirectsToHome()
+    {
+        var response = await _client.GetAsync("/Identity/Account/UnlockAccount");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location!.OriginalString.Should().Be("/");
+    }
+
+    [Fact]
+    public async Task UnlockAccount_InvalidUserId_ReturnsPage()
+    {
+        var response = await _client.GetAsync(
+            "/Identity/Account/UnlockAccount?userId=nonexistent&code=bogus"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task UnlockAccount_InvalidToken_ReturnsPage()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "invalid-token-test@example.com",
+            Email = "invalid-token-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Token Test User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+
+        var tamperedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("tampered-token"));
+        var response = await _client.GetAsync(
+            $"/Identity/Account/UnlockAccount?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(tamperedCode)}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task UnlockAccount_ValidToken_UnlocksUser()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var user = new ApplicationUser
+        {
+            UserName = "valid-unlock-test@example.com",
+            Email = "valid-unlock-test@example.com",
+            EmailConfirmed = true,
+            DisplayName = "Valid Unlock User",
+        };
+        await userManager.CreateAsync(user, "TestPass1234!");
+        await userManager.SetLockoutEnabledAsync(user, true);
+        await userManager.SetLockoutEndDateAsync(
+            user,
+            DateTimeOffset.UtcNow.AddHours(1)
+        );
+
+        // Generate a valid unlock token
+        var code = await userManager.GenerateUserTokenAsync(
+            user,
+            TokenOptions.DefaultProvider,
+            "AccountUnlock"
+        );
+        var encodedCode = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+        var response = await _client.GetAsync(
+            $"/Identity/Account/UnlockAccount?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(encodedCode)}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify the user is actually unlocked
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyManager =
+            verifyScope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var updatedUser = await verifyManager.FindByIdAsync(user.Id);
+        updatedUser.Should().NotBeNull();
+        (await verifyManager.IsLockedOutAsync(updatedUser!)).Should().BeFalse();
+        updatedUser!.AccessFailedCount.Should().Be(0);
+    }
+}

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -88,19 +88,16 @@ export const routes = {
   },
   tenants: {
     api: {
-      deleteTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      deleteTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       getTenantFeatures: (id: string | number) => `/api/tenants/${id}/features`,
-      setTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      setTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       addHost: (id: string | number) => `/api/tenants/${id}/hosts`,
       changeStatus: (id: string | number) => `/api/tenants/${id}/status`,
       create: () => '/api/tenants' as const,
       delete: (id: string | number) => `/api/tenants/${id}`,
       getAll: () => '/api/tenants' as const,
       getById: (id: string | number) => `/api/tenants/${id}`,
-      removeHost: (id: string | number, hostId: string | number) =>
-        `/api/tenants/${id}/hosts/${hostId}`,
+      removeHost: (id: string | number, hostId: string | number) => `/api/tenants/${id}/hosts/${hostId}`,
       update: (id: string | number) => `/api/tenants/${id}`,
     },
     views: {
@@ -157,7 +154,10 @@ export const routes = {
       resetAuthenticator: () => '/Identity/Account/Manage/ResetAuthenticator' as const,
       resetPasswordConfirmation: () => '/Identity/Account/ResetPasswordConfirmation' as const,
       resetPassword: () => '/Identity/Account/ResetPassword' as const,
+      sendUnlockEmailConfirmation: () => '/Identity/Account/SendUnlockEmailConfirmation' as const,
+      sendUnlockEmail: () => '/Identity/Account/SendUnlockEmail' as const,
       twoFactorAuthentication: () => '/Identity/Account/Manage/TwoFactorAuthentication' as const,
+      unlockAccount: () => '/Identity/Account/UnlockAccount' as const,
       changePassword: () => '/Identity/Account/Manage/ChangePassword' as const,
       deletePersonalData: () => '/Identity/Account/Manage/DeletePersonalData' as const,
       email: () => '/Identity/Account/Manage/Email' as const,
@@ -205,8 +205,7 @@ export const routes = {
   admin: {
     api: {
       adminRoles: () => '/admin/roles' as const,
-      adminSessions: (id: string | number, tokenId: string | number) =>
-        `/admin/users/${id}/sessions/${tokenId}`,
+      adminSessions: (id: string | number, tokenId: string | number) => `/admin/users/${id}/sessions/${tokenId}`,
       adminUsers: () => '/admin/users' as const,
     },
     views: {
@@ -220,3 +219,4 @@ export const routes = {
     },
   },
 } as const;
+

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -88,16 +88,19 @@ export const routes = {
   },
   tenants: {
     api: {
-      deleteTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
+      deleteTenantFeature: (id: string | number, flagName: string | number) =>
+        `/api/tenants/${id}/features/${flagName}`,
       getTenantFeatures: (id: string | number) => `/api/tenants/${id}/features`,
-      setTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
+      setTenantFeature: (id: string | number, flagName: string | number) =>
+        `/api/tenants/${id}/features/${flagName}`,
       addHost: (id: string | number) => `/api/tenants/${id}/hosts`,
       changeStatus: (id: string | number) => `/api/tenants/${id}/status`,
       create: () => '/api/tenants' as const,
       delete: (id: string | number) => `/api/tenants/${id}`,
       getAll: () => '/api/tenants' as const,
       getById: (id: string | number) => `/api/tenants/${id}`,
-      removeHost: (id: string | number, hostId: string | number) => `/api/tenants/${id}/hosts/${hostId}`,
+      removeHost: (id: string | number, hostId: string | number) =>
+        `/api/tenants/${id}/hosts/${hostId}`,
       update: (id: string | number) => `/api/tenants/${id}`,
     },
     views: {
@@ -205,7 +208,8 @@ export const routes = {
   admin: {
     api: {
       adminRoles: () => '/admin/roles' as const,
-      adminSessions: (id: string | number, tokenId: string | number) => `/admin/users/${id}/sessions/${tokenId}`,
+      adminSessions: (id: string | number, tokenId: string | number) =>
+        `/admin/users/${id}/sessions/${tokenId}`,
       adminUsers: () => '/admin/users' as const,
     },
     views: {
@@ -219,4 +223,3 @@ export const routes = {
     },
   },
 } as const;
-


### PR DESCRIPTION
## Summary
- Adds a self-service unlock flow: locked-out users can request an unlock link by email, and clicking it rotates their security stamp and clears the lockout. Closes #181.
- Endpoints (`SendUnlockEmail`, `SendUnlockEmailConfirmation`, `UnlockAccount`) gate on `IsEmailConfirmedAsync` + `IsLockedOutAsync`, return identical error messages on every failure path to prevent user enumeration, and never throw on malformed input.
- POST is rate-limited under the existing `auth-strict` policy (10/min/IP); GET pages and the confirmation redirect are unauthenticated.

## Notable details
- `IAccountUnlockEmailSender` contract lives in `SimpleModule.Users.Contracts` with a `ConsoleAccountUnlockEmailSender` fallback in the Users module and a real `IdentityAccountUnlockEmailSender` registered by the Email module.
- `UserSelfUnlockedEvent` is published on successful unlock; auditing flows through the existing `AuditingMessageBus` decorator, so no extra handler is required.
- Token purpose `"AccountUnlock"` is centralised in `UsersConstants.TokenPurposes` so both endpoints can't drift.
- Decoder uses `Base64Url.DecodeFromChars` with `OperationStatus`, which is genuinely non-throwing on invalid input (unlike `TryDecodeFromChars`).

## Test plan
- [x] `dotnet test` — all 17 projects pass (52 in `Users.Tests`, including 12 new integration tests).
- [x] `npx biome check .` — clean.
- [x] `npm run validate-pages` — new Inertia component names registered in `Pages/index.ts`.
- [x] `npm run validate:i18n`, `npm run typecheck`, framework-scope validation — clean.
- [x] `dotnet build SimpleModule.slnx` — 0 errors, 0 warnings.
- [ ] Manual smoke (CI Playwright): visit `/Identity/Account/Lockout` → follow the unlock link → confirm 200 page + login works.