### PR TITLE
feat(notifications): add multi-channel notifications module (closes #158)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ COPY modules/Localization/src/SimpleModule.Localization.Contracts/*.csproj modul
 COPY modules/Localization/src/SimpleModule.Localization/*.csproj modules/Localization/src/SimpleModule.Localization/
 COPY modules/Email/src/SimpleModule.Email.Contracts/*.csproj modules/Email/src/SimpleModule.Email.Contracts/
 COPY modules/Email/src/SimpleModule.Email/*.csproj modules/Email/src/SimpleModule.Email/
+COPY modules/Notifications/src/SimpleModule.Notifications.Contracts/*.csproj modules/Notifications/src/SimpleModule.Notifications.Contracts/
+COPY modules/Notifications/src/SimpleModule.Notifications/*.csproj modules/Notifications/src/SimpleModule.Notifications/
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/*.csproj modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting/*.csproj modules/RateLimiting/src/SimpleModule.RateLimiting/
 
@@ -89,6 +91,7 @@ COPY modules/Tenants/src/SimpleModule.Tenants/package.json modules/Tenants/src/S
 COPY modules/Users/src/SimpleModule.Users/package.json modules/Users/src/SimpleModule.Users/
 COPY modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/package.json modules/BackgroundJobs/src/SimpleModule.BackgroundJobs/
 COPY modules/Email/src/SimpleModule.Email/package.json modules/Email/src/SimpleModule.Email/
+COPY modules/Notifications/src/SimpleModule.Notifications/package.json modules/Notifications/src/SimpleModule.Notifications/
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting/package.json modules/RateLimiting/src/SimpleModule.RateLimiting/
 COPY packages/SimpleModule.Client/package.json packages/SimpleModule.Client/
 COPY packages/SimpleModule.Theme.Default/package.json packages/SimpleModule.Theme.Default/

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -71,6 +71,8 @@ COPY modules/Localization/src/SimpleModule.Localization.Contracts/*.csproj modul
 COPY modules/Localization/src/SimpleModule.Localization/*.csproj modules/Localization/src/SimpleModule.Localization/
 COPY modules/Email/src/SimpleModule.Email.Contracts/*.csproj modules/Email/src/SimpleModule.Email.Contracts/
 COPY modules/Email/src/SimpleModule.Email/*.csproj modules/Email/src/SimpleModule.Email/
+COPY modules/Notifications/src/SimpleModule.Notifications.Contracts/*.csproj modules/Notifications/src/SimpleModule.Notifications.Contracts/
+COPY modules/Notifications/src/SimpleModule.Notifications/*.csproj modules/Notifications/src/SimpleModule.Notifications/
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/*.csproj modules/RateLimiting/src/SimpleModule.RateLimiting.Contracts/
 COPY modules/RateLimiting/src/SimpleModule.RateLimiting/*.csproj modules/RateLimiting/src/SimpleModule.RateLimiting/
 

--- a/SimpleModule.slnx
+++ b/SimpleModule.slnx
@@ -92,6 +92,11 @@
     <Project Path="modules/Email/src/SimpleModule.Email/SimpleModule.Email.csproj" />
     <Project Path="modules/Email/tests/SimpleModule.Email.Tests/SimpleModule.Email.Tests.csproj" />
   </Folder>
+  <Folder Name="/modules/Notifications/">
+    <Project Path="modules/Notifications/src/SimpleModule.Notifications.Contracts/SimpleModule.Notifications.Contracts.csproj" />
+    <Project Path="modules/Notifications/src/SimpleModule.Notifications/SimpleModule.Notifications.csproj" />
+    <Project Path="modules/Notifications/tests/SimpleModule.Notifications.Tests/SimpleModule.Notifications.Tests.csproj" />
+  </Folder>
   <Folder Name="/template/">
     <Project Path="template/SimpleModule.Host/SimpleModule.Host.csproj" />
     <Project Path="template/SimpleModule.Worker/SimpleModule.Worker.csproj" />

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/DatabaseNotificationPayload.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/DatabaseNotificationPayload.cs
@@ -1,0 +1,20 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[NoDtoGeneration]
+public sealed class DatabaseNotificationPayload
+{
+    public DatabaseNotificationPayload() { }
+
+    public DatabaseNotificationPayload(string? title, string? body, object? data = null)
+    {
+        Title = title;
+        Body = body;
+        Data = data;
+    }
+
+    public string? Title { get; set; }
+    public string? Body { get; set; }
+    public object? Data { get; set; }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/Events/NotificationFailedEvent.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/Events/NotificationFailedEvent.cs
@@ -1,0 +1,11 @@
+using SimpleModule.Core.Events;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Contracts.Events;
+
+public sealed record NotificationFailedEvent(
+    UserId UserId,
+    string NotificationType,
+    string Channel,
+    string Error
+) : DomainEvent;

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/Events/NotificationSentEvent.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/Events/NotificationSentEvent.cs
@@ -1,0 +1,10 @@
+using SimpleModule.Core.Events;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Contracts.Events;
+
+public sealed record NotificationSentEvent(
+    UserId UserId,
+    string NotificationType,
+    string Channel
+) : DomainEvent;

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotification.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotification.cs
@@ -1,0 +1,19 @@
+namespace SimpleModule.Notifications.Contracts;
+
+/// <summary>
+/// A notification that can be dispatched to one or more channels for a given recipient.
+/// Implement <see cref="Via"/> to declare which channel names should attempt delivery
+/// and override the per-channel <c>To*</c> methods to supply the channel-specific payload.
+/// </summary>
+public interface INotification
+{
+    /// <summary>Stable identifier for this notification type (e.g. <c>"orders.shipped"</c>).</summary>
+    string NotificationType { get; }
+
+    /// <summary>Channel names to deliver this notification on (see <see cref="NotificationsConstants.Channels"/>).</summary>
+    string[] Via(NotificationRecipient recipient);
+
+    MailMessage? ToMail(NotificationRecipient recipient) => null;
+    DatabaseNotificationPayload? ToDatabase(NotificationRecipient recipient) => null;
+    SmsMessage? ToSms(NotificationRecipient recipient) => null;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotificationsContracts.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotificationsContracts.cs
@@ -1,0 +1,13 @@
+using SimpleModule.Core;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Contracts;
+
+public interface INotificationsContracts
+{
+    Task<PagedResult<Notification>> ListAsync(UserId userId, QueryNotificationsRequest request);
+    Task<int> GetUnreadCountAsync(UserId userId, CancellationToken cancellationToken = default);
+    Task<Notification?> GetByIdAsync(NotificationId id, UserId userId);
+    Task<bool> MarkReadAsync(NotificationId id, UserId userId);
+    Task<int> MarkAllReadAsync(UserId userId);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotifier.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/INotifier.cs
@@ -1,0 +1,24 @@
+namespace SimpleModule.Notifications.Contracts;
+
+/// <summary>
+/// High-level send API. <see cref="SendAsync"/> queues delivery through the background
+/// jobs system so the caller does not block on slow channels. <see cref="SendNowAsync"/>
+/// dispatches synchronously and is intended for tests and tightly-coupled flows where
+/// the caller wants to surface errors immediately.
+/// </summary>
+public interface INotifier
+{
+    Task SendAsync<T>(
+        NotificationRecipient recipient,
+        T notification,
+        CancellationToken cancellationToken = default
+    )
+        where T : INotification;
+
+    Task SendNowAsync<T>(
+        NotificationRecipient recipient,
+        T notification,
+        CancellationToken cancellationToken = default
+    )
+        where T : INotification;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/MailMessage.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/MailMessage.cs
@@ -1,0 +1,20 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[NoDtoGeneration]
+public sealed class MailMessage
+{
+    public MailMessage() { }
+
+    public MailMessage(string subject, string body, bool isHtml = false)
+    {
+        Subject = subject;
+        Body = body;
+        IsHtml = isHtml;
+    }
+
+    public string Subject { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public bool IsHtml { get; set; }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/Notification.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/Notification.cs
@@ -1,0 +1,21 @@
+using SimpleModule.Core;
+using SimpleModule.Core.Entities;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[Dto]
+public class Notification : Entity<NotificationId>
+{
+    public UserId UserId { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public string? Body { get; set; }
+
+    // JSON payload — arbitrary, channel-specific or in-app data
+    public string DataJson { get; set; } = "{}";
+
+    public DateTimeOffset? ReadAt { get; set; }
+    public bool IsRead => ReadAt.HasValue;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationId.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[ValueObject<Guid>(conversions: Conversions.SystemTextJson | Conversions.EfCoreValueConverter)]
+public readonly partial struct NotificationId;

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationRecipient.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationRecipient.cs
@@ -1,0 +1,27 @@
+using SimpleModule.Core;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Contracts;
+
+/// <summary>
+/// Identifies a recipient of a notification and supplies the per-channel addresses
+/// the channel implementations need. A recipient is keyed by <see cref="UserId"/> so
+/// the database channel can persist notifications, while the optional addresses let
+/// the mail/sms channels deliver out-of-band.
+/// </summary>
+[NoDtoGeneration]
+public sealed class NotificationRecipient
+{
+    public NotificationRecipient() { }
+
+    public NotificationRecipient(UserId userId, string? email = null, string? phoneNumber = null)
+    {
+        UserId = userId;
+        Email = email;
+        PhoneNumber = phoneNumber;
+    }
+
+    public UserId UserId { get; set; }
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationsConstants.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/NotificationsConstants.cs
@@ -1,0 +1,36 @@
+namespace SimpleModule.Notifications.Contracts;
+
+public static class NotificationsConstants
+{
+    public const string ModuleName = "Notifications";
+    public const string RoutePrefix = "/api/notifications";
+    public const string ViewPrefix = "/notifications";
+
+    public static class Channels
+    {
+        public const string Mail = "mail";
+        public const string Database = "database";
+        public const string Sms = "sms";
+    }
+
+    public static class Routes
+    {
+        // API endpoints
+        public const string List = "/";
+        public const string UnreadCount = "/unread-count";
+        public const string MarkRead = "/{id}/read";
+        public const string MarkAllRead = "/read-all";
+        public const string Send = "/send";
+
+        // View endpoints
+        public const string Inbox = "/";
+    }
+
+    public static class SettingsKeys
+    {
+        public const string MailChannelEnabled = "notifications.channel.mail.enabled";
+        public const string DatabaseChannelEnabled = "notifications.channel.database.enabled";
+        public const string SmsChannelEnabled = "notifications.channel.sms.enabled";
+        public const string DefaultPageSize = "notifications.defaultPageSize";
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/QueryNotificationsRequest.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/QueryNotificationsRequest.cs
@@ -1,0 +1,16 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[Dto]
+public class QueryNotificationsRequest
+{
+    public int? Page { get; set; }
+    public int? PageSize { get; set; }
+    public bool? UnreadOnly { get; set; }
+    public string? Channel { get; set; }
+    public string? Type { get; set; }
+
+    public int EffectivePage => Page is > 0 ? Page.Value : 1;
+    public int EffectivePageSize => PageSize is > 0 and <= 100 ? PageSize.Value : 20;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/SimpleModule.Notifications.Contracts.csproj
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/SimpleModule.Notifications.Contracts.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <DefineConstants>$(DefineConstants);VOGEN_NO_VALIDATION</DefineConstants>
+    <Description>Notifications module contracts for SimpleModule. Multi-channel notification dispatch (mail, database, SMS, etc.).</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Vogen" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Users\src\SimpleModule.Users.Contracts\SimpleModule.Users.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/modules/Notifications/src/SimpleModule.Notifications.Contracts/SmsMessage.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications.Contracts/SmsMessage.cs
@@ -1,0 +1,16 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Notifications.Contracts;
+
+[NoDtoGeneration]
+public sealed class SmsMessage
+{
+    public SmsMessage() { }
+
+    public SmsMessage(string body)
+    {
+        Body = body;
+    }
+
+    public string Body { get; set; } = string.Empty;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Channels/DatabaseChannel.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Channels/DatabaseChannel.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Contracts.Events;
+using Wolverine.EntityFrameworkCore;
+
+namespace SimpleModule.Notifications.Channels;
+
+public partial class DatabaseChannel(
+    NotificationsDbContext db,
+    IDbContextOutbox<NotificationsDbContext> outbox,
+    ILogger<DatabaseChannel> logger
+) : INotificationChannel
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public string Name => NotificationsConstants.Channels.Database;
+
+    public async Task SendAsync(
+        NotificationRecipient recipient,
+        INotification notification,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var payload = notification.ToDatabase(recipient);
+        if (payload is null)
+        {
+            return;
+        }
+
+        var entity = new Notification
+        {
+            Id = NotificationId.From(Guid.CreateVersion7()),
+            UserId = recipient.UserId,
+            Type = notification.NotificationType,
+            Channel = Name,
+            Title = payload.Title,
+            Body = payload.Body,
+            DataJson = payload.Data is null
+                ? "{}"
+                : JsonSerializer.Serialize(payload.Data, JsonOptions),
+        };
+
+        db.Notifications.Add(entity);
+
+        await outbox.PublishAsync(
+            new NotificationSentEvent(recipient.UserId, notification.NotificationType, Name)
+        );
+        await outbox.SaveChangesAndFlushMessagesAsync(cancellationToken);
+
+        LogPersisted(logger, entity.Id, recipient.UserId.Value, notification.NotificationType);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Persisted notification {NotificationId} for user {UserId} type {Type}"
+    )]
+    private static partial void LogPersisted(
+        ILogger logger,
+        NotificationId notificationId,
+        string userId,
+        string type
+    );
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Channels/INotificationChannel.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Channels/INotificationChannel.cs
@@ -1,0 +1,27 @@
+using SimpleModule.Notifications.Contracts;
+
+namespace SimpleModule.Notifications.Channels;
+
+/// <summary>
+/// A delivery channel — mail, database, sms, slack, push, etc. Each channel
+/// implementation is registered in DI by name and the notifier dispatches to it
+/// based on what <see cref="INotification.Via"/> returns.
+/// </summary>
+/// <remarks>
+/// Lives in the implementation assembly (not <c>SimpleModule.Notifications.Contracts</c>)
+/// because each channel is a per-module-internal extension point with many implementations,
+/// which the source generator's contract rules forbid in a Contracts assembly. Optional
+/// out-of-tree channels (Slack, push, custom SMS providers) reference this assembly
+/// directly the same way Email providers reference <c>SimpleModule.Email</c>.
+/// </remarks>
+public interface INotificationChannel
+{
+    /// <summary>Channel identifier matching the names returned from <see cref="INotification.Via"/>.</summary>
+    string Name { get; }
+
+    Task SendAsync(
+        NotificationRecipient recipient,
+        INotification notification,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Channels/INotificationChannelRegistry.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Channels/INotificationChannelRegistry.cs
@@ -1,0 +1,24 @@
+using SimpleModule.Notifications.Contracts;
+
+namespace SimpleModule.Notifications.Channels;
+
+public interface INotificationChannelRegistry
+{
+    INotificationChannel? Find(string name);
+    IReadOnlyCollection<string> RegisteredNames { get; }
+}
+
+public sealed class NotificationChannelRegistry : INotificationChannelRegistry
+{
+    private readonly Dictionary<string, INotificationChannel> _channels;
+
+    public NotificationChannelRegistry(IEnumerable<INotificationChannel> channels)
+    {
+        _channels = channels.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public INotificationChannel? Find(string name) =>
+        _channels.TryGetValue(name, out var channel) ? channel : null;
+
+    public IReadOnlyCollection<string> RegisteredNames => _channels.Keys;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Channels/LogSmsChannel.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Channels/LogSmsChannel.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+using SimpleModule.Notifications.Contracts;
+
+namespace SimpleModule.Notifications.Channels;
+
+/// <summary>
+/// Default SMS channel: writes the message to the log. A real provider (Twilio, etc.)
+/// can be plugged in by replacing this registration with another <see cref="INotificationChannel"/>
+/// implementation whose <see cref="Name"/> returns <c>"sms"</c>.
+/// </summary>
+public partial class LogSmsChannel(ILogger<LogSmsChannel> logger) : INotificationChannel
+{
+    public string Name => NotificationsConstants.Channels.Sms;
+
+    public Task SendAsync(
+        NotificationRecipient recipient,
+        INotification notification,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var sms = notification.ToSms(recipient);
+        if (sms is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (string.IsNullOrWhiteSpace(recipient.PhoneNumber))
+        {
+            LogMissingPhone(logger, recipient.UserId.Value, notification.NotificationType);
+            return Task.CompletedTask;
+        }
+
+        LogSms(logger, recipient.PhoneNumber, notification.NotificationType, sms.Body);
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "[SMS] to={Phone} type={Type} body={Body}"
+    )]
+    private static partial void LogSms(ILogger logger, string phone, string type, string body);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Skipping SMS notification for user {UserId} type {Type}: recipient has no phone number"
+    )]
+    private static partial void LogMissingPhone(ILogger logger, string userId, string type);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Channels/MailChannel.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Channels/MailChannel.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using SimpleModule.Email.Contracts;
+using SimpleModule.Notifications.Contracts;
+
+namespace SimpleModule.Notifications.Channels;
+
+/// <summary>
+/// Forwards a notification's mail payload to the Email module. Skips silently when the
+/// recipient has no email address — channel selection happens upstream in the notifier,
+/// but we still defend here so mis-configured callers don't fault.
+/// </summary>
+public partial class MailChannel(IEmailContracts email, ILogger<MailChannel> logger)
+    : INotificationChannel
+{
+    public string Name => NotificationsConstants.Channels.Mail;
+
+    public async Task SendAsync(
+        NotificationRecipient recipient,
+        INotification notification,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var mail = notification.ToMail(recipient);
+        if (mail is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(recipient.Email))
+        {
+            LogMissingEmail(logger, recipient.UserId.Value, notification.NotificationType);
+            return;
+        }
+
+        await email.SendEmailAsync(
+            new SendEmailRequest
+            {
+                To = recipient.Email,
+                Subject = mail.Subject,
+                Body = mail.Body,
+                IsHtml = mail.IsHtml,
+            }
+        );
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Skipping mail notification for user {UserId} type {Type}: recipient has no email address"
+    )]
+    private static partial void LogMissingEmail(ILogger logger, string userId, string type);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/ListNotificationsEndpoint.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/ListNotificationsEndpoint.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Extensions;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Endpoints.Notifications;
+
+public class ListNotificationsEndpoint : IEndpoint
+{
+    public const string Route = NotificationsConstants.Routes.List;
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(
+                Route,
+                (
+                    [AsParameters] QueryNotificationsRequest request,
+                    HttpContext context,
+                    INotificationsContracts notifications
+                ) =>
+                    notifications.ListAsync(UserId.From(context.User.GetUserId()!), request)
+            )
+            .RequirePermission(NotificationsPermissions.ViewOwn);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/MarkAllReadEndpoint.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/MarkAllReadEndpoint.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Extensions;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Endpoints.Notifications;
+
+public class MarkAllReadEndpoint : IEndpoint
+{
+    public const string Route = NotificationsConstants.Routes.MarkAllRead;
+    public const string Method = "POST";
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPost(
+                Route,
+                async (HttpContext context, INotificationsContracts notifications) =>
+                {
+                    var marked = await notifications.MarkAllReadAsync(
+                        UserId.From(context.User.GetUserId()!)
+                    );
+                    return new { marked };
+                }
+            )
+            .RequirePermission(NotificationsPermissions.ViewOwn);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/MarkReadEndpoint.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/MarkReadEndpoint.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Extensions;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Endpoints.Notifications;
+
+public class MarkReadEndpoint : IEndpoint
+{
+    public const string Route = NotificationsConstants.Routes.MarkRead;
+    public const string Method = "POST";
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPost(
+                Route,
+                async Task<IResult> (
+                    Guid id,
+                    HttpContext context,
+                    INotificationsContracts notifications
+                ) =>
+                {
+                    var ok = await notifications.MarkReadAsync(
+                        NotificationId.From(id),
+                        UserId.From(context.User.GetUserId()!)
+                    );
+                    return ok ? TypedResults.NoContent() : TypedResults.NotFound();
+                }
+            )
+            .RequirePermission(NotificationsPermissions.ViewOwn);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/UnreadCountEndpoint.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Endpoints/Notifications/UnreadCountEndpoint.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Extensions;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Endpoints.Notifications;
+
+public class UnreadCountEndpoint : IEndpoint
+{
+    public const string Route = NotificationsConstants.Routes.UnreadCount;
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(
+                Route,
+                async (
+                    HttpContext context,
+                    INotificationsContracts notifications,
+                    CancellationToken ct
+                ) =>
+                {
+                    var count = await notifications.GetUnreadCountAsync(
+                        UserId.From(context.User.GetUserId()!),
+                        ct
+                    );
+                    return new { count };
+                }
+            )
+            .RequirePermission(NotificationsPermissions.ViewOwn);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/EntityConfigurations/NotificationConfiguration.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/EntityConfigurations/NotificationConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SimpleModule.Notifications.Contracts;
+
+namespace SimpleModule.Notifications.EntityConfigurations;
+
+public class NotificationConfiguration : IEntityTypeConfiguration<Notification>
+{
+    public void Configure(EntityTypeBuilder<Notification> builder)
+    {
+        builder.HasKey(n => n.Id);
+        builder.Property(n => n.UserId).IsRequired().HasMaxLength(450);
+        builder.Property(n => n.Type).IsRequired().HasMaxLength(200);
+        builder.Property(n => n.Channel).IsRequired().HasMaxLength(50);
+        builder.Property(n => n.Title).HasMaxLength(500);
+        builder.Property(n => n.Body).HasMaxLength(4000);
+        builder.Property(n => n.DataJson).IsRequired();
+        builder.Property(n => n.ConcurrencyStamp).HasMaxLength(64);
+        builder.Ignore(n => n.IsRead);
+
+        // Covers the inbox list query (filter UserId + order CreatedAt DESC, Id as tiebreaker)
+        // and the unread-count query (predicate on UserId + ReadAt).
+        builder.HasIndex(n => new { n.UserId, n.CreatedAt, n.Id });
+        builder.HasIndex(n => new { n.UserId, n.ReadAt });
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Jobs/DispatchNotificationJob.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Jobs/DispatchNotificationJob.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SimpleModule.BackgroundJobs.Contracts;
+using SimpleModule.Notifications.Channels;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Contracts.Events;
+using SimpleModule.Notifications.Services;
+using SimpleModule.Users.Contracts;
+using Wolverine;
+
+namespace SimpleModule.Notifications.Jobs;
+
+public sealed record DispatchNotificationJobData(
+    string UserId,
+    string? Email,
+    string? PhoneNumber,
+    string ChannelName,
+    string NotificationTypeName,
+    string NotificationJson
+);
+
+public class DispatchNotificationJob(
+    INotificationChannelRegistry channels,
+    IMessageBus bus,
+    ILogger<DispatchNotificationJob> logger
+) : IModuleJob
+{
+    public async Task ExecuteAsync(
+        IJobExecutionContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var jobData = context.GetData<DispatchNotificationJobData>();
+
+        var channel = channels.Find(jobData.ChannelName);
+        if (channel is null)
+        {
+            context.Log($"Unknown channel '{jobData.ChannelName}'; dropping notification.");
+            return;
+        }
+
+        var notificationType = Type.GetType(jobData.NotificationTypeName);
+        if (notificationType is null)
+        {
+            context.Log(
+                $"Unable to resolve notification type {jobData.NotificationTypeName}; dropping."
+            );
+            return;
+        }
+
+        if (
+            JsonSerializer.Deserialize(jobData.NotificationJson, notificationType)
+            is not INotification notification
+        )
+        {
+            context.Log($"Failed to deserialize notification of type {notificationType.Name}.");
+            return;
+        }
+
+        var recipient = new NotificationRecipient(
+            UserId.From(jobData.UserId),
+            jobData.Email,
+            jobData.PhoneNumber
+        );
+
+        try
+        {
+            await channel.SendAsync(recipient, notification, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            NotificationsLog.ChannelFailure(
+                logger,
+                jobData.ChannelName,
+                notification.NotificationType,
+                jobData.UserId,
+                ex
+            );
+
+            await bus.PublishAsync(
+                new NotificationFailedEvent(
+                    recipient.UserId,
+                    notification.NotificationType,
+                    jobData.ChannelName,
+                    ex.Message
+                )
+            );
+            throw;
+        }
+
+        context.ReportProgress(100);
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/NotificationsDbContext.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/NotificationsDbContext.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.Extensions.Options;
+using SimpleModule.Database;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.EntityConfigurations;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications;
+
+public class NotificationsDbContext(
+    DbContextOptions<NotificationsDbContext> options,
+    IOptions<DatabaseOptions> dbOptions
+) : DbContext(options)
+{
+    public DbSet<Notification> Notifications => Set<Notification>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new NotificationConfiguration());
+        modelBuilder.ApplyModuleSchema("Notifications", dbOptions.Value);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<NotificationId>()
+            .HaveConversion<
+                NotificationId.EfCoreValueConverter,
+                NotificationId.EfCoreValueComparer
+            >();
+        configurationBuilder
+            .Properties<UserId>()
+            .HaveConversion<UserId.EfCoreValueConverter, UserId.EfCoreValueComparer>();
+
+        if (dbOptions.Value.DetectProvider("Notifications") == DatabaseProvider.Sqlite)
+        {
+            configurationBuilder
+                .Properties<DateTimeOffset>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+            configurationBuilder
+                .Properties<DateTimeOffset?>()
+                .HaveConversion<DateTimeOffsetToBinaryConverter>();
+        }
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/NotificationsModule.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/NotificationsModule.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleModule.BackgroundJobs.Contracts;
+using SimpleModule.Core;
+using SimpleModule.Core.Settings;
+using SimpleModule.Database;
+using SimpleModule.Notifications.Channels;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Jobs;
+using SimpleModule.Notifications.Services;
+
+namespace SimpleModule.Notifications;
+
+[Module(
+    NotificationsConstants.ModuleName,
+    RoutePrefix = NotificationsConstants.RoutePrefix,
+    ViewPrefix = NotificationsConstants.ViewPrefix
+)]
+public class NotificationsModule : IModule, IModuleServices
+{
+    public void ConfigureMiddleware(IApplicationBuilder app)
+    {
+        // DispatchNotificationJob and the Notifier rely on IBackgroundJobs (whose
+        // implementation lives in the BackgroundJobs module, not its Contracts assembly).
+        // Fail fast with a directive message if the implementation isn't installed.
+        var probe = app.ApplicationServices.GetRequiredService<IServiceProviderIsService>();
+        if (!probe.IsService(typeof(IBackgroundJobs)))
+        {
+            throw new InvalidOperationException(
+                "SimpleModule.Notifications requires SimpleModule.BackgroundJobs to be installed. "
+                    + "Add a reference to the SimpleModule.BackgroundJobs project so IBackgroundJobs can be resolved."
+            );
+        }
+    }
+
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddModuleDbContext<NotificationsDbContext>(
+            configuration,
+            NotificationsConstants.ModuleName
+        );
+        services.Configure<NotificationsModuleOptions>(configuration.GetSection("Notifications"));
+
+        services.AddScoped<INotificationsContracts, NotificationService>();
+        services.AddScoped<INotifier, Notifier>();
+
+        // Channels — registered as INotificationChannel so the registry can enumerate them.
+        services.AddScoped<INotificationChannel, DatabaseChannel>();
+        services.AddScoped<INotificationChannel, MailChannel>();
+        services.AddScoped<INotificationChannel, LogSmsChannel>();
+        services.AddScoped<INotificationChannelRegistry, NotificationChannelRegistry>();
+
+        services.AddModuleJob<DispatchNotificationJob>();
+    }
+
+    public void ConfigureSettings(ISettingsBuilder settings)
+    {
+        settings
+            .Add(
+                new SettingDefinition
+                {
+                    Key = NotificationsConstants.SettingsKeys.MailChannelEnabled,
+                    DisplayName = "Mail notifications",
+                    Description = "Receive notifications by email.",
+                    Group = "Notifications",
+                    Scope = SettingScope.User,
+                    DefaultValue = "true",
+                    Type = SettingType.Bool,
+                }
+            )
+            .Add(
+                new SettingDefinition
+                {
+                    Key = NotificationsConstants.SettingsKeys.DatabaseChannelEnabled,
+                    DisplayName = "In-app notifications",
+                    Description = "Show notifications in the in-app inbox.",
+                    Group = "Notifications",
+                    Scope = SettingScope.User,
+                    DefaultValue = "true",
+                    Type = SettingType.Bool,
+                }
+            )
+            .Add(
+                new SettingDefinition
+                {
+                    Key = NotificationsConstants.SettingsKeys.SmsChannelEnabled,
+                    DisplayName = "SMS notifications",
+                    Description = "Receive notifications by SMS (when a phone number is on file).",
+                    Group = "Notifications",
+                    Scope = SettingScope.User,
+                    DefaultValue = "false",
+                    Type = SettingType.Bool,
+                }
+            )
+            .Add(
+                new SettingDefinition
+                {
+                    Key = NotificationsConstants.SettingsKeys.DefaultPageSize,
+                    DisplayName = "Inbox page size",
+                    Description = "Notifications to load per page in the inbox.",
+                    Group = "Notifications",
+                    Scope = SettingScope.Application,
+                    DefaultValue = "20",
+                    Type = SettingType.Number,
+                }
+            );
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/NotificationsModuleOptions.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/NotificationsModuleOptions.cs
@@ -1,0 +1,11 @@
+using SimpleModule.Core;
+
+namespace SimpleModule.Notifications;
+
+public class NotificationsModuleOptions : IModuleOptions
+{
+    public bool MailChannelEnabled { get; set; } = true;
+    public bool DatabaseChannelEnabled { get; set; } = true;
+    public bool SmsChannelEnabled { get; set; }
+    public int DefaultPageSize { get; set; } = 20;
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/NotificationsPermissions.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/NotificationsPermissions.cs
@@ -1,0 +1,9 @@
+using SimpleModule.Core.Authorization;
+
+namespace SimpleModule.Notifications;
+
+public sealed class NotificationsPermissions : IModulePermissions
+{
+    public const string ViewOwn = "Notifications.ViewOwn";
+    public const string SendToOthers = "Notifications.SendToOthers";
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Pages/Inbox.tsx
+++ b/modules/Notifications/src/SimpleModule.Notifications/Pages/Inbox.tsx
@@ -1,0 +1,81 @@
+import { router } from '@inertiajs/react';
+import { Badge, Button, Card, CardContent, PageShell } from '@simplemodule/ui';
+import type { Notification } from '../types';
+
+interface Props {
+  items: Notification[];
+  totalCount: number;
+  unreadCount: number;
+}
+
+function formatDate(value: string): string {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+export default function Inbox({ items, totalCount, unreadCount }: Props) {
+  const markRead = (id: string) => {
+    router.post(
+      `/api/notifications/${id}/read`,
+      {},
+      { preserveScroll: true, onSuccess: () => router.reload({ only: ['items', 'unreadCount'] }) },
+    );
+  };
+
+  const markAllRead = () => {
+    router.post(
+      '/api/notifications/read-all',
+      {},
+      { preserveScroll: true, onSuccess: () => router.reload({ only: ['items', 'unreadCount'] }) },
+    );
+  };
+
+  return (
+    <PageShell
+      className="space-y-4 sm:space-y-6"
+      title="Notifications"
+      description={`${totalCount} total · ${unreadCount} unread`}
+    >
+      <div className="flex justify-end">
+        <Button onClick={markAllRead} disabled={unreadCount === 0} variant="secondary">
+          Mark all read
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <Card>
+          <CardContent className="p-6 text-center text-text-muted">
+            You're all caught up.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {items.map((n) => (
+            <Card key={n.id}>
+              <CardContent className="flex items-start justify-between gap-4 p-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    {!n.readAt && <Badge variant="default">New</Badge>}
+                    <Badge variant="outline">{n.channel}</Badge>
+                    <span className="text-xs text-text-muted">{n.type}</span>
+                  </div>
+                  {n.title && <p className="mt-1 font-medium">{n.title}</p>}
+                  {n.body && <p className="mt-1 text-sm text-text-muted">{n.body}</p>}
+                  <p className="mt-1 text-xs text-text-muted">{formatDate(n.createdAt)}</p>
+                </div>
+                {!n.readAt && (
+                  <Button onClick={() => markRead(n.id)} variant="ghost" size="sm">
+                    Mark read
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Pages/Inbox.tsx
+++ b/modules/Notifications/src/SimpleModule.Notifications/Pages/Inbox.tsx
@@ -58,8 +58,8 @@ export default function Inbox({ items, totalCount, unreadCount }: Props) {
               <CardContent className="flex items-start justify-between gap-4 p-4">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    {!n.readAt && <Badge variant="default">New</Badge>}
-                    <Badge variant="outline">{n.channel}</Badge>
+                    {!n.readAt && <Badge variant="info">New</Badge>}
+                    <Badge variant="default">{n.channel}</Badge>
                     <span className="text-xs text-text-muted">{n.type}</span>
                   </div>
                   {n.title && <p className="mt-1 font-medium">{n.title}</p>}

--- a/modules/Notifications/src/SimpleModule.Notifications/Pages/InboxEndpoint.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Pages/InboxEndpoint.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using SimpleModule.Core;
+using SimpleModule.Core.Authorization;
+using SimpleModule.Core.Extensions;
+using SimpleModule.Core.Inertia;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Pages;
+
+public class InboxEndpoint : IViewEndpoint
+{
+    public const string Route = NotificationsConstants.Routes.Inbox;
+
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapGet(
+                Route,
+                async (
+                    HttpContext context,
+                    INotificationsContracts notifications,
+                    bool? unreadOnly
+                ) =>
+                {
+                    var userId = UserId.From(context.User.GetUserId()!);
+                    var page = await notifications.ListAsync(
+                        userId,
+                        new QueryNotificationsRequest { UnreadOnly = unreadOnly }
+                    );
+                    var unreadCount = await notifications.GetUnreadCountAsync(userId);
+
+                    return Inertia.Render(
+                        "Notifications/Inbox",
+                        new
+                        {
+                            items = page.Items,
+                            totalCount = page.TotalCount,
+                            unreadCount,
+                        }
+                    );
+                }
+            )
+            .RequirePermission(NotificationsPermissions.ViewOwn);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Pages/index.ts
+++ b/modules/Notifications/src/SimpleModule.Notifications/Pages/index.ts
@@ -1,0 +1,3 @@
+export const pages: Record<string, unknown> = {
+  'Notifications/Inbox': () => import('./Inbox'),
+};

--- a/modules/Notifications/src/SimpleModule.Notifications/Services/NotificationService.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Services/NotificationService.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using SimpleModule.Core;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Services;
+
+public class NotificationService(NotificationsDbContext db) : INotificationsContracts
+{
+    public async Task<PagedResult<Notification>> ListAsync(
+        UserId userId,
+        QueryNotificationsRequest request
+    )
+    {
+        var query = db.Notifications.AsNoTracking().Where(n => n.UserId == userId);
+
+        if (request.UnreadOnly == true)
+        {
+            query = query.Where(n => n.ReadAt == null);
+        }
+        if (!string.IsNullOrWhiteSpace(request.Channel))
+        {
+            query = query.Where(n => n.Channel == request.Channel);
+        }
+        if (!string.IsNullOrWhiteSpace(request.Type))
+        {
+            query = query.Where(n => n.Type == request.Type);
+        }
+
+        var totalCount = await query.CountAsync();
+        var page = request.EffectivePage;
+        var pageSize = request.EffectivePageSize;
+
+        var items = await query
+            .OrderByDescending(n => n.CreatedAt)
+            .ThenByDescending(n => n.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return new PagedResult<Notification>
+        {
+            Items = items,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize,
+        };
+    }
+
+    public Task<int> GetUnreadCountAsync(
+        UserId userId,
+        CancellationToken cancellationToken = default
+    ) =>
+        db.Notifications.CountAsync(
+            n => n.UserId == userId && n.ReadAt == null,
+            cancellationToken
+        );
+
+    public async Task<Notification?> GetByIdAsync(NotificationId id, UserId userId) =>
+        await db.Notifications.AsNoTracking().FirstOrDefaultAsync(n =>
+            n.Id == id && n.UserId == userId
+        );
+
+    public async Task<bool> MarkReadAsync(NotificationId id, UserId userId)
+    {
+        var notification = await db.Notifications.FirstOrDefaultAsync(n =>
+            n.Id == id && n.UserId == userId
+        );
+        if (notification is null)
+        {
+            return false;
+        }
+
+        if (notification.ReadAt is not null)
+        {
+            return true;
+        }
+
+        notification.ReadAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<int> MarkAllReadAsync(UserId userId)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return await db
+            .Notifications.Where(n => n.UserId == userId && n.ReadAt == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReadAt, now));
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Services/NotificationsLog.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Services/NotificationsLog.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+
+namespace SimpleModule.Notifications.Services;
+
+internal static partial class NotificationsLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Notification channel {Channel} failed for type {Type} user {UserId}"
+    )]
+    public static partial void ChannelFailure(
+        ILogger logger,
+        string channel,
+        string type,
+        string userId,
+        Exception exception
+    );
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Unknown notification channel '{Channel}' requested for type {Type}; skipping"
+    )]
+    public static partial void UnknownChannel(ILogger logger, string channel, string type);
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/Services/Notifier.cs
+++ b/modules/Notifications/src/SimpleModule.Notifications/Services/Notifier.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Logging;
+using SimpleModule.BackgroundJobs.Contracts;
+using SimpleModule.Notifications.Channels;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Contracts.Events;
+using SimpleModule.Notifications.Jobs;
+using Wolverine;
+
+namespace SimpleModule.Notifications.Services;
+
+public class Notifier(
+    INotificationChannelRegistry channels,
+    IBackgroundJobs backgroundJobs,
+    IMessageBus bus,
+    ILogger<Notifier> logger
+) : INotifier
+{
+    public async Task SendAsync<T>(
+        NotificationRecipient recipient,
+        T notification,
+        CancellationToken cancellationToken = default
+    )
+        where T : INotification
+    {
+        // One job per channel so a slow/failing channel cannot block siblings and so retries are per-channel.
+        var channelNames = notification.Via(recipient);
+        var notificationJson = System.Text.Json.JsonSerializer.Serialize(
+            notification,
+            notification.GetType()
+        );
+        var typeName = typeof(T).AssemblyQualifiedName!;
+
+        foreach (var channelName in channelNames)
+        {
+            await backgroundJobs.EnqueueAsync<DispatchNotificationJob>(
+                new DispatchNotificationJobData(
+                    recipient.UserId.Value,
+                    recipient.Email,
+                    recipient.PhoneNumber,
+                    channelName,
+                    typeName,
+                    notificationJson
+                ),
+                cancellationToken
+            );
+        }
+    }
+
+    public async Task SendNowAsync<T>(
+        NotificationRecipient recipient,
+        T notification,
+        CancellationToken cancellationToken = default
+    )
+        where T : INotification
+    {
+        var channelNames = notification.Via(recipient);
+
+        foreach (var channelName in channelNames)
+        {
+            var channel = channels.Find(channelName);
+            if (channel is null)
+            {
+                NotificationsLog.UnknownChannel(logger, channelName, notification.NotificationType);
+                continue;
+            }
+
+            try
+            {
+                await channel.SendAsync(recipient, notification, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                NotificationsLog.ChannelFailure(
+                    logger,
+                    channelName,
+                    notification.NotificationType,
+                    recipient.UserId.Value,
+                    ex
+                );
+                await bus.PublishAsync(
+                    new NotificationFailedEvent(
+                        recipient.UserId,
+                        notification.NotificationType,
+                        channelName,
+                        ex.Message
+                    )
+                );
+            }
+        }
+    }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/SimpleModule.Notifications.csproj
+++ b/modules/Notifications/src/SimpleModule.Notifications/SimpleModule.Notifications.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.StaticWebAssets">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Notifications module for SimpleModule. Multi-channel dispatch (mail, database, SMS) with in-app bell-icon UI.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Core\SimpleModule.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\framework\SimpleModule.Database\SimpleModule.Database.csproj" />
+    <ProjectReference Include="..\SimpleModule.Notifications.Contracts\SimpleModule.Notifications.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Users\src\SimpleModule.Users.Contracts\SimpleModule.Users.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\BackgroundJobs\src\SimpleModule.BackgroundJobs.Contracts\SimpleModule.BackgroundJobs.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Email\src\SimpleModule.Email.Contracts\SimpleModule.Email.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Settings\src\SimpleModule.Settings.Contracts\SimpleModule.Settings.Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Views\*.tsx">
+      <DependentUpon>%(Filename)Endpoint.cs</DependentUpon>
+    </None>
+  </ItemGroup>
+</Project>

--- a/modules/Notifications/src/SimpleModule.Notifications/package.json
+++ b/modules/Notifications/src/SimpleModule.Notifications/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "@simplemodule/notifications",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "cross-env VITE_MODE=prod vite build --configLoader runner",
+    "build:dev": "cross-env VITE_MODE=dev vite build --configLoader runner",
+    "watch": "cross-env VITE_MODE=dev vite build --configLoader runner --watch"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/tsconfig.json
+++ b/modules/Notifications/src/SimpleModule.Notifications/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@simplemodule/tsconfig/base",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/modules/Notifications/src/SimpleModule.Notifications/types.ts
+++ b/modules/Notifications/src/SimpleModule.Notifications/types.ts
@@ -1,0 +1,26 @@
+// Auto-generated from [Dto] types — do not edit
+export interface Notification {
+  userId: string;
+  type: string;
+  channel: string;
+  title: string;
+  body: string;
+  dataJson: string;
+  readAt: string | null;
+  isRead: boolean;
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  concurrencyStamp: string;
+}
+
+export interface QueryNotificationsRequest {
+  page: number | null;
+  pageSize: number | null;
+  unreadOnly: boolean | null;
+  channel: string;
+  type: string;
+  effectivePage: number;
+  effectivePageSize: number;
+}
+

--- a/modules/Notifications/src/SimpleModule.Notifications/vite.config.ts
+++ b/modules/Notifications/src/SimpleModule.Notifications/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineModuleConfig } from '@simplemodule/client/module';
+
+export default defineModuleConfig(import.meta.dirname);

--- a/modules/Notifications/tests/SimpleModule.Notifications.Tests/GlobalUsings.cs
+++ b/modules/Notifications/tests/SimpleModule.Notifications.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/modules/Notifications/tests/SimpleModule.Notifications.Tests/SimpleModule.Notifications.Tests.csproj
+++ b/modules/Notifications/tests/SimpleModule.Notifications.Tests/SimpleModule.Notifications.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SimpleModule.Notifications\SimpleModule.Notifications.csproj" />
+    <ProjectReference Include="..\..\src\SimpleModule.Notifications.Contracts\SimpleModule.Notifications.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\tests\SimpleModule.Tests.Shared\SimpleModule.Tests.Shared.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\BackgroundJobs\src\SimpleModule.BackgroundJobs.Contracts\SimpleModule.BackgroundJobs.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Email\src\SimpleModule.Email.Contracts\SimpleModule.Email.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\..\modules\Users\src\SimpleModule.Users.Contracts\SimpleModule.Users.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/NotificationServiceTests.cs
+++ b/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/NotificationServiceTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SimpleModule.Database;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Services;
+using SimpleModule.Users.Contracts;
+
+namespace SimpleModule.Notifications.Tests.Unit;
+
+public sealed class NotificationServiceTests : IDisposable
+{
+    private readonly NotificationsDbContext _db;
+    private readonly NotificationService _sut;
+    private readonly UserId _userId = UserId.From("user-1");
+
+    public NotificationServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<NotificationsDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        var dbOptions = Options.Create(
+            new DatabaseOptions
+            {
+                ModuleConnections = new Dictionary<string, string>
+                {
+                    ["Notifications"] = "Data Source=:memory:",
+                },
+            }
+        );
+        _db = new NotificationsDbContext(options, dbOptions);
+        _db.Database.OpenConnection();
+        _db.Database.EnsureCreated();
+        _sut = new NotificationService(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private async Task<Notification> SeedAsync(UserId? userId = null, DateTimeOffset? readAt = null)
+    {
+        var n = new Notification
+        {
+            Id = NotificationId.From(Guid.CreateVersion7()),
+            UserId = userId ?? _userId,
+            Type = "test.event",
+            Channel = NotificationsConstants.Channels.Database,
+            Title = "Title",
+            Body = "Body",
+            DataJson = "{}",
+            ReadAt = readAt,
+        };
+        _db.Notifications.Add(n);
+        await _db.SaveChangesAsync();
+        return n;
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsOnlyOwnNotifications()
+    {
+        await SeedAsync();
+        await SeedAsync();
+        await SeedAsync(userId: UserId.From("other-user"));
+
+        var result = await _sut.ListAsync(_userId, new QueryNotificationsRequest());
+
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ListAsync_UnreadOnly_FiltersReadNotifications()
+    {
+        await SeedAsync();
+        await SeedAsync(readAt: DateTimeOffset.UtcNow);
+
+        var result = await _sut.ListAsync(
+            _userId,
+            new QueryNotificationsRequest { UnreadOnly = true }
+        );
+
+        result.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_ReturnsUnreadOnly()
+    {
+        await SeedAsync();
+        await SeedAsync();
+        await SeedAsync(readAt: DateTimeOffset.UtcNow);
+
+        var count = await _sut.GetUnreadCountAsync(_userId);
+
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_SetsReadAt()
+    {
+        var n = await SeedAsync();
+
+        var result = await _sut.MarkReadAsync(n.Id, _userId);
+
+        result.Should().BeTrue();
+        var refreshed = await _db.Notifications.AsNoTracking().FirstAsync(x => x.Id == n.Id);
+        refreshed.ReadAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_WithDifferentUser_ReturnsFalse()
+    {
+        var n = await SeedAsync();
+
+        var result = await _sut.MarkReadAsync(n.Id, UserId.From("not-the-owner"));
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_MarksAllUnreadForUser()
+    {
+        await SeedAsync();
+        await SeedAsync();
+        await SeedAsync(readAt: DateTimeOffset.UtcNow);
+        await SeedAsync(userId: UserId.From("other"));
+
+        var marked = await _sut.MarkAllReadAsync(_userId);
+
+        marked.Should().Be(2);
+        var remainingUnread = await _sut.GetUnreadCountAsync(_userId);
+        remainingUnread.Should().Be(0);
+        var otherUserUnread = await _sut.GetUnreadCountAsync(UserId.From("other"));
+        otherUserUnread.Should().Be(1);
+    }
+}

--- a/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/NotifierTests.cs
+++ b/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/NotifierTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SimpleModule.Notifications.Channels;
+using SimpleModule.Notifications.Contracts;
+using SimpleModule.Notifications.Jobs;
+using SimpleModule.Notifications.Services;
+using SimpleModule.Users.Contracts;
+using Wolverine;
+
+namespace SimpleModule.Notifications.Tests.Unit;
+
+public sealed class NotifierTests
+{
+    private sealed class CapturingChannel(string name) : INotificationChannel
+    {
+        public string Name { get; } = name;
+        public List<(NotificationRecipient Recipient, INotification Notification)> Calls { get; } =
+            [];
+
+        public Task SendAsync(
+            NotificationRecipient recipient,
+            INotification notification,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Calls.Add((recipient, notification));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingChannel(string name) : INotificationChannel
+    {
+        public string Name { get; } = name;
+
+        public Task SendAsync(
+            NotificationRecipient recipient,
+            INotification notification,
+            CancellationToken cancellationToken = default
+        ) => throw new InvalidOperationException("boom");
+    }
+
+    private sealed record TestNotification(string[] Channels) : INotification
+    {
+        public string NotificationType => "test.event";
+
+        public string[] Via(NotificationRecipient recipient) => Channels;
+
+        public DatabaseNotificationPayload? ToDatabase(NotificationRecipient recipient) =>
+            new("Title", "Body");
+    }
+
+    [Fact]
+    public async Task SendNowAsync_DispatchesToEachChannel()
+    {
+        var db = new CapturingChannel(NotificationsConstants.Channels.Database);
+        var mail = new CapturingChannel(NotificationsConstants.Channels.Mail);
+        var registry = new NotificationChannelRegistry([db, mail]);
+        var sut = new Notifier(
+            registry,
+            new TestBackgroundJobs(),
+            Substitute.For<IMessageBus>(),
+            NullLogger<Notifier>.Instance
+        );
+
+        var recipient = new NotificationRecipient(UserId.From("u1"), "u1@test.com");
+        var notification = new TestNotification(
+            [NotificationsConstants.Channels.Database, NotificationsConstants.Channels.Mail]
+        );
+
+        await sut.SendNowAsync(recipient, notification);
+
+        db.Calls.Should().HaveCount(1);
+        mail.Calls.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SendNowAsync_UnknownChannelIsSkipped()
+    {
+        var db = new CapturingChannel(NotificationsConstants.Channels.Database);
+        var registry = new NotificationChannelRegistry([db]);
+        var sut = new Notifier(
+            registry,
+            new TestBackgroundJobs(),
+            Substitute.For<IMessageBus>(),
+            NullLogger<Notifier>.Instance
+        );
+
+        var recipient = new NotificationRecipient(UserId.From("u1"));
+        const string unregisteredChannel = "unregistered";
+        var notification = new TestNotification(
+            [unregisteredChannel, NotificationsConstants.Channels.Database]
+        );
+
+        await sut.SendNowAsync(recipient, notification);
+
+        db.Calls.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SendNowAsync_PublishesFailedEvent_WhenChannelThrows()
+    {
+        var failing = new FailingChannel(NotificationsConstants.Channels.Database);
+        var registry = new NotificationChannelRegistry([failing]);
+        var bus = Substitute.For<IMessageBus>();
+        var sut = new Notifier(
+            registry,
+            new TestBackgroundJobs(),
+            bus,
+            NullLogger<Notifier>.Instance
+        );
+
+        var recipient = new NotificationRecipient(UserId.From("u1"));
+        var notification = new TestNotification([NotificationsConstants.Channels.Database]);
+
+        await sut.SendNowAsync(recipient, notification);
+
+        await bus.Received(1)
+            .PublishAsync(
+                Arg.Any<Contracts.Events.NotificationFailedEvent>(),
+                Arg.Any<DeliveryOptions?>()
+            );
+    }
+
+    [Fact]
+    public async Task SendAsync_EnqueuesOneJobPerChannel()
+    {
+        var registry = new NotificationChannelRegistry([]);
+        var jobs = new TestBackgroundJobs();
+        var sut = new Notifier(
+            registry,
+            jobs,
+            Substitute.For<IMessageBus>(),
+            NullLogger<Notifier>.Instance
+        );
+
+        var recipient = new NotificationRecipient(UserId.From("u1"), "u1@test.com");
+        var notification = new TestNotification(
+            [NotificationsConstants.Channels.Database, NotificationsConstants.Channels.Mail]
+        );
+
+        await sut.SendAsync(recipient, notification);
+
+        jobs.EnqueuedJobs.Should().HaveCount(2);
+        jobs.EnqueuedJobs.Should().AllSatisfy(j => j.JobType.Should().Be<DispatchNotificationJob>());
+    }
+}

--- a/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/TestBackgroundJobs.cs
+++ b/modules/Notifications/tests/SimpleModule.Notifications.Tests/Unit/TestBackgroundJobs.cs
@@ -1,0 +1,41 @@
+using SimpleModule.BackgroundJobs.Contracts;
+
+namespace SimpleModule.Notifications.Tests.Unit;
+
+internal sealed class TestBackgroundJobs : IBackgroundJobs
+{
+    public List<(Type JobType, object? Data)> EnqueuedJobs { get; } = [];
+
+    public Task<JobId> EnqueueAsync<TJob>(object? data = null, CancellationToken ct = default)
+        where TJob : IModuleJob
+    {
+        EnqueuedJobs.Add((typeof(TJob), data));
+        return Task.FromResult(JobId.From(Guid.NewGuid()));
+    }
+
+    public Task<JobId> ScheduleAsync<TJob>(
+        DateTimeOffset executeAt,
+        object? data = null,
+        CancellationToken ct = default
+    )
+        where TJob : IModuleJob => Task.FromResult(JobId.From(Guid.NewGuid()));
+
+    public Task<RecurringJobId> AddRecurringAsync<TJob>(
+        string name,
+        string cronExpression,
+        object? data = null,
+        CancellationToken ct = default
+    )
+        where TJob : IModuleJob => Task.FromResult(RecurringJobId.From(Guid.NewGuid()));
+
+    public Task RemoveRecurringAsync(RecurringJobId id, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    public Task<bool> ToggleRecurringAsync(RecurringJobId id, CancellationToken ct = default) =>
+        Task.FromResult(true);
+
+    public Task CancelAsync(JobId jobId, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<JobStatusDto?> GetStatusAsync(JobId jobId, CancellationToken ct = default) =>
+        Task.FromResult<JobStatusDto?>(null);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,14 @@
         "react-dom": "^19.0.0"
       }
     },
+    "modules/Notifications/src/SimpleModule.Notifications": {
+      "name": "@simplemodule/notifications",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "modules/OpenIddict/src/SimpleModule.OpenIddict": {
       "name": "@simplemodule/openiddict",
       "version": "0.0.0",
@@ -4001,6 +4009,10 @@
     },
     "node_modules/@simplemodule/k6": {
       "resolved": "tests/k6",
+      "link": true
+    },
+    "node_modules/@simplemodule/notifications": {
+      "resolved": "modules/Notifications/src/SimpleModule.Notifications",
       "link": true
     },
     "node_modules/@simplemodule/openiddict": {

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -88,16 +88,19 @@ export const routes = {
   },
   tenants: {
     api: {
-      deleteTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
+      deleteTenantFeature: (id: string | number, flagName: string | number) =>
+        `/api/tenants/${id}/features/${flagName}`,
       getTenantFeatures: (id: string | number) => `/api/tenants/${id}/features`,
-      setTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
+      setTenantFeature: (id: string | number, flagName: string | number) =>
+        `/api/tenants/${id}/features/${flagName}`,
       addHost: (id: string | number) => `/api/tenants/${id}/hosts`,
       changeStatus: (id: string | number) => `/api/tenants/${id}/status`,
       create: () => '/api/tenants' as const,
       delete: (id: string | number) => `/api/tenants/${id}`,
       getAll: () => '/api/tenants' as const,
       getById: (id: string | number) => `/api/tenants/${id}`,
-      removeHost: (id: string | number, hostId: string | number) => `/api/tenants/${id}/hosts/${hostId}`,
+      removeHost: (id: string | number, hostId: string | number) =>
+        `/api/tenants/${id}/hosts/${hostId}`,
       update: (id: string | number) => `/api/tenants/${id}`,
     },
     views: {
@@ -209,7 +212,8 @@ export const routes = {
       userinfo: () => '/connect/userinfo' as const,
       activeSessions: () => '/Identity/Account/Manage/ActiveSessions' as const,
       revokeOtherSessions: () => '/Identity/Account/Manage/ActiveSessions/revoke-others' as const,
-      revokeSession: (tokenId: string | number) => `/Identity/Account/Manage/ActiveSessions/${tokenId}/revoke`,
+      revokeSession: (tokenId: string | number) =>
+        `/Identity/Account/Manage/ActiveSessions/${tokenId}/revoke`,
     },
     views: {
       clientsCreate: () => '/openiddict/clients/create' as const,
@@ -220,7 +224,8 @@ export const routes = {
   admin: {
     api: {
       adminRoles: () => '/admin/roles' as const,
-      adminSessions: (id: string | number, tokenId: string | number) => `/admin/users/${id}/sessions/${tokenId}`,
+      adminSessions: (id: string | number, tokenId: string | number) =>
+        `/admin/users/${id}/sessions/${tokenId}`,
       adminUsers: () => '/admin/users' as const,
     },
     views: {
@@ -234,4 +239,3 @@ export const routes = {
     },
   },
 } as const;
-

--- a/packages/SimpleModule.Client/src/routes.ts
+++ b/packages/SimpleModule.Client/src/routes.ts
@@ -88,19 +88,16 @@ export const routes = {
   },
   tenants: {
     api: {
-      deleteTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      deleteTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       getTenantFeatures: (id: string | number) => `/api/tenants/${id}/features`,
-      setTenantFeature: (id: string | number, flagName: string | number) =>
-        `/api/tenants/${id}/features/${flagName}`,
+      setTenantFeature: (id: string | number, flagName: string | number) => `/api/tenants/${id}/features/${flagName}`,
       addHost: (id: string | number) => `/api/tenants/${id}/hosts`,
       changeStatus: (id: string | number) => `/api/tenants/${id}/status`,
       create: () => '/api/tenants' as const,
       delete: (id: string | number) => `/api/tenants/${id}`,
       getAll: () => '/api/tenants' as const,
       getById: (id: string | number) => `/api/tenants/${id}`,
-      removeHost: (id: string | number, hostId: string | number) =>
-        `/api/tenants/${id}/hosts/${hostId}`,
+      removeHost: (id: string | number, hostId: string | number) => `/api/tenants/${id}/hosts/${hostId}`,
       update: (id: string | number) => `/api/tenants/${id}`,
     },
     views: {
@@ -192,6 +189,17 @@ export const routes = {
       templates: () => '/email/templates' as const,
     },
   },
+  notifications: {
+    api: {
+      listNotifications: () => '/api/notifications' as const,
+      markAllRead: () => '/api/notifications/read-all' as const,
+      markRead: (id: string | number) => `/api/notifications/${id}/read`,
+      unreadCount: () => '/api/notifications/unread-count' as const,
+    },
+    views: {
+      inbox: () => '/notifications' as const,
+    },
+  },
   openIddict: {
     api: {
       authorization: () => '/connect/authorize' as const,
@@ -201,8 +209,7 @@ export const routes = {
       userinfo: () => '/connect/userinfo' as const,
       activeSessions: () => '/Identity/Account/Manage/ActiveSessions' as const,
       revokeOtherSessions: () => '/Identity/Account/Manage/ActiveSessions/revoke-others' as const,
-      revokeSession: (tokenId: string | number) =>
-        `/Identity/Account/Manage/ActiveSessions/${tokenId}/revoke`,
+      revokeSession: (tokenId: string | number) => `/Identity/Account/Manage/ActiveSessions/${tokenId}/revoke`,
     },
     views: {
       clientsCreate: () => '/openiddict/clients/create' as const,
@@ -213,8 +220,7 @@ export const routes = {
   admin: {
     api: {
       adminRoles: () => '/admin/roles' as const,
-      adminSessions: (id: string | number, tokenId: string | number) =>
-        `/admin/users/${id}/sessions/${tokenId}`,
+      adminSessions: (id: string | number, tokenId: string | number) => `/admin/users/${id}/sessions/${tokenId}`,
       adminUsers: () => '/admin/users' as const,
     },
     views: {
@@ -228,3 +234,4 @@ export const routes = {
     },
   },
 } as const;
+

--- a/template/SimpleModule.Host/Migrations/20260511185843_AddNotificationsModule.Designer.cs
+++ b/template/SimpleModule.Host/Migrations/20260511185843_AddNotificationsModule.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimpleModule.Host;
 
@@ -10,9 +11,11 @@ using SimpleModule.Host;
 namespace SimpleModule.Host.Migrations
 {
     [DbContext(typeof(HostDbContext))]
-    partial class HostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511185843_AddNotificationsModule")]
+    partial class AddNotificationsModule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.3");

--- a/template/SimpleModule.Host/Migrations/20260511185843_AddNotificationsModule.cs
+++ b/template/SimpleModule.Host/Migrations/20260511185843_AddNotificationsModule.cs
@@ -1,0 +1,1425 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace SimpleModule.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotificationsModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Agents_Messages");
+
+            migrationBuilder.DropTable(name: "Agents_Sessions");
+
+            migrationBuilder.DropTable(name: "Chat_ChatMessages");
+
+            migrationBuilder.DropTable(name: "Datasets_Datasets");
+
+            migrationBuilder.DropTable(name: "Map_Basemaps");
+
+            migrationBuilder.DropTable(name: "Map_LayerSources");
+
+            migrationBuilder.DropTable(name: "Map_MapBasemap");
+
+            migrationBuilder.DropTable(name: "Map_MapLayer");
+
+            migrationBuilder.DropTable(name: "Orders_OrderItems");
+
+            migrationBuilder.DropTable(name: "PageBuilder_Tags");
+
+            migrationBuilder.DropTable(name: "PageBuilder_Templates");
+
+            migrationBuilder.DropTable(name: "Products_Products");
+
+            migrationBuilder.DropTable(name: "Rag_CachedStructuredKnowledge");
+
+            migrationBuilder.DropTable(name: "Chat_Conversations");
+
+            migrationBuilder.DropTable(name: "Map_SavedMaps");
+
+            migrationBuilder.DropTable(name: "Orders_Orders");
+
+            migrationBuilder.DropTable(name: "PageBuilder_Pages");
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_Tenants",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_TenantHosts",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_Settings",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_PublicMenuItems",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "RateLimiting_Rules",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FileStorage_StoredFiles",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlagOverrides",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailTemplates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailMessages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "AuditLogs_AuditEntries",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.CreateTable(
+                name: "Notifications_Notifications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UserId = table.Column<string>(type: "TEXT", maxLength: 450, nullable: false),
+                    Type = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Channel = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    Title = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
+                    Body = table.Column<string>(type: "TEXT", maxLength: 4000, nullable: true),
+                    DataJson = table.Column<string>(type: "TEXT", nullable: false),
+                    ReadAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notifications_Notifications", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_Notifications_UserId_CreatedAt_Id",
+                table: "Notifications_Notifications",
+                columns: new[] { "UserId", "CreatedAt", "Id" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_Notifications_UserId_ReadAt",
+                table: "Notifications_Notifications",
+                columns: new[] { "UserId", "ReadAt" }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Notifications_Notifications");
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_Tenants",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Tenants_TenantHosts",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_Settings",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Settings_PublicMenuItems",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "RateLimiting_Rules",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FileStorage_StoredFiles",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlags",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "FeatureFlags_FeatureFlagOverrides",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailTemplates",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "Email_EmailMessages",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder
+                .AlterColumn<int>(
+                    name: "Id",
+                    table: "AuditLogs_AuditEntries",
+                    type: "INTEGER",
+                    nullable: false,
+                    oldClrType: typeof(int),
+                    oldType: "INTEGER"
+                )
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.CreateTable(
+                name: "Agents_Messages",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", maxLength: 36, nullable: false),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    Role = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    SessionId = table.Column<string>(type: "TEXT", maxLength: 36, nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    TokenCount = table.Column<int>(type: "INTEGER", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Agents_Messages", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Agents_Sessions",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", maxLength: 36, nullable: false),
+                    AgentName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    LastMessageAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UserId = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Agents_Sessions", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Chat_Conversations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    AgentName = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                    Pinned = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Title = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
+                    UpdatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                    UserId = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Chat_Conversations", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Datasets_Datasets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    BboxMaxX = table.Column<double>(type: "REAL", nullable: true),
+                    BboxMaxY = table.Column<double>(type: "REAL", nullable: true),
+                    BboxMinX = table.Column<double>(type: "REAL", nullable: true),
+                    BboxMinY = table.Column<double>(type: "REAL", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    ContentHash = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    DeletedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    ErrorMessage = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 4096,
+                        nullable: true
+                    ),
+                    FeatureCount = table.Column<long>(type: "INTEGER", nullable: true),
+                    Format = table.Column<int>(type: "INTEGER", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "INTEGER", nullable: false),
+                    MetadataJson = table.Column<string>(type: "TEXT", nullable: true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
+                    NormalizedPath = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 1024,
+                        nullable: true
+                    ),
+                    OriginalFileName = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 512,
+                        nullable: false
+                    ),
+                    ProcessedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    SizeBytes = table.Column<long>(type: "INTEGER", nullable: false),
+                    SourceSrid = table.Column<int>(type: "INTEGER", nullable: true),
+                    Srid = table.Column<int>(type: "INTEGER", nullable: true),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    StoragePath = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 1024,
+                        nullable: false
+                    ),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Version = table.Column<int>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Datasets_Datasets", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Map_Basemaps",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Attribution = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 500,
+                        nullable: true
+                    ),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Description = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 2000,
+                        nullable: true
+                    ),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    StyleUrl = table.Column<string>(type: "TEXT", maxLength: 2048, nullable: false),
+                    ThumbnailUrl = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 2048,
+                        nullable: true
+                    ),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Map_Basemaps", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Map_LayerSources",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Attribution = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 500,
+                        nullable: true
+                    ),
+                    Bounds = table.Column<string>(type: "TEXT", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Description = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 2000,
+                        nullable: true
+                    ),
+                    MaxZoom = table.Column<int>(type: "INTEGER", nullable: true),
+                    Metadata = table.Column<string>(type: "TEXT", nullable: false),
+                    MinZoom = table.Column<int>(type: "INTEGER", nullable: true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Url = table.Column<string>(type: "TEXT", maxLength: 2048, nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Map_LayerSources", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Map_SavedMaps",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    BaseStyleUrl = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 2048,
+                        nullable: false
+                    ),
+                    Bearing = table.Column<double>(type: "REAL", nullable: false),
+                    CenterLat = table.Column<double>(type: "REAL", nullable: false),
+                    CenterLng = table.Column<double>(type: "REAL", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Description = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 2000,
+                        nullable: true
+                    ),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Pitch = table.Column<double>(type: "REAL", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Zoom = table.Column<double>(type: "REAL", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Map_SavedMaps", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Orders_Orders",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Total = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders_Orders", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "PageBuilder_Pages",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    CreatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    DeletedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    DraftContent = table.Column<string>(type: "TEXT", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "INTEGER", nullable: false),
+                    IsPublished = table.Column<bool>(
+                        type: "INTEGER",
+                        nullable: false,
+                        defaultValue: false
+                    ),
+                    MetaDescription = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 300,
+                        nullable: true
+                    ),
+                    MetaKeywords = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 500,
+                        nullable: true
+                    ),
+                    OgImage = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
+                    Order = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0),
+                    Slug = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Title = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: true),
+                    Version = table.Column<int>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageBuilder_Pages", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "PageBuilder_Templates",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageBuilder_Templates", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Products_Products",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Products_Products", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Rag_CachedStructuredKnowledge",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CollectionName = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 256,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    DocumentHash = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    HitCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    SourceTitle = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 512,
+                        nullable: false
+                    ),
+                    StructureType = table.Column<int>(type: "INTEGER", nullable: false),
+                    StructuredContent = table.Column<string>(type: "TEXT", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Rag_CachedStructuredKnowledge", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Chat_ChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    Content = table.Column<string>(type: "TEXT", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                    Role = table.Column<int>(type: "INTEGER", nullable: false),
+                    UpdatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Chat_ChatMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Chat_ChatMessages_Chat_Conversations_ConversationId",
+                        column: x => x.ConversationId,
+                        principalTable: "Chat_Conversations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Map_MapBasemap",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    BasemapId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Order = table.Column<int>(type: "INTEGER", nullable: false),
+                    SavedMapId = table.Column<Guid>(type: "TEXT", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Map_MapBasemap", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Map_MapBasemap_Map_SavedMaps_SavedMapId",
+                        column: x => x.SavedMapId,
+                        principalTable: "Map_SavedMaps",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Map_MapLayer",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    LayerSourceId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Opacity = table.Column<double>(type: "REAL", nullable: false),
+                    Order = table.Column<int>(type: "INTEGER", nullable: false),
+                    SavedMapId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    StyleOverrides = table.Column<string>(type: "TEXT", nullable: false),
+                    Visible = table.Column<bool>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Map_MapLayer", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Map_MapLayer_Map_SavedMaps_SavedMapId",
+                        column: x => x.SavedMapId,
+                        principalTable: "Map_SavedMaps",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Orders_OrderItems",
+                columns: table => new
+                {
+                    OrderId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ProductId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Quantity = table.Column<int>(type: "INTEGER", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders_OrderItems", x => new { x.OrderId, x.ProductId });
+                    table.ForeignKey(
+                        name: "FK_Orders_OrderItems_Orders_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders_Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "PageBuilder_Tags",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    PageId = table.Column<int>(type: "INTEGER", nullable: true),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageBuilder_Tags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PageBuilder_Tags_PageBuilder_Pages_PageId",
+                        column: x => x.PageId,
+                        principalTable: "PageBuilder_Pages",
+                        principalColumn: "Id"
+                    );
+                }
+            );
+
+            migrationBuilder.InsertData(
+                table: "Map_Basemaps",
+                columns: new[]
+                {
+                    "Id",
+                    "Attribution",
+                    "ConcurrencyStamp",
+                    "CreatedAt",
+                    "CreatedBy",
+                    "Description",
+                    "Name",
+                    "StyleUrl",
+                    "ThumbnailUrl",
+                    "UpdatedAt",
+                    "UpdatedBy",
+                },
+                values: new object[,]
+                {
+                    {
+                        new Guid("22222222-2222-2222-2222-000000000001"),
+                        "MapLibre",
+                        "seed-basemap-demotiles",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Official MapLibre demo vector style. Free for development.",
+                        "MapLibre Demotiles",
+                        "https://demotiles.maplibre.org/style.json",
+                        null,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                    },
+                    {
+                        new Guid("22222222-2222-2222-2222-000000000002"),
+                        "© OpenStreetMap contributors, OpenFreeMap",
+                        "seed-basemap-openfreemap-liberty",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "OpenFreeMap free vector basemap, Liberty style.",
+                        "OpenFreeMap Liberty",
+                        "https://tiles.openfreemap.org/styles/liberty",
+                        null,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                    },
+                    {
+                        new Guid("22222222-2222-2222-2222-000000000003"),
+                        "© OpenStreetMap contributors, OpenFreeMap",
+                        "seed-basemap-openfreemap-positron",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "OpenFreeMap free vector basemap, light Positron style.",
+                        "OpenFreeMap Positron",
+                        "https://tiles.openfreemap.org/styles/positron",
+                        null,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                    },
+                    {
+                        new Guid("22222222-2222-2222-2222-000000000004"),
+                        "© OpenStreetMap contributors, OpenFreeMap",
+                        "seed-basemap-openfreemap-bright",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "OpenFreeMap free vector basemap, Bright style.",
+                        "OpenFreeMap Bright",
+                        "https://tiles.openfreemap.org/styles/bright",
+                        null,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                    },
+                    {
+                        new Guid("22222222-2222-2222-2222-000000000005"),
+                        "© OpenStreetMap contributors, VersaTiles",
+                        "seed-basemap-versatiles-colorful",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "VersaTiles free OSM-based vector basemap, Colorful style.",
+                        "Versatiles Colorful",
+                        "https://tiles.versatiles.org/assets/styles/colorful/style.json",
+                        null,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                    },
+                }
+            );
+
+            migrationBuilder.InsertData(
+                table: "Map_LayerSources",
+                columns: new[]
+                {
+                    "Id",
+                    "Attribution",
+                    "Bounds",
+                    "ConcurrencyStamp",
+                    "CreatedAt",
+                    "CreatedBy",
+                    "Description",
+                    "MaxZoom",
+                    "Metadata",
+                    "MinZoom",
+                    "Name",
+                    "Type",
+                    "UpdatedAt",
+                    "UpdatedBy",
+                    "Url",
+                },
+                values: new object[,]
+                {
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000001"),
+                        "© OpenStreetMap contributors",
+                        "[-180,-85,180,85]",
+                        "seed-osm-xyz",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Standard OSM raster tiles. Free for low-volume use; respect the OSMF tile usage policy.",
+                        19,
+                        "{}",
+                        0,
+                        "OpenStreetMap (raster tiles)",
+                        3,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000002"),
+                        "© OpenStreetMap contributors, terrestris",
+                        "[-180,-85,180,85]",
+                        "seed-terrestris-wms",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Public WMS by terrestris. Used in the official MapLibre 'Add a WMS source' example.",
+                        null,
+                        "{\"layers\":\"OSM-WMS\",\"format\":\"image/png\",\"version\":\"1.1.1\",\"crs\":\"EPSG:3857\",\"transparent\":\"true\"}",
+                        null,
+                        "terrestris OSM-WMS",
+                        0,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://ows.terrestris.de/osm/service",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000003"),
+                        "© OpenStreetMap contributors, terrestris",
+                        "[-180,-85,180,85]",
+                        "seed-terrestris-topo",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "terrestris topographic WMS overlay layer (transparent).",
+                        null,
+                        "{\"layers\":\"TOPO-WMS,OSM-Overlay-WMS\",\"format\":\"image/png\",\"version\":\"1.1.1\",\"crs\":\"EPSG:3857\",\"transparent\":\"true\"}",
+                        null,
+                        "terrestris TOPO-WMS",
+                        0,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://ows.terrestris.de/osm/service",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000004"),
+                        "MapLibre",
+                        "[-180,-85,180,85]",
+                        "seed-maplibre-demotiles",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Official MapLibre demo MVT vector tileset. Free for development.",
+                        14,
+                        "{\"sourceLayer\":\"countries\"}",
+                        0,
+                        "MapLibre demotiles (vector)",
+                        4,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000005"),
+                        "© OpenStreetMap contributors, Protomaps",
+                        "[11.154,43.727,11.328,43.823]",
+                        "seed-protomaps-firenze",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Public PMTiles vector archive of Florence (ODbL). Used in the MapLibre PMTiles example.",
+                        null,
+                        "{\"tileType\":\"vector\",\"sourceLayer\":\"landuse\"}",
+                        null,
+                        "Protomaps Firenze (PMTiles)",
+                        5,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000006"),
+                        "Geomatico",
+                        "[-180,-85,180,85]",
+                        "seed-geomatico-cog",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Public Cloud-Optimized GeoTIFF demo from the maplibre-cog-protocol sample viewer.",
+                        null,
+                        "{}",
+                        null,
+                        "Geomatico kriging COG (demo)",
+                        6,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://labs.geomatico.es/maplibre-cog-protocol/data/kriging.tif",
+                    },
+                    {
+                        new Guid("11111111-1111-1111-1111-000000000007"),
+                        "USGS / MapLibre demo",
+                        "[-180,-85,180,85]",
+                        "seed-maplibre-earthquakes",
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "Small public GeoJSON FeatureCollection from the MapLibre demo assets.",
+                        null,
+                        "{\"color\":\"#ef4444\"}",
+                        null,
+                        "MapLibre demotiles point sample (GeoJSON)",
+                        7,
+                        new DateTimeOffset(
+                            new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        null,
+                        "https://maplibre.org/maplibre-gl-js/docs/assets/significant-earthquakes-2015.geojson",
+                    },
+                }
+            );
+
+            migrationBuilder.InsertData(
+                table: "Products_Products",
+                columns: new[]
+                {
+                    "Id",
+                    "ConcurrencyStamp",
+                    "CreatedAt",
+                    "Name",
+                    "Price",
+                    "UpdatedAt",
+                },
+                values: new object[,]
+                {
+                    {
+                        1,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Fantastic Rubber Shoes",
+                        991.68m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        2,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Fantastic Rubber Bacon",
+                        446.22m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        3,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Fantastic Concrete Bike",
+                        660.12m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        4,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Handcrafted Concrete Keyboard",
+                        633.67m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        5,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Intelligent Frozen Mouse",
+                        674.30m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        6,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Sleek Soft Hat",
+                        851.63m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        7,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Practical Fresh Bike",
+                        417.48m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        8,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Handmade Steel Ball",
+                        975.56m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        9,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Ergonomic Fresh Pants",
+                        928.09m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                    {
+                        10,
+                        "",
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                        "Licensed Steel Sausages",
+                        592.60m,
+                        new DateTimeOffset(
+                            new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            new TimeSpan(0, 0, 0, 0, 0)
+                        ),
+                    },
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Agents_Messages_SessionId",
+                table: "Agents_Messages",
+                column: "SessionId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Agents_Messages_SessionId_Timestamp",
+                table: "Agents_Messages",
+                columns: new[] { "SessionId", "Timestamp" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Agents_Sessions_AgentName",
+                table: "Agents_Sessions",
+                column: "AgentName"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Agents_Sessions_UserId",
+                table: "Agents_Sessions",
+                column: "UserId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Chat_ChatMessages_ConversationId_CreatedAt",
+                table: "Chat_ChatMessages",
+                columns: new[] { "ConversationId", "CreatedAt" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Chat_Conversations_UserId_UpdatedAt",
+                table: "Chat_Conversations",
+                columns: new[] { "UserId", "UpdatedAt" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_Datasets_BboxMinX_BboxMaxX_BboxMinY_BboxMaxY",
+                table: "Datasets_Datasets",
+                columns: new[] { "BboxMinX", "BboxMaxX", "BboxMinY", "BboxMaxY" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_Datasets_ContentHash",
+                table: "Datasets_Datasets",
+                column: "ContentHash"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_Datasets_Format",
+                table: "Datasets_Datasets",
+                column: "Format"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_Datasets_IsDeleted_CreatedAt",
+                table: "Datasets_Datasets",
+                columns: new[] { "IsDeleted", "CreatedAt" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Datasets_Datasets_Status",
+                table: "Datasets_Datasets",
+                column: "Status"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Map_MapBasemap_SavedMapId",
+                table: "Map_MapBasemap",
+                column: "SavedMapId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Map_MapLayer_SavedMapId",
+                table: "Map_MapLayer",
+                column: "SavedMapId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Pages_IsDeleted_DeletedAt",
+                table: "PageBuilder_Pages",
+                columns: new[] { "IsDeleted", "DeletedAt" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Pages_IsPublished",
+                table: "PageBuilder_Pages",
+                column: "IsPublished"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Pages_Slug",
+                table: "PageBuilder_Pages",
+                column: "Slug",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Tags_Name",
+                table: "PageBuilder_Tags",
+                column: "Name",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Tags_PageId",
+                table: "PageBuilder_Tags",
+                column: "PageId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageBuilder_Templates_Name",
+                table: "PageBuilder_Templates",
+                column: "Name",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Rag_CachedStructuredKnowledge_CollectionName_DocumentHash_StructureType",
+                table: "Rag_CachedStructuredKnowledge",
+                columns: new[] { "CollectionName", "DocumentHash", "StructureType" },
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Rag_CachedStructuredKnowledge_ExpiresAt",
+                table: "Rag_CachedStructuredKnowledge",
+                column: "ExpiresAt"
+            );
+        }
+    }
+}

--- a/template/SimpleModule.Host/SimpleModule.Host.csproj
+++ b/template/SimpleModule.Host/SimpleModule.Host.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\modules\Localization\src\SimpleModule.Localization\SimpleModule.Localization.csproj" />
     <ProjectReference Include="..\..\modules\RateLimiting\src\SimpleModule.RateLimiting\SimpleModule.RateLimiting.csproj" />
     <ProjectReference Include="..\..\modules\Email\src\SimpleModule.Email\SimpleModule.Email.csproj" />
+    <ProjectReference Include="..\..\modules\Notifications\src\SimpleModule.Notifications\SimpleModule.Notifications.csproj" />
     <ProjectReference Include="..\..\framework\SimpleModule.Storage.Local\SimpleModule.Storage.Local.csproj" />
     <ProjectReference Include="..\..\SimpleModule.ServiceDefaults\SimpleModule.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.Databases.cs
+++ b/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.Databases.cs
@@ -9,6 +9,7 @@ using SimpleModule.Email;
 using SimpleModule.FeatureFlags;
 using SimpleModule.FileStorage;
 using SimpleModule.Host;
+using SimpleModule.Notifications;
 using SimpleModule.OpenIddict;
 using SimpleModule.Permissions;
 using SimpleModule.RateLimiting;
@@ -48,6 +49,7 @@ public partial class SimpleModuleWebApplicationFactory
         EnsureTablesCreated<BackgroundJobsDbContext>(sp);
         EnsureTablesCreated<RateLimitingDbContext>(sp);
         EnsureTablesCreated<EmailDbContext>(sp);
+        EnsureTablesCreated<NotificationsDbContext>(sp);
         EnsureTablesCreated<OpenIddictAppDbContext>(sp);
     }
 

--- a/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
+++ b/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
@@ -11,6 +11,7 @@ using SimpleModule.Email;
 using SimpleModule.FeatureFlags;
 using SimpleModule.FileStorage;
 using SimpleModule.Host;
+using SimpleModule.Notifications;
 using SimpleModule.OpenIddict;
 using SimpleModule.OpenIddict.Contracts;
 using SimpleModule.Permissions;
@@ -74,6 +75,7 @@ public partial class SimpleModuleWebApplicationFactory : WebApplicationFactory<P
             ReplaceDbContext<BackgroundJobsDbContext>(services);
             ReplaceDbContext<RateLimitingDbContext>(services);
             ReplaceDbContext<EmailDbContext>(services);
+            ReplaceDbContext<NotificationsDbContext>(services);
             ReplaceDbContext<OpenIddictAppDbContext>(services, useOpenIddict: true);
 
             // Remove hosted seed services — they need real DB tables that


### PR DESCRIPTION
## Summary
- New `modules/Notifications` exposing `INotifier.SendAsync`/`SendNowAsync` so any module can dispatch a notification across the channels declared by `INotification.Via(recipient)`.
- In-tree channels: `DatabaseChannel` (persists `Notifications_Notifications` rows for the in-app inbox + outbox `NotificationSentEvent`), `MailChannel` (delegates to `IEmailContracts`), and a log-based `LogSmsChannel` as the default SMS sink that out-of-tree providers (Twilio, Slack, push) can replace.
- Inbox page at `/notifications/` with list, unread-count, mark-read, and mark-all-read endpoints, plus per-user channel opt-in settings.
- One job per (recipient, channel) via `IBackgroundJobs.EnqueueAsync<DispatchNotificationJob>` so a slow channel can't block siblings.

## Verification
- Manually exercised the inbox at `https://localhost:5001/notifications/` via playwright-cli:
  - Empty-state renders with `0 total · 0 unread` and a disabled "Mark all read".
  - After seeding one row, the card shows the "New" badge, channel chip, type label, title, and body; counter updates to `1 total · 1 unread`.
  - `POST /api/notifications/{id}/read` returns 204 and the UI re-renders to `1 total · 0 unread` with the per-item "Mark read" button gone.
  - `POST /api/notifications/read-all` returns 200; `GET /api/notifications/unread-count` returns the live count.
- Local CI clean: `npm run check`, `npm run build`, `dotnet build`, `dotnet test --no-build` (every module suite + Core + Generator green), and `npm run test:smoke -w tests/e2e` (47/47 passed).

## Test plan
- [ ] CI green on PR.
- [ ] Reviewer spot-checks the channel-fanout policy in `Notifier.SendAsync` (one job per channel, JSON serialized once outside the loop) and the JSON-blob job dispatch in `DispatchNotificationJob` — flagged as the structural-rewrite candidate (move to `IMessageBus` later) in the cleanup pass.
- [ ] Reviewer confirms the EF migration's accumulated drops are expected (matches prior per-module migration pattern; the dropped tables correspond to modules already removed from the codebase).