### PR TITLE
fix(events): neutralize MaintenanceModeMiddleware in test factory

### DIFF
--- a/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
+++ b/tests/SimpleModule.Tests.Shared/Fixtures/SimpleModuleWebApplicationFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using SimpleModule.AuditLogs;
 using SimpleModule.BackgroundJobs;
+using SimpleModule.Core.Maintenance;
 using SimpleModule.Database;
 using SimpleModule.Email;
 using SimpleModule.FeatureFlags;
@@ -91,6 +92,19 @@ public partial class SimpleModuleWebApplicationFactory : WebApplicationFactory<P
             RemoveHostedService<SimpleModule.Email.Jobs.EmailJobRegistrationHostedService>(
                 services
             );
+
+            // Replace the file-based maintenance state provider with a no-op so that
+            // a leftover .maintenance sentinel on the developer's machine (or a CI
+            // agent that ran `sm down`) cannot block API requests and cause spurious
+            // test failures with 503 responses.
+            var maintenanceDescriptor = services.SingleOrDefault(d =>
+                d.ServiceType == typeof(IMaintenanceStateProvider)
+            );
+            if (maintenanceDescriptor is not null)
+            {
+                services.Remove(maintenanceDescriptor);
+            }
+            services.AddSingleton<IMaintenanceStateProvider, NullMaintenanceStateProvider>();
 
             // Add test authentication scheme that bypasses OpenIddict validation
             services.AddTestAuthentication();
@@ -181,5 +195,15 @@ public partial class SimpleModuleWebApplicationFactory : WebApplicationFactory<P
             // an empty temp DB is acceptable for test cleanup.
         }
 #pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// Always reports the application as live. Prevents a stale <c>.maintenance</c>
+    /// sentinel on the developer's machine from returning 503 for every test request.
+    /// </summary>
+    private sealed class NullMaintenanceStateProvider : IMaintenanceStateProvider
+    {
+        public ValueTask<MaintenanceState?> GetAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<MaintenanceState?>(null);
     }
 }


### PR DESCRIPTION
## What was broken

`PublishedEvent_Survives_The_Durable_Pipeline_End_To_End` was failing with:

```
Expected response.IsSuccessStatusCode to be True, but found False.
```

The root cause: the `feat(maintenance)` commit (#201) wired `FileSystemMaintenanceStateProvider` into the request pipeline unconditionally. `WebApplicationFactory<Program>` resolves its content root to `template/SimpleModule.Host/` (where it finds `appsettings.json`). When a developer runs `sm down` locally and leaves the `.maintenance` sentinel file in that directory, the maintenance middleware returns **503 Service Unavailable** for every non-health request — including the `PUT /api/settings` this test makes.

## What fixed it

`SimpleModuleWebApplicationFactory.ConfigureWebHost` now replaces `IMaintenanceStateProvider` with `NullMaintenanceStateProvider`, which always returns `null` (app is live). The maintenance middleware passes through unconditionally in tests, regardless of whether a `.maintenance` file exists on the developer's machine or a CI runner that previously ran `sm down`.

This follows the same pattern used for seed services and DB context replacements in the factory.

## How verified

1. Confirmed the failure: created `template/SimpleModule.Host/.maintenance` → test fails with 503.
2. Applied fix, rebuilt: test passes with `.maintenance` present.
3. Removed `.maintenance`, ran full Core.Tests suite: **210 / 210 pass**.