### PR TITLE
feat(database): complete soft-delete recovery surface (closes #165)

### DIFF
--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
             { text: 'Endpoints', link: '/guide/endpoints' },
             { text: 'Contracts & DTOs', link: '/guide/contracts' },
             { text: 'Database', link: '/guide/database' },
+            { text: 'Soft Delete', link: '/guide/soft-delete' },
           ],
         },
         {

--- a/docs/site/guide/soft-delete.md
+++ b/docs/site/guide/soft-delete.md
@@ -1,0 +1,197 @@
+---
+outline: deep
+---
+
+# Soft Delete
+
+SimpleModule's soft-delete surface mirrors Laravel's `SoftDeletes` trait. Entities that implement `ISoftDelete` are automatically excluded from queries by a global query filter and are kept in the database when `Remove()` is called. The framework also exposes a recovery surface — `WithTrashed`, `OnlyTrashed`, `Restore`, `ForceDelete` — so admin restore UIs, audit flows, and retention policies do not have to leak the abstraction by reaching for `IgnoreQueryFilters()`.
+
+## ISoftDelete
+
+```csharp
+public interface ISoftDelete
+{
+    bool IsDeleted { get; set; }
+    DateTimeOffset? DeletedAt { get; set; }
+    string? DeletedBy { get; set; }
+}
+```
+
+`FullAuditableEntity<TId>` implements this for you. When you call `dbContext.Remove(entity)` on an `ISoftDelete` entity, the `EntityInterceptor` converts the delete to an update that sets `IsDeleted=true`, `DeletedAt=UtcNow`, and `DeletedBy` to the current user. A real `DELETE` statement is never issued unless you opt into [force delete](#force-delete).
+
+## Querying Trashed Rows
+
+By default, soft-deleted rows are hidden from every `DbSet<T>` query.
+
+```csharp
+public static class SoftDeleteQueryExtensions
+{
+    public static IQueryable<T> WithTrashed<T>(this IQueryable<T> q)
+        where T : class, ISoftDelete;
+
+    public static IQueryable<T> OnlyTrashed<T>(this IQueryable<T> q)
+        where T : class, ISoftDelete;
+}
+```
+
+| Extension | Result |
+|-----------|--------|
+| (default)         | Live rows only — soft-delete filter applied |
+| `WithTrashed()`   | Live + trashed rows |
+| `OnlyTrashed()`   | Trashed rows only |
+
+```csharp
+// Live rows
+var customers = await db.Customers.ToListAsync();
+
+// Live + trashed
+var all = await db.Customers.WithTrashed().ToListAsync();
+
+// Trashed only — for an admin "Recently Deleted" view
+var trashed = await db.Customers
+    .OnlyTrashed()
+    .OrderByDescending(c => c.DeletedAt)
+    .Take(50)
+    .ToListAsync();
+```
+
+::: tip Multi-tenant safety
+`WithTrashed` / `OnlyTrashed` ignore only the soft-delete filter. The multi-tenant filter (and any other named filter) stays active, so tenant isolation is preserved when admins browse the trash.
+:::
+
+## ISoftDeleteService<T>
+
+For per-row recovery operations, register `ISoftDeleteService<T>` and inject it into your endpoints or services.
+
+```csharp
+public interface ISoftDeleteService<T> where T : class, ISoftDelete
+{
+    Task<int> RestoreAsync(object id, CancellationToken ct = default);
+    Task<int> ForceDeleteAsync(object id, CancellationToken ct = default);
+    Task<int> ForceDeleteRangeAsync(IEnumerable<object> ids, CancellationToken ct = default);
+    Task<int> PurgeOlderThanAsync(TimeSpan age, CancellationToken ct = default);
+}
+```
+
+Register one per soft-deletable entity in the owning module's `ConfigureServices`:
+
+```csharp
+public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+{
+    services.AddModuleDbContext<CustomersDbContext>(configuration, "Customers");
+    services.AddSoftDelete<Customer, CustomersDbContext>();
+}
+```
+
+`AddSoftDelete<T, TContext>()` registers a scoped `ISoftDeleteService<T>` backed by the supplied `DbContext`.
+
+## Restore
+
+```csharp
+app.MapPost("/customers/{id:int}/restore",
+    (int id, ISoftDeleteService<Customer> svc, CancellationToken ct) =>
+        CrudEndpoints.Restore(() => svc.RestoreAsync(id, ct)));
+```
+
+Returns `204 No Content` if a trashed row was restored, `404 Not Found` if the id doesn't match a trashed row.
+
+`RestoreAsync` clears `IsDeleted`, `DeletedAt`, and `DeletedBy`. The `EntityInterceptor` writes a fresh `UpdatedAt`/`UpdatedBy` for the row.
+
+## Force Delete
+
+When you genuinely need to remove a row from the database — GDPR purges, test cleanup, or admin-initiated permanent deletion — call the `ForceDelete` extension instead of `Remove`:
+
+```csharp
+db.ForceDelete(customer);          // single
+db.ForceDeleteRange(customers);    // batch
+await db.SaveChangesAsync();
+```
+
+The interceptor consults a per-context marker set, recognises the entry as opted-out of soft delete, and lets the `DELETE` go through. The marker is consumed on observation, so it never leaks across calls.
+
+For id-based force delete, use the service:
+
+```csharp
+await svc.ForceDeleteAsync(customerId, ct);
+await svc.ForceDeleteRangeAsync([id1, id2, id3], ct);
+```
+
+`ForceDeleteAsync` finds the row regardless of trashed state, so it works on both live and already-trashed records.
+
+## Retention / Purge Job
+
+`PurgeOlderThanAsync(age)` permanently deletes every trashed row whose `DeletedAt` is older than the given window. Wire it up as a recurring job using the `BackgroundJobs` module:
+
+```csharp
+public sealed class PurgeOldCustomersJob(
+    ISoftDeleteService<Customer> softDelete,
+    ISettingsContracts settings
+) : IModuleJob
+{
+    public async Task ExecuteAsync(IJobExecutionContext context, CancellationToken ct)
+    {
+        var raw = await settings.GetSettingAsync("SoftDelete.Customer.RetainDays", SettingScope.System);
+        var days = int.TryParse(raw, out var d) ? d : 90;
+        var purged = await softDelete.PurgeOlderThanAsync(TimeSpan.FromDays(days), ct);
+        context.Log($"Purged {purged} customer rows older than {days} days");
+    }
+}
+
+// In your module's ConfigureServices
+services.AddModuleJob<PurgeOldCustomersJob>();
+
+// On startup, schedule it
+await backgroundJobs.AddRecurringAsync<PurgeOldCustomersJob>(
+    name: "Purge old customers",
+    cronExpression: "0 3 * * *");  // every day at 03:00
+```
+
+The retention window is read from a per-entity setting (`SoftDelete.{Entity}.RetainDays`), so operators can tune it without redeploying.
+
+## End-to-End Example
+
+```csharp
+// Endpoint module
+public sealed class RestoreCustomerEndpoint : IEndpoint
+{
+    public void Configure(RouteGroupBuilder group)
+    {
+        group.MapPost("/{id:int}/restore",
+            (int id, ISoftDeleteService<Customer> svc, CancellationToken ct) =>
+                CrudEndpoints.Restore(() => svc.RestoreAsync(id, ct)))
+            .RequireAuthorization("Customers.Restore");
+    }
+}
+
+public sealed class ForceDeleteCustomerEndpoint : IEndpoint
+{
+    public void Configure(RouteGroupBuilder group)
+    {
+        group.MapDelete("/{id:int}/force",
+            (int id, ISoftDeleteService<Customer> svc, CancellationToken ct) =>
+                CrudEndpoints.ForceDelete(() => svc.ForceDeleteAsync(id, ct)))
+            .RequireAuthorization("Customers.ForceDelete");
+    }
+}
+```
+
+## Reference
+
+| Symbol | Purpose |
+|--------|---------|
+| `WithTrashed<T>()` | Include soft-deleted rows in a query |
+| `OnlyTrashed<T>()` | Return only soft-deleted rows |
+| `DbContext.ForceDelete(entity)` | Issue a real DELETE for one row |
+| `DbContext.ForceDeleteRange(entities)` | Issue real DELETEs for many rows |
+| `ISoftDeleteService<T>.RestoreAsync(id)` | Clear soft-delete fields by id |
+| `ISoftDeleteService<T>.ForceDeleteAsync(id)` | Hard delete by id |
+| `ISoftDeleteService<T>.ForceDeleteRangeAsync(ids)` | Batch hard delete |
+| `ISoftDeleteService<T>.PurgeOlderThanAsync(age)` | Retention sweep |
+| `CrudEndpoints.Restore` | Endpoint helper, 204/404 |
+| `CrudEndpoints.ForceDelete` | Endpoint helper, 204/404 |
+
+## Next Steps
+
+- [Database](/guide/database) -- query filters, schema isolation, and DbContext wiring
+- [Background Jobs](/guide/background-jobs) -- scheduling the retention sweep
+- [EF Core Interceptors](/advanced/interceptors) -- how the soft-delete interceptor is wired in

--- a/framework/SimpleModule.Core/Endpoints/CrudEndpoints.cs
+++ b/framework/SimpleModule.Core/Endpoints/CrudEndpoints.cs
@@ -34,4 +34,26 @@ public static class CrudEndpoints
         await delete();
         return TypedResults.NoContent();
     }
+
+    /// <summary>
+    /// Endpoint helper for restoring a soft-deleted row. The <paramref name="restore"/>
+    /// delegate should call <c>ISoftDeleteService&lt;T&gt;.RestoreAsync(id)</c> and return
+    /// the number of rows affected (0 → 404, 1 → 204).
+    /// </summary>
+    public static async Task<IResult> Restore(Func<Task<int>> restore)
+    {
+        var affected = await restore();
+        return affected > 0 ? TypedResults.NoContent() : TypedResults.NotFound();
+    }
+
+    /// <summary>
+    /// Endpoint helper for force-deleting a row (bypassing soft delete). The
+    /// <paramref name="forceDelete"/> delegate should call
+    /// <c>ISoftDeleteService&lt;T&gt;.ForceDeleteAsync(id)</c>.
+    /// </summary>
+    public static async Task<IResult> ForceDelete(Func<Task<int>> forceDelete)
+    {
+        var affected = await forceDelete();
+        return affected > 0 ? TypedResults.NoContent() : TypedResults.NotFound();
+    }
 }

