### PR TITLE
fix(users): check IdentityResult on unlock to avoid silent failure

### DIFF
--- a/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
+++ b/modules/Users/src/SimpleModule.Users/Pages/Account/UnlockAccountEndpoint.cs
@@ -76,8 +76,16 @@ public class UnlockAccountEndpoint : IViewEndpoint
 
                     user.LockoutEnd = null;
                     user.AccessFailedCount = 0;
-                    await userManager.UpdateAsync(user);
-                    await userManager.UpdateSecurityStampAsync(user);
+                    var updateResult = await userManager.UpdateAsync(user);
+                    if (!updateResult.Succeeded)
+                    {
+                        return InvalidLink();
+                    }
+                    var stampResult = await userManager.UpdateSecurityStampAsync(user);
+                    if (!stampResult.Succeeded)
+                    {
+                        return InvalidLink();
+                    }
 
                     await bus.PublishAsync(
                         new UserSelfUnlockedEvent(UserId.From(user.Id), user.Email ?? string.Empty)


### PR DESCRIPTION
## Summary
- `UnlockAccountEndpoint` now checks `IdentityResult.Succeeded` on both `UpdateAsync` (clearing `LockoutEnd` / `AccessFailedCount`) and `UpdateSecurityStampAsync`. Previously, a store failure (concurrency, persistence error) was silently swallowed: the page rendered "Account unlocked successfully" and `UserSelfUnlockedEvent` was published for an unlock that never persisted.
- On failure, the endpoint now returns the same `InvalidLink()` page used for invalid tokens, so the user can request a fresh unlock email.

## Verification
- Manually exercised the full unlock flow at https://localhost:5001 via Playwright:
  - `/Identity/Account/Lockout` renders the new "receive an unlock link by email" link
  - Form on `/Identity/Account/SendUnlockEmail` redirects to `/SendUnlockEmailConfirmation`
  - Unlock URL pulled from host log; navigating to it shows "Account unlocked"
  - DB confirmed `LockoutEnd` cleared, `AccessFailedCount=0`, `SecurityStamp` rotated
  - Reusing the same URL after success correctly shows "Invalid or expired unlock link" (security stamp invalidated the token)
- All local CI passed: lint, frontend build, .NET build, 939 .NET tests, 47 Playwright smoke tests.

## Test plan
- [ ] CI green on PR
- [ ] Reviewer spot-checks `UnlockAccountEndpoint.cs` for the `Succeeded` branches