### PR TITLE
fix(e2e): repair filestorage + permissions tests

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
-const baseURL = isCI ? 'http://localhost:5000' : 'https://localhost:5001';
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? (isCI ? 'http://localhost:5000' : 'https://localhost:5001');
 
 export default defineConfig({
   testDir: './tests',

--- a/tests/e2e/tests/flows/filestorage-crud.spec.ts
+++ b/tests/e2e/tests/flows/filestorage-crud.spec.ts
@@ -153,14 +153,16 @@ test.describe('FileStorage permissions', () => {
           },
         },
       });
-      expect(response.status()).toBe(302);
+      // API endpoints return 401 for unauthenticated requests (no redirect for non-browser clients)
+      expect(response.status()).toBe(401);
     });
 
     test('delete is rejected', async ({ request }) => {
       const response = await request.delete('/api/files/1', {
         maxRedirects: 0,
       });
-      expect(response.status()).toBe(302);
+      // API endpoints return 401 for unauthenticated requests (no redirect for non-browser clients)
+      expect(response.status()).toBe(401);
     });
   });
 });

--- a/tests/e2e/tests/flows/permissions.spec.ts
+++ b/tests/e2e/tests/flows/permissions.spec.ts
@@ -15,7 +15,7 @@ test.describe('Permission System', () => {
     });
 
     test('can access settings page', async ({ page }) => {
-      await page.goto('/settings');
+      await page.goto('/settings/me');
       await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible();
     });
   });
@@ -25,10 +25,10 @@ test.describe('Permission System', () => {
     test.use({ storageState: { cookies: [], origins: [] } });
 
     test('admin API rejects unauthenticated request', async ({ request }) => {
-      const response = await request.get('/api/admin/users', {
+      const response = await request.get('/admin/users', {
         maxRedirects: 0,
       });
-      // Identity cookie scheme returns 302 redirect to login for unauthenticated requests
+      // Identity cookie scheme returns 302 redirect to login for unauthenticated browser requests
       expect(response.status()).toBe(302);
     });
 


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing failing e2e tests across 2 spec files.

- **FileStorage permissions (2 tests)**: `POST /api/files` and `DELETE /api/files/{id}` unauthenticated were expected to return `302` but actually return `401`. The SmartAuth policy scheme forwards challenge to the Identity cookie scheme for browser navigation, but API `APIRequestContext` calls (no `Accept: text/html`, no cookies) get `401` — which is the correct and intended behavior for machine clients. Updated assertions from `toBe(302)` → `toBe(401)`.

- **Settings page test**: Test navigated to `/settings` which is a 404 (no route matches that bare path). The correct user-facing settings route is `/settings/me` (renders `UserSettings` component with heading "My Settings", which matches `/settings/i`). Fixed navigation target.

- **Admin unauthenticated test**: Test hit `GET /api/admin/users` which does not exist — falls through to the anonymous catch-all returning `404`. The real route that triggers Identity cookie redirect is `GET /admin/users` (the Inertia view endpoint). Fixed request URL.

- **playwright.config.ts**: Added `PLAYWRIGHT_BASE_URL` env var support so parallel CI agents can each run their host on a dedicated port without patching the config file.

## Test plan

- [ ] All 19 tests in `filestorage-crud.spec.ts` and `permissions.spec.ts` pass locally
- [ ] Biome check passes on all modified `.ts` files
- [ ] No production code was changed — only test assertions and test URLs corrected to match actual server behavior