--- a/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
+++ b/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using SimpleModule.Core.Entities;
+using SimpleModule.Database.SoftDelete;
 
 namespace SimpleModule.Database.Interceptors;
 
@@ -65,6 +66,11 @@ public sealed class EntityInterceptor(
                     break;
 
                 case EntityState.Deleted when entry.Entity is ISoftDelete sd:
+                    if (ForceDeleteExtensions.IsMarked(eventData.Context, sd))
+                    {
+                        ForceDeleteExtensions.Consume(eventData.Context, sd);
+                        break;
+                    }
                     entry.State = EntityState.Modified;
                     sd.IsDeleted = true;
                     sd.DeletedAt = now;

--- a/framework/SimpleModule.Database/SoftDelete/ForceDeleteExtensions.cs
+++ b/framework/SimpleModule.Database/SoftDelete/ForceDeleteExtensions.cs
@@ -1,0 +1,82 @@
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.SoftDelete;
+
+/// <summary>
+/// Extensions that bypass the soft-delete interceptor and issue a real <c>DELETE</c>
+/// against the database. Required for GDPR purges, test cleanup, and recovery flows
+/// where retaining the row is undesirable.
+/// </summary>
+/// <remarks>
+/// The marker is tracked per-entity in a <see cref="ConditionalWeakTable{TKey, TValue}"/>
+/// keyed by <see cref="DbContext"/>, then consumed (and removed) by
+/// <c>EntityInterceptor</c> when it inspects each entry. Markers do not survive past
+/// the next <c>SaveChanges</c> on that context.
+/// <para>
+/// If <c>SaveChanges</c> never runs after a <c>ForceDelete</c> call (e.g. an exception
+/// aborts the unit of work, or the entity is detached via <c>ChangeTracker.Clear()</c>
+/// before save), the marker remains until the <see cref="DbContext"/> itself is collected.
+/// This is bounded — scoped contexts are short-lived — but callers using long-lived
+/// contexts should not stage force-deletes they don't intend to commit.
+/// </para>
+/// </remarks>
+public static class ForceDeleteExtensions
+{
+    private static readonly ConditionalWeakTable<DbContext, HashSet<object>> Markers = new();
+
+    /// <summary>
+    /// Marks <paramref name="entity"/> for hard delete and removes it from the context.
+    /// The soft-delete interceptor will leave this entry alone, so a real <c>DELETE</c>
+    /// statement is issued on <c>SaveChanges</c>.
+    /// </summary>
+    public static EntityEntry<T> ForceDelete<T>(this DbContext context, T entity)
+        where T : class, ISoftDelete
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        Mark(context, entity);
+        return context.Remove(entity);
+    }
+
+    /// <summary>
+    /// Marks each entity for hard delete and removes them from the context.
+    /// </summary>
+    public static void ForceDeleteRange<T>(this DbContext context, IEnumerable<T> entities)
+        where T : class, ISoftDelete
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(entities);
+
+        foreach (var entity in entities)
+        {
+            Mark(context, entity);
+            context.Remove(entity);
+        }
+    }
+
+    internal static bool IsMarked(DbContext context, object entity) =>
+        Markers.TryGetValue(context, out var set) && set.Contains(entity);
+
+    /// <summary>
+    /// Removes the marker for <paramref name="entity"/> after the interceptor has
+    /// observed it. Called by <c>EntityInterceptor</c> per entry to keep the marker
+    /// set bounded.
+    /// </summary>
+    internal static void Consume(DbContext context, object entity)
+    {
+        if (Markers.TryGetValue(context, out var set))
+        {
+            set.Remove(entity);
+        }
+    }
+
+    private static void Mark(DbContext context, object entity)
+    {
+        var set = Markers.GetValue(context, _ => []);
+        set.Add(entity);
+    }
+}

