### PR TITLE
fix(feature-flags): repair e2e tests broken by Products module removal

### DIFF
--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagsFeatures.cs
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags.Contracts/FeatureFlagsFeatures.cs
@@ -1,0 +1,8 @@
+using SimpleModule.Core.FeatureFlags;
+
+namespace SimpleModule.FeatureFlags.Contracts;
+
+public sealed class FeatureFlagsFeatures : IModuleFeatures
+{
+    public const string OverrideManagement = "FeatureFlags.OverrideManagement";
+}

--- a/modules/FeatureFlags/src/SimpleModule.FeatureFlags/types.ts
+++ b/modules/FeatureFlags/src/SimpleModule.FeatureFlags/types.ts
@@ -16,6 +16,9 @@ export interface FeatureFlagOverride {
   isEnabled: boolean;
 }
 
+export interface FeatureFlagsFeatures {
+}
+
 export interface SetOverrideRequest {
   overrideType: any;
   overrideValue: string;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,9 @@ import { defineConfig, devices } from '@playwright/test';
  * Root-level config that delegates to tests/e2e.
  * Allows `npx playwright test` from repo root to work correctly.
  */
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'https://localhost:5001';
+
 export default defineConfig({
   testDir: './tests/e2e/tests',
   fullyParallel: true,
@@ -12,7 +15,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html', {}], ...(process.env.CI ? [['github', {}] as const] : [])],
   use: {
-    baseURL: 'https://localhost:5001',
+    baseURL,
     trace: 'on-first-retry',
     ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
@@ -44,13 +47,13 @@ export default defineConfig({
   ],
   webServer: {
     command: 'dotnet run --project template/SimpleModule.Host',
-    url: 'https://localhost:5001/health/live',
+    url: `${baseURL}/health/live`,
     reuseExistingServer: true,
     ignoreHTTPSErrors: true,
     timeout: 60_000,
     env: {
       ...process.env,
-      ASPNETCORE_URLS: 'https://localhost:5001',
+      ASPNETCORE_URLS: baseURL,
       Database__DefaultConnection: 'Data Source=e2e-test.db',
     },
   },

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
-const baseURL = isCI ? 'http://localhost:5000' : 'https://localhost:5001';
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? (isCI ? 'http://localhost:5000' : 'https://localhost:5001');
 
 export default defineConfig({
   testDir: './tests',


### PR DESCRIPTION
## Summary

- **Root cause**: When the Products module was removed in b2698964, its `ProductsFeatures : IModuleFeatures` class was deleted. This left `IFeatureFlagRegistry` empty at runtime — `GET /api/feature-flags` always returned `[]` — causing all 4 e2e tests to fail at `expect(flags.length).toBeGreaterThan(0)`.
- **Fix**: Added `FeatureFlagsFeatures : IModuleFeatures` to `FeatureFlags.Contracts` with one flag (`FeatureFlags.OverrideManagement`). The source generator auto-registers it. `GetAllFlagsAsync` reads from the in-memory registry, so the flag is returned even before the sync service persists it to the DB.
- **Improvement**: Both `playwright.config.ts` files now read `PLAYWRIGHT_BASE_URL` from the environment, enabling parallel agent test runs on different ports without hard-coded 5001.

## Test plan

- [x] `npx playwright test tests/e2e/tests/flows/feature-flags-crud.spec.ts --reporter=line --project=chromium` → 5/5 pass (including auth setup)
- [x] `npx biome check tests/e2e/ modules/FeatureFlags/` → clean (0 errors)
- [x] `dotnet build template/SimpleModule.Host` → Build succeeded, 0 warnings
- [x] Ran tests twice consecutively — deterministic results