--- a/framework/SimpleModule.Database/SoftDelete/ISoftDeleteService.cs
+++ b/framework/SimpleModule.Database/SoftDelete/ISoftDeleteService.cs
@@ -1,0 +1,44 @@
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.SoftDelete;
+
+/// <summary>
+/// Recovery operations for a soft-deletable entity. Mirrors the operations needed by
+/// admin restore UIs, GDPR purge flows, and retention policies.
+/// </summary>
+/// <typeparam name="T">The <see cref="ISoftDelete"/> entity type managed by this service.</typeparam>
+public interface ISoftDeleteService<T>
+    where T : class, ISoftDelete
+{
+    /// <summary>
+    /// Restores a single soft-deleted row by primary key. The row's <see cref="ISoftDelete.IsDeleted"/>,
+    /// <see cref="ISoftDelete.DeletedAt"/>, and <see cref="ISoftDelete.DeletedBy"/> fields are cleared.
+    /// </summary>
+    /// <returns>1 if a row was restored; 0 if the id was not found among trashed rows.</returns>
+    Task<int> RestoreAsync(object id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issues a real <c>DELETE</c> for the row with the given key, bypassing the soft-delete
+    /// interceptor. The row is removed from the database whether or not it was previously
+    /// soft-deleted.
+    /// </summary>
+    /// <returns>1 if a row was deleted; 0 if the id was not found.</returns>
+    Task<int> ForceDeleteAsync(object id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issues a real <c>DELETE</c> for each row matching the given keys.
+    /// </summary>
+    /// <returns>The number of rows actually deleted.</returns>
+    Task<int> ForceDeleteRangeAsync(
+        IEnumerable<object> ids,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Permanently deletes every soft-deleted row whose <see cref="ISoftDelete.DeletedAt"/>
+    /// is older than <paramref name="age"/>. Use this from a scheduled background job to
+    /// implement retention policies.
+    /// </summary>
+    /// <returns>The number of rows purged.</returns>
+    Task<int> PurgeOlderThanAsync(TimeSpan age, CancellationToken cancellationToken = default);
+}

--- a/framework/SimpleModule.Database/SoftDelete/SoftDeleteQueryExtensions.cs
+++ b/framework/SimpleModule.Database/SoftDelete/SoftDeleteQueryExtensions.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.SoftDelete;
+
+/// <summary>
+/// Query extensions for working with soft-deleted (<see cref="ISoftDelete"/>) entities.
+/// Provides a fluent surface that mirrors Laravel's <c>withTrashed()</c> / <c>onlyTrashed()</c>
+/// helpers so callers do not have to reach for <see cref="EntityFrameworkQueryableExtensions.IgnoreQueryFilters{T}"/>
+/// directly and leak the soft-delete abstraction.
+/// </summary>
+public static class SoftDeleteQueryExtensions
+{
+    /// <summary>
+    /// Includes soft-deleted rows in the query result alongside live rows by ignoring
+    /// the soft-delete query filter.
+    /// </summary>
+    public static IQueryable<T> WithTrashed<T>(this IQueryable<T> query)
+        where T : class, ISoftDelete
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return query.IgnoreQueryFilters([DatabaseConstants.SoftDeleteQueryFilterKey]);
+    }
+
+    /// <summary>
+    /// Returns only soft-deleted rows. Other query filters (e.g. multi-tenant) remain active.
+    /// </summary>
+    public static IQueryable<T> OnlyTrashed<T>(this IQueryable<T> query)
+        where T : class, ISoftDelete
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return query
+            .IgnoreQueryFilters([DatabaseConstants.SoftDeleteQueryFilterKey])
+            .Where(e => e.IsDeleted);
+    }
+}

--- a/framework/SimpleModule.Database/SoftDelete/SoftDeleteService.cs
+++ b/framework/SimpleModule.Database/SoftDelete/SoftDeleteService.cs
@@ -1,0 +1,233 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.SoftDelete;
+
+/// <summary>
+/// Default <see cref="ISoftDeleteService{T}"/> implementation. Generic over the entity
+/// type and its owning <see cref="DbContext"/>; register one per soft-deletable entity
+/// via <see cref="SoftDeleteServiceCollectionExtensions.AddSoftDelete{T, TContext}"/>.
+/// </summary>
+public sealed class SoftDeleteService<T, TContext>(TContext context) : ISoftDeleteService<T>
+    where T : class, ISoftDelete
+    where TContext : DbContext
+{
+    private const int PurgeBatchSize = 1000;
+
+    private static KeyMetadata? _keyMetadata;
+
+    public async Task<int> RestoreAsync(object id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var entity = await FindTrashedAsync(id, cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return 0;
+
+        entity.IsDeleted = false;
+        entity.DeletedAt = null;
+        entity.DeletedBy = null;
+        return await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false) > 0 ? 1 : 0;
+    }
+
+    public async Task<int> ForceDeleteAsync(
+        object id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var entity = await FindAnyAsync(id, cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return 0;
+
+        context.ForceDelete(entity);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return 1;
+    }
+
+    public async Task<int> ForceDeleteRangeAsync(
+        IEnumerable<object> ids,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+
+        var meta = GetKeyMetadata();
+        var typedIds = CoerceIds(ids, meta.KeyType);
+        if (typedIds.Length == 0)
+            return 0;
+
+        var predicate = BuildKeyContainsPredicate(meta, typedIds);
+        var entities = await context
+            .Set<T>()
+            .WithTrashed()
+            .Where(predicate)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entities.Count == 0)
+            return 0;
+
+        context.ForceDeleteRange(entities);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return entities.Count;
+    }
+
+    public async Task<int> PurgeOlderThanAsync(
+        TimeSpan age,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (age < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(age), "Age must be non-negative.");
+
+        var cutoff = DateTimeOffset.UtcNow - age;
+        var meta = GetKeyMetadata();
+        var totalPurged = 0;
+        var skip = 0;
+
+        // Page through trashed rows ordered by primary key. We can't filter or order on
+        // DeletedAt server-side under SQLite (no DateTimeOffset translation), so each
+        // page is filtered against the cutoff in memory. Chunk size bounds the change
+        // tracker and keeps memory under control on large tables.
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var page = await meta.OrderByKey(context.Set<T>().OnlyTrashed())
+                .Skip(skip)
+                .Take(PurgeBatchSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (page.Count == 0)
+                break;
+
+            var stale = page.Where(e => e.DeletedAt is { } d && d < cutoff).ToList();
+            if (stale.Count > 0)
+            {
+                context.ForceDeleteRange(stale);
+                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                totalPurged += stale.Count;
+            }
+
+            // Skipped rows shift left after their preceding peers are deleted.
+            // Advance the cursor only past the rows we kept.
+            skip += page.Count - stale.Count;
+
+            if (page.Count < PurgeBatchSize)
+                break;
+        }
+
+        return totalPurged;
+    }
+
+    private Task<T?> FindTrashedAsync(object id, CancellationToken cancellationToken)
+    {
+        var meta = GetKeyMetadata();
+        var coerced = CoerceId(id, meta.KeyType);
+        return context
+            .Set<T>()
+            .OnlyTrashed()
+            .FirstOrDefaultAsync(meta.BuildKeyEqualsPredicate(coerced), cancellationToken);
+    }
+
+    private Task<T?> FindAnyAsync(object id, CancellationToken cancellationToken)
+    {
+        var meta = GetKeyMetadata();
+        var coerced = CoerceId(id, meta.KeyType);
+        return context
+            .Set<T>()
+            .WithTrashed()
+            .FirstOrDefaultAsync(meta.BuildKeyEqualsPredicate(coerced), cancellationToken);
+    }
+
+    private KeyMetadata GetKeyMetadata()
+    {
+        if (_keyMetadata is not null)
+            return _keyMetadata;
+
+        var entityType =
+            context.Model.FindEntityType(typeof(T))
+            ?? throw new InvalidOperationException(
+                $"Entity type {typeof(T).Name} is not registered with {typeof(TContext).Name}."
+            );
+        var key =
+            entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException(
+                $"Entity type {typeof(T).Name} has no primary key."
+            );
+        if (key.Properties.Count != 1)
+            throw new InvalidOperationException(
+                $"SoftDeleteService requires a single-property primary key on {typeof(T).Name}."
+            );
+
+        var keyProperty = key.Properties[0];
+        _keyMetadata = new KeyMetadata(keyProperty.Name, keyProperty.ClrType);
+        return _keyMetadata;
+    }
+
+    private static Expression<Func<T, bool>> BuildKeyContainsPredicate(
+        KeyMetadata meta,
+        Array typedIds
+    )
+    {
+        var parameter = Expression.Parameter(typeof(T), "e");
+        var keyAccess = Expression.Property(parameter, meta.KeyName);
+        var idsConstant = Expression.Constant(typedIds);
+        var contains = ContainsMethodFor(meta.KeyType);
+        var call = Expression.Call(contains, idsConstant, keyAccess);
+        return Expression.Lambda<Func<T, bool>>(call, parameter);
+    }
+
+    private static System.Reflection.MethodInfo ContainsMethodFor(Type keyType) =>
+        typeof(Enumerable)
+            .GetMethods()
+            .First(m => m.Name == nameof(Enumerable.Contains) && m.GetParameters().Length == 2)
+            .MakeGenericMethod(keyType);
+
+    private static Array CoerceIds(IEnumerable<object> ids, Type keyType)
+    {
+        var list = ids.ToList();
+        var typed = Array.CreateInstance(keyType, list.Count);
+        for (var i = 0; i < list.Count; i++)
+        {
+            typed.SetValue(CoerceId(list[i], keyType), i);
+        }
+        return typed;
+    }
+
+    private static object CoerceId(object id, Type keyType)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return id.GetType() == keyType
+            ? id
+            : Convert.ChangeType(id, keyType, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private sealed record KeyMetadata(string KeyName, Type KeyType)
+    {
+        public Expression<Func<T, bool>> BuildKeyEqualsPredicate(object id)
+        {
+            var parameter = Expression.Parameter(typeof(T), "e");
+            var keyAccess = Expression.Property(parameter, KeyName);
+            var idConstant = Expression.Constant(id, KeyType);
+            var equals = Expression.Equal(keyAccess, idConstant);
+            return Expression.Lambda<Func<T, bool>>(equals, parameter);
+        }
+
+        public IOrderedQueryable<T> OrderByKey(IQueryable<T> source)
+        {
+            var parameter = Expression.Parameter(typeof(T), "e");
+            var keyAccess = Expression.Property(parameter, KeyName);
+            var lambda = Expression.Lambda(keyAccess, parameter);
+            var orderBy = typeof(Queryable)
+                .GetMethods()
+                .First(m => m.Name == nameof(Queryable.OrderBy) && m.GetParameters().Length == 2)
+                .MakeGenericMethod(typeof(T), KeyType);
+            return (IOrderedQueryable<T>)orderBy.Invoke(null, [source, lambda])!;
+        }
+    }
+}

--- a/framework/SimpleModule.Database/SoftDelete/SoftDeleteServiceCollectionExtensions.cs
+++ b/framework/SimpleModule.Database/SoftDelete/SoftDeleteServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.Core.Entities;
+
+namespace SimpleModule.Database.SoftDelete;
+
+/// <summary>
+/// Service registration helpers for <see cref="ISoftDeleteService{T}"/>.
+/// </summary>
+public static class SoftDeleteServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers an <see cref="ISoftDeleteService{T}"/> backed by <typeparamref name="TContext"/>
+    /// in DI. Call this once per soft-deletable entity from the owning module's
+    /// <c>ConfigureServices</c>:
+    /// <code>
+    /// services.AddSoftDelete&lt;Customer, CustomersDbContext&gt;();
+    /// </code>
+    /// </summary>
+    public static IServiceCollection AddSoftDelete<T, TContext>(this IServiceCollection services)
+        where T : class, ISoftDelete
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddScoped<ISoftDeleteService<T>, SoftDeleteService<T, TContext>>();
+        return services;
+    }
+}

--- a/tests/SimpleModule.Database.Tests/SoftDeleteTests.cs
+++ b/tests/SimpleModule.Database.Tests/SoftDeleteTests.cs
@@ -1,0 +1,257 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SimpleModule.Core.Entities;
+using SimpleModule.Database.Interceptors;
+using SimpleModule.Database.SoftDelete;
+
+namespace SimpleModule.Database.Tests;
+
+public sealed class SoftDeleteTests
+{
+    [Fact]
+    public async Task WithTrashed_Returns_Live_And_Soft_Deleted_Rows()
+    {
+        await using var fixture = CreateFixture();
+        fixture.Context.Items.AddRange(
+            new SoftDeleteItem { Name = "alive" },
+            new SoftDeleteItem { Name = "trashed" }
+        );
+        await fixture.Context.SaveChangesAsync();
+
+        var trashed = await fixture.Context.Items.FirstAsync(x => x.Name == "trashed");
+        fixture.Context.Items.Remove(trashed);
+        await fixture.Context.SaveChangesAsync();
+
+        var visible = await fixture.Context.Items.ToListAsync();
+        var withTrashed = await fixture.Context.Items.WithTrashed().ToListAsync();
+
+        visible.Should().ContainSingle().Which.Name.Should().Be("alive");
+        withTrashed.Should().HaveCount(2);
+        withTrashed.Should().Contain(x => x.Name == "trashed" && x.IsDeleted);
+    }
+
+    [Fact]
+    public async Task OnlyTrashed_Returns_Only_Soft_Deleted_Rows()
+    {
+        await using var fixture = CreateFixture();
+        fixture.Context.Items.AddRange(
+            new SoftDeleteItem { Name = "alive" },
+            new SoftDeleteItem { Name = "trashed" }
+        );
+        await fixture.Context.SaveChangesAsync();
+
+        var trashed = await fixture.Context.Items.FirstAsync(x => x.Name == "trashed");
+        fixture.Context.Items.Remove(trashed);
+        await fixture.Context.SaveChangesAsync();
+
+        var only = await fixture.Context.Items.OnlyTrashed().ToListAsync();
+
+        only.Should().ContainSingle().Which.Name.Should().Be("trashed");
+        only[0].IsDeleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Clears_Soft_Delete_Fields()
+    {
+        await using var fixture = CreateFixture("user-1");
+        var item = new SoftDeleteItem { Name = "doomed" };
+        fixture.Context.Items.Add(item);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.Items.Remove(item);
+        await fixture.Context.SaveChangesAsync();
+        item.IsDeleted.Should().BeTrue();
+
+        var service = fixture.GetService();
+        var affected = await service.RestoreAsync(item.Id);
+
+        affected.Should().Be(1);
+        var restored = await fixture.Context.Items.FirstAsync(x => x.Id == item.Id);
+        restored.IsDeleted.Should().BeFalse();
+        restored.DeletedAt.Should().BeNull();
+        restored.DeletedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Returns_Zero_When_Not_Trashed()
+    {
+        await using var fixture = CreateFixture();
+        var item = new SoftDeleteItem { Name = "alive" };
+        fixture.Context.Items.Add(item);
+        await fixture.Context.SaveChangesAsync();
+
+        var affected = await fixture.GetService().RestoreAsync(item.Id);
+
+        affected.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ForceDelete_Issues_Real_Delete_Bypassing_Soft_Delete()
+    {
+        await using var fixture = CreateFixture();
+        var item = new SoftDeleteItem { Name = "purge-me" };
+        fixture.Context.Items.Add(item);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.ForceDelete(item);
+        await fixture.Context.SaveChangesAsync();
+
+        var any = await fixture.Context.Items.WithTrashed().AnyAsync(x => x.Id == item.Id);
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ForceDeleteAsync_Removes_Trashed_Row()
+    {
+        await using var fixture = CreateFixture();
+        var item = new SoftDeleteItem { Name = "two-step" };
+        fixture.Context.Items.Add(item);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.Items.Remove(item);
+        await fixture.Context.SaveChangesAsync();
+
+        var affected = await fixture.GetService().ForceDeleteAsync(item.Id);
+
+        affected.Should().Be(1);
+        var any = await fixture.Context.Items.WithTrashed().AnyAsync(x => x.Id == item.Id);
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ForceDeleteRangeAsync_Removes_Multiple_Rows()
+    {
+        await using var fixture = CreateFixture();
+        var a = new SoftDeleteItem { Name = "a" };
+        var b = new SoftDeleteItem { Name = "b" };
+        var c = new SoftDeleteItem { Name = "c" };
+        fixture.Context.Items.AddRange(a, b, c);
+        await fixture.Context.SaveChangesAsync();
+
+        var affected = await fixture.GetService().ForceDeleteRangeAsync([a.Id, b.Id]);
+
+        affected.Should().Be(2);
+        var remaining = await fixture.Context.Items.WithTrashed().Select(x => x.Name).ToListAsync();
+        remaining.Should().ContainSingle().Which.Should().Be("c");
+    }
+
+    [Fact]
+    public async Task PurgeOlderThanAsync_Deletes_Only_Old_Trashed_Rows()
+    {
+        await using var fixture = CreateFixture();
+        var fresh = new SoftDeleteItem { Name = "fresh" };
+        var stale = new SoftDeleteItem { Name = "stale" };
+        fixture.Context.Items.AddRange(fresh, stale);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.Items.Remove(stale);
+        await fixture.Context.SaveChangesAsync();
+        stale.DeletedAt = DateTimeOffset.UtcNow - TimeSpan.FromDays(40);
+        await fixture.Context.SaveChangesAsync();
+
+        fixture.Context.Items.Remove(fresh);
+        await fixture.Context.SaveChangesAsync();
+
+        var purged = await fixture.GetService().PurgeOlderThanAsync(TimeSpan.FromDays(30));
+
+        purged.Should().Be(1);
+        var survivors = await fixture.Context.Items.WithTrashed().Select(x => x.Name).ToListAsync();
+        survivors.Should().ContainSingle().Which.Should().Be("fresh");
+    }
+
+    [Fact]
+    public async Task PurgeOlderThanAsync_Skips_Non_Trashed_Rows()
+    {
+        await using var fixture = CreateFixture();
+        var alive = new SoftDeleteItem { Name = "alive" };
+        fixture.Context.Items.Add(alive);
+        await fixture.Context.SaveChangesAsync();
+
+        var purged = await fixture.GetService().PurgeOlderThanAsync(TimeSpan.Zero);
+
+        purged.Should().Be(0);
+        (await fixture.Context.Items.AnyAsync(x => x.Id == alive.Id)).Should().BeTrue();
+    }
+
+    private static TestFixture CreateFixture(string? userId = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Database:DefaultConnection"] = "Data Source=:memory:",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var httpContext = new DefaultHttpContext();
+        if (userId is not null)
+        {
+            httpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId)], "TestAuth")
+            );
+        }
+
+        services.AddSingleton<IHttpContextAccessor>(
+            new HttpContextAccessor { HttpContext = httpContext }
+        );
+        services.AddScoped<ISaveChangesInterceptor, EntityInterceptor>();
+        services.AddModuleDbContext<SoftDeleteTestDbContext>(config, "SoftDeleteTest");
+        services.AddSoftDelete<SoftDeleteItem, SoftDeleteTestDbContext>();
+
+        var provider = services.BuildServiceProvider();
+        var context = provider.GetRequiredService<SoftDeleteTestDbContext>();
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+        return new TestFixture(provider, context);
+    }
+
+    private sealed class TestFixture(ServiceProvider provider, SoftDeleteTestDbContext context)
+        : IAsyncDisposable
+    {
+        public SoftDeleteTestDbContext Context => context;
+
+        public ISoftDeleteService<SoftDeleteItem> GetService() =>
+            provider.GetRequiredService<ISoftDeleteService<SoftDeleteItem>>();
+
+        public async ValueTask DisposeAsync()
+        {
+            await context.DisposeAsync();
+            await provider.DisposeAsync();
+        }
+    }
+
+    public sealed class SoftDeleteItem : ISoftDelete
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? DeletedAt { get; set; }
+        public string? DeletedBy { get; set; }
+    }
+
+    public sealed class SoftDeleteTestDbContext(
+        DbContextOptions<SoftDeleteTestDbContext> options,
+        IOptions<DatabaseOptions> dbOptions
+    ) : DbContext(options)
+    {
+        public DbSet<SoftDeleteItem> Items => Set<SoftDeleteItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SoftDeleteItem>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedOnAdd();
+            });
+            modelBuilder.ApplyModuleSchema("SoftDeleteTest", dbOptions.Value);
+        }
+    }
+}


### PR DESCRIPTION
Closes #165

## Summary

Adds the recovery operations missing from the existing `ISoftDelete` pipeline — modelled on Laravel's `SoftDeletes` trait. Before this PR, soft-deleted rows were hidden by a global query filter but there was no fluent way to query trashed rows, no `Restore`, no force-delete bypass, and developers were reaching for `IgnoreQueryFilters()` directly, leaking the abstraction.

## What's new

### Query extensions (`SimpleModule.Database.SoftDelete.SoftDeleteQueryExtensions`)

```csharp
db.Customers.WithTrashed()    // live + soft-deleted rows
db.Customers.OnlyTrashed()    // soft-deleted rows only
```

Both ignore only the *named* soft-delete filter (`DatabaseConstants.SoftDeleteQueryFilterKey`), so multi-tenant filters stay active when admins browse the trash.

### Force-delete bypass (`ForceDeleteExtensions`)

```csharp
db.ForceDelete(customer);          // single hard delete
db.ForceDeleteRange(customers);    // batch hard delete
await db.SaveChangesAsync();
```

Uses a `ConditionalWeakTable<DbContext, HashSet<object>>` keyed marker. The existing `EntityInterceptor` consults it before flipping `Deleted` → `Modified`, so a real `DELETE` is issued for explicitly opted-out entities. Markers are consumed on observation and never leak across saves.

### Recovery service (`ISoftDeleteService<T>`)

```csharp
public interface ISoftDeleteService<T> where T : class, ISoftDelete
{
    Task<int> RestoreAsync(object id, CancellationToken ct = default);
    Task<int> ForceDeleteAsync(object id, CancellationToken ct = default);
    Task<int> ForceDeleteRangeAsync(IEnumerable<object> ids, CancellationToken ct = default);
    Task<int> PurgeOlderThanAsync(TimeSpan age, CancellationToken ct = default);
}
```

Default implementation `SoftDeleteService<T, TContext>` — register one per soft-deletable entity:

```csharp
services.AddSoftDelete<Customer, CustomersDbContext>();
```

Implementation notes:

- **Cached key metadata** — `FindEntityType`/`FindPrimaryKey` walks happen once per closed generic, then `(KeyName, KeyType)` is reused.
- **Range delete is a single `WHERE Id IN (...)` query** — dynamic LINQ expression built once, no N+1.
- **Purge is paged + chunked** — orders by primary key, pulls 1000-row pages, filters `DeletedAt < cutoff` in memory (SQLite cannot translate `DateTimeOffset` ordering or comparison), force-deletes the stale slice, advances the cursor only past kept rows. Bounds both DB read size and EF Core ChangeTracker memory.

### Endpoint helpers (`CrudEndpoints`)

```csharp
group.MapPost("/{id:int}/restore",
    (int id, ISoftDeleteService<Customer> svc, CancellationToken ct) =>
        CrudEndpoints.Restore(() => svc.RestoreAsync(id, ct)));

group.MapDelete("/{id:int}/force",
    (int id, ISoftDeleteService<Customer> svc, CancellationToken ct) =>
        CrudEndpoints.ForceDelete(() => svc.ForceDeleteAsync(id, ct)));
```

Returns `204 No Content` on success, `404 Not Found` if the id isn't found among the appropriate set.

### Docs (`docs/site/guide/soft-delete.md`)

New guide page covering the full recovery surface with a worked example for wiring `PurgeOlderThanAsync` into `IBackgroundJobs.AddRecurringAsync` and reading the retention window from a per-entity setting (`SoftDelete.{Entity}.RetainDays`). Sidebar entry added under *Core Concepts → Database*.

## Why the background-purge job isn't shipped

The framework `SimpleModule.Database` cannot depend on the `BackgroundJobs` module (cycle). The service primitive (`PurgeOlderThanAsync`) is in the framework; the docs show the recurring-job wiring pattern for module owners.

## Test plan

- [x] Unit tests in `tests/SimpleModule.Database.Tests/SoftDeleteTests.cs` (9 new tests):
  - `WithTrashed` returns live + trashed rows
  - `OnlyTrashed` returns only trashed rows
  - `RestoreAsync` clears `IsDeleted`/`DeletedAt`/`DeletedBy`; returns 0 on miss
  - `ForceDelete` extension issues real `DELETE`
  - `ForceDeleteAsync`/`ForceDeleteRangeAsync` purge by id
  - `PurgeOlderThanAsync` deletes only stale rows; skips non-trashed; respects cutoff
- [x] Full database test suite passes (86 tests including the new 9)
- [x] Full solution build with `TreatWarningsAsErrors=true` — 0 errors, 0 warnings
- [x] CI mirror locally:
  - `npm run check` ✅ (lint + format + page registry + i18n + typecheck)
  - `npm run build` ✅
  - `dotnet build` ✅
  - `dotnet test --no-build` ✅ (~970 tests across 23 projects)
  - `npm run test:smoke -w tests/e2e` ✅ (47/47 Playwright smoke tests)
- [x] Live app smoke walk-through on `https://localhost:5001`:
  - Login, navigate Admin → Tenants → delete a row → list refreshes (interceptor still routes `Remove()` correctly through the new force-delete bypass branch)
  - `/health/live`, `/health/ready`, `/swagger`, `/admin/users`, `/admin/jobs`, `/files`, `/settings/me` all 200

## Acceptance criteria from #165

- [x] Extensions + service in `SimpleModule.Database`
- [x] `DeletedBy`/`DeletedAt` populated by interceptor (current user from `IHttpContextAccessor`) — *already in place; no behavior change*
- [x] `ForceDelete` opt-out path
- [x] xUnit tests: filter on/off, restore, force-delete, purge
- [x] `CrudEndpoints` helper for restore + force-delete
- [x] Docs page
- [ ] Background purge job + per-entity retention setting — *primitive shipped (`PurgeOlderThanAsync`); job lives in module-owner code per docs example, since the framework cannot depend on the BackgroundJobs module*

## Files

- `framework/SimpleModule.Database/SoftDelete/SoftDeleteQueryExtensions.cs` (new)
- `framework/SimpleModule.Database/SoftDelete/ForceDeleteExtensions.cs` (new)
- `framework/SimpleModule.Database/SoftDelete/ISoftDeleteService.cs` (new)
- `framework/SimpleModule.Database/SoftDelete/SoftDeleteService.cs` (new)
- `framework/SimpleModule.Database/SoftDelete/SoftDeleteServiceCollectionExtensions.cs` (new)
- `framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs` (force-delete bypass branch)
- `framework/SimpleModule.Core/Endpoints/CrudEndpoints.cs` (`Restore`, `ForceDelete` helpers)
- `tests/SimpleModule.Database.Tests/SoftDeleteTests.cs` (new, 9 tests)
- `docs/site/guide/soft-delete.md` (new)
- `docs/site/.vitepress/config.ts` (sidebar entry)