### PR TITLE
docs: sync site against recent framework changes

### DIFF
--- a/docs/site/.vitepress/config.ts
+++ b/docs/site/.vitepress/config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
           items: [
             { text: 'Modules', link: '/guide/modules' },
             { text: 'Endpoints', link: '/guide/endpoints' },
+            { text: 'Form Requests', link: '/guide/form-requests' },
             { text: 'Contracts & DTOs', link: '/guide/contracts' },
             { text: 'Database', link: '/guide/database' },
             { text: 'Soft Delete', link: '/guide/soft-delete' },

--- a/docs/site/frontend/components.md
+++ b/docs/site/frontend/components.md
@@ -64,6 +64,9 @@ This avoids class conflicts (e.g., `p-4` and `p-2` don't both end up in the DOM 
 | `Skeleton` | Loading placeholder |
 | `Spinner` | Loading spinner with size variants |
 | `Progress` | Progress bar |
+| `Stat` | Dashboard metric tile -- value, unit, label, trend, and optional `interactive`/`lift` |
+| `EmptyState` | Standard empty-state block with icon, title, description, and action slots |
+| `FilterBar` | Toolbar for list pages with `search`, `controls`, and `actions` slots |
 
 ### Navigation
 
@@ -80,8 +83,11 @@ This avoids class conflicts (e.g., `p-4` and `p-2` don't both end up in the DOM 
 
 | Component | Description |
 |---|---|
-| `Button` | Button with variants (`primary`, `secondary`, `ghost`, `danger`, `outline`) and sizes (`sm`, `default`, `lg`) |
+| `Button` | Button with variants (`primary`, `secondary`, `ghost`, `danger`, `outline`) and sizes (`sm`, `default`, `lg`, `icon`) |
 | `Input` | Text input with variants |
+| `SearchInput` | Search field with a leading icon and optional `shortcut` hint |
+| `NumberInput` | Numeric input with stepper buttons; clamps to `min`/`max` |
+| `Kbd` | Inline keyboard key cap (e.g. `⌘K`) |
 | `Textarea` | Multi-line text input |
 | `Checkbox` | Checkbox input |
 | `RadioGroup` | Radio button group (`RadioGroup`, `RadioGroupItem`) |
@@ -189,9 +195,52 @@ export default function Manage({ customers }) {
       description="Manage your customer list."
       columns={columns}
       data={customers}
+      // Shown automatically when data is empty:
+      emptyTitle="No customers yet"
+      emptyDescription="Create your first customer to get started."
     />
   );
 }
+```
+
+`DataGridPage` renders an `EmptyState` internally when `data` is empty; `emptyTitle`, `emptyDescription`, `emptyIcon`, and `emptyAction` customize it.
+
+### Dashboard Stats
+
+```tsx
+import { Stat } from '@simplemodule/ui';
+
+<div className="grid gap-4 sm:grid-cols-3">
+  <Stat label="Active users" value={1284} trend="up" change="+12% vs last week" />
+  <Stat label="Avg. latency" value={98} unit="ms" trend="down" />
+  <Stat label="Error rate" value="0.4%" trend="flat" onClick={openDetails} />
+</div>
+```
+
+When `onClick` is provided, `Stat` renders as a keyboard-accessible `<button>` and turns on the `interactive` affordance.
+
+### Filter Bar with Search
+
+```tsx
+import { FilterBar, SearchInput, Button } from '@simplemodule/ui';
+
+<FilterBar
+  search={<SearchInput placeholder="Search customers" shortcut="⌘K" />}
+  controls={<Button variant="secondary" size="sm">Filters</Button>}
+  actions={<Button>New customer</Button>}
+/>
+```
+
+### Empty State
+
+```tsx
+import { EmptyState, Button } from '@simplemodule/ui';
+
+<EmptyState
+  title="No results"
+  description="Try adjusting your search or filters."
+  action={<Button variant="secondary">Clear search</Button>}
+/>
 ```
 
 ## Dependencies

--- a/docs/site/frontend/styling.md
+++ b/docs/site/frontend/styling.md
@@ -27,15 +27,18 @@ The `@simplemodule/theme-default` package (`packages/SimpleModule.Theme.Default/
 
 ### Color Tokens
 
+Colors are defined in **OKLCH** for perceptually even lightness and vivid, accessible hues. The palette is "quiet editorial" — emerald primary, rose danger, amber warning, sky info, with warm-leaning neutrals.
+
 #### Primary & Accent
 
 | Token | Light | Purpose |
 |---|---|---|
-| `--color-primary` | `#059669` | Primary actions, links, focus rings |
-| `--color-primary-hover` | `#047857` | Primary hover state |
-| `--color-primary-light` | `#34d399` | Light primary variant |
-| `--color-primary-subtle` | `rgba(5, 150, 105, 0.08)` | Subtle backgrounds |
-| `--color-accent` | `#0f766e` | Gradient endpoints, deep emphasis (teal) |
+| `--color-primary` | `oklch(0.62 0.16 158)` | Primary actions, links, focus rings (emerald) |
+| `--color-primary-hover` | `oklch(0.55 0.17 158)` | Primary hover state |
+| `--color-primary-light` | `oklch(0.78 0.16 158)` | Light primary variant |
+| `--color-primary-subtle` | `oklch(0.62 0.16 158 / 0.09)` | Subtle backgrounds |
+| `--color-primary-ring` | `oklch(0.62 0.16 158 / 0.32)` | Focus ring color |
+| `--color-accent` | `oklch(0.5 0.11 192)` | Deep emphasis (teal) |
 
 #### Semantic Colors
 
@@ -50,24 +53,49 @@ The `@simplemodule/theme-default` package (`packages/SimpleModule.Theme.Default/
 
 | Token | Light | Dark |
 |---|---|---|
-| `--color-surface` | `#ffffff` | `#0f172a` |
-| `--color-surface-raised` | `#f8fafc` | `#1e293b` |
-| `--color-surface-sunken` | `#f1f5f9` | `#0b1120` |
-| `--color-text` | `#0f172a` | `#f1f5f9` |
-| `--color-text-secondary` | `#475569` | `#94a3b8` |
-| `--color-text-muted` | `#94a3b8` | `#64748b` |
+| `--color-surface` | `oklch(1 0 0)` | `oklch(0.205 0.006 60)` |
+| `--color-surface-raised` | `oklch(0.985 0.003 80)` | `oklch(0.245 0.007 60)` |
+| `--color-surface-sunken` | `oklch(0.965 0.005 80)` | `oklch(0.16 0.006 60)` |
+| `--color-text` | `oklch(0.22 0.015 250)` | `oklch(0.96 0.005 80)` |
+| `--color-text-secondary` | `oklch(0.45 0.015 250)` | `oklch(0.74 0.008 80)` |
+| `--color-text-muted` | `oklch(0.62 0.012 250)` | `oklch(0.55 0.008 80)` |
 
-All tokens are accessible as Tailwind utilities. For example, `bg-surface`, `text-primary`, `border-border-strong`.
+Dark surfaces sit at hue 60 (toward amber) at very low chroma — a warm graphite that never reads as cold blue. All tokens are accessible as Tailwind utilities, for example `bg-surface`, `text-primary`, `border-border-strong`.
 
 ### Shadows
 
-The theme defines themeable shadows used by button components:
+The theme defines a layered, OKLCH-based shadow scale. `--shadow-xs` through `--shadow-xl` cover elevation; colored variants tint buttons:
 
 ```css
---shadow-primary: 0 4px 14px rgba(5, 150, 105, 0.35);
---shadow-primary-hover: 0 6px 20px rgba(5, 150, 105, 0.5);
---shadow-danger: 0 4px 14px rgba(225, 29, 72, 0.25);
---shadow-danger-hover: 0 6px 20px rgba(225, 29, 72, 0.4);
+--shadow-xs: 0 1px 2px 0 oklch(0.18 0.012 260 / 0.05);
+--shadow-sm: 0 1px 2px 0 oklch(0.18 0.012 260 / 0.06), 0 1px 3px 0 oklch(0.18 0.012 260 / 0.04);
+--shadow-md: 0 4px 8px -2px oklch(0.18 0.012 260 / 0.08), 0 2px 4px -2px oklch(0.18 0.012 260 / 0.05);
+--shadow-lg: 0 12px 24px -8px oklch(0.18 0.012 260 / 0.12), 0 4px 8px -4px oklch(0.18 0.012 260 / 0.06);
+--shadow-xl: 0 24px 48px -12px oklch(0.18 0.012 260 / 0.18), 0 8px 16px -8px oklch(0.18 0.012 260 / 0.08);
+--shadow-primary: 0 6px 18px -4px oklch(0.62 0.16 158 / 0.42), 0 2px 4px -2px oklch(0.62 0.16 158 / 0.25);
+--shadow-danger: 0 6px 18px -4px oklch(0.6 0.21 17 / 0.32);
+```
+
+In dark mode the elevation shadows deepen and the primary shadow becomes a colored glow.
+
+### Motion, Layering & Opacity
+
+The theme also exposes scales for animation, stacking, and opacity so components stay consistent:
+
+```css
+/* Motion */
+--duration-instant: 80ms;  --duration-fast: 150ms;  --duration-base: 200ms;
+--duration-moderate: 300ms;  --duration-slow: 500ms;
+--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+--ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+/* Z-index stack */
+--z-sticky: 10;  --z-overlay: 20;  --z-sidebar: 40;  --z-dropdown: 50;
+--z-modal: 60;  --z-toast: 80;  --z-tooltip: 90;
+
+/* Opacity */
+--opacity-disabled: 0.45;  --opacity-muted: 0.65;
+--opacity-overlay: 0.78;  --opacity-backdrop: 0.5;
 ```
 
 ## Dark Mode {#dark-mode}
@@ -76,11 +104,11 @@ Dark mode is built into the theme via the `.dark` class selector. When the `.dar
 
 ```css
 .dark {
-  --color-surface: #0f172a;
-  --color-surface-raised: #1e293b;
-  --color-text: #f1f5f9;
-  --color-text-secondary: #94a3b8;
-  --color-border: #1e293b;
+  --color-surface: oklch(0.205 0.006 60);
+  --color-surface-raised: oklch(0.245 0.007 60);
+  --color-text: oklch(0.96 0.005 80);
+  --color-text-secondary: oklch(0.74 0.008 80);
+  --color-border: oklch(0.3 0.008 60);
   /* ... all tokens are overridden */
 }
 ```
@@ -94,14 +122,18 @@ The theme provides pre-built CSS component classes in the `@layer components` bl
 ### Buttons
 
 ```css
-.btn-primary     /* Gradient background, white text, elevated shadow */
+.btn-primary     /* Flat solid emerald, white text, elevated shadow */
 .btn-secondary   /* Surface background, bordered */
 .btn-ghost       /* Transparent, subtle hover */
-.btn-danger      /* Red background, elevated shadow */
+.btn-danger      /* Solid rose background, elevated shadow */
 .btn-outline     /* Transparent, primary border */
 .btn-sm          /* Small size modifier */
 .btn-lg          /* Large size modifier */
 ```
+
+::: tip
+Design-system v2 removed gradient surface treatments — the primary button and accents are now flat solid color. Legacy helpers like `.gradient-text` are kept for compatibility but render as solid primary.
+:::
 
 ### Cards & Surfaces
 
@@ -132,21 +164,36 @@ The theme provides pre-built CSS component classes in the `@layer components` bl
 ### Utilities
 
 ```css
-.gradient-text       /* Gradient-filled text */
-.gradient-border     /* Gradient border using mask technique */
-.bg-mesh             /* Animated background gradient mesh */
+.font-display        /* Fraunces display serif (headings, stat values) */
+.font-body           /* Geist body sans */
+.dash-stat           /* Large display-font metric value */
+.dash-label          /* Small uppercase metric label */
+.gradient-text       /* Compatibility shim — now renders solid primary */
+.gradient-border     /* Primary border using mask technique */
+.bg-mesh             /* Flat ambient background fill */
 .spinner             /* CSS loading spinner */
+```
+
+### Tables
+
+Base table styles ship globally. Row-hover is **opt-in** — set `data-interactive` on the `<table>` so read-only tables (recovery codes, dashboard lists) don't pick up an interactive cue. Add the `.num` class to a `td`/`th` for right-aligned, tabular-figure numeric columns.
+
+```html
+<table data-interactive>
+  <thead><tr><th>Name</th><th class="num">Requests</th></tr></thead>
+  ...
+</table>
 ```
 
 ## Typography
 
-The theme sets two font families:
+The theme sets three font families, exposed as `--font-body`, `--font-display`, and `--font-mono`:
 
-- **Body text**: `"DM Sans"`, system-ui, sans-serif
-- **Headings**: `"Sora"`, "DM Sans", system-ui, sans-serif
-- **Code**: `"JetBrains Mono"`, "Fira Code", monospace
+- **Body text** (`--font-body`): `"Geist"`, "Inter", system-ui, sans-serif
+- **Display / headings** (`--font-display`): `"Fraunces"`, serif fallbacks
+- **Code** (`--font-mono`): `"JetBrains Mono"`, "Fira Code", monospace
 
-Headings (`h1`-`h6`) are styled in the base layer with tight tracking and bold weight.
+Headings (`h1`-`h6`) use the display serif with tight tracking. Apply `.font-display` or `.font-body` directly when you need the family on non-heading elements (for example, stat values).
 
 ## Theme Customization
 

--- a/docs/site/guide/endpoints.md
+++ b/docs/site/guide/endpoints.md
@@ -400,6 +400,10 @@ app.MapGet("/", (ICustomerContracts customers) => ...);
 
 ## Validation
 
+::: tip Prefer Form Requests
+For most endpoints, the recommended approach is a [Form Request](/guide/form-requests) — a `[FormRequest]` class that binds, authorizes, normalizes, and validates the request body before your handler runs. The manual `IValidator<T>` pattern below still works and is useful when a contract DTO is validated in several places.
+:::
+
 Request validation uses **[FluentValidation](https://docs.fluentvalidation.net/)**. Write an `AbstractValidator<T>` for every request DTO that needs validation.
 
 ```csharp

--- a/docs/site/guide/form-requests.md
+++ b/docs/site/guide/form-requests.md
@@ -1,0 +1,192 @@
+---
+outline: deep
+---
+
+# Form Requests
+
+A **Form Request** bundles request binding, authorization, normalization, and validation for a single endpoint into one class. Instead of injecting `IValidator<T>` and checking results by hand in every handler, you declare a `[FormRequest]` type, accept it as a handler parameter, and the framework runs the full pipeline before your handler body executes.
+
+The pattern is inspired by Laravel's form requests and lives in `SimpleModule.Core.FormRequests`.
+
+## At a Glance
+
+```csharp
+[FormRequest]
+public sealed partial class CreateTemplateFormRequest : FormRequest<CreateTemplateFormRequest>
+{
+    public string Name { get; set; } = "";
+    public string Slug { get; set; } = "";
+    public string Subject { get; set; } = "";
+    public string Body { get; set; } = "";
+    public bool IsHtml { get; set; } = true;
+
+    public override void Prepare()
+    {
+        Name = Name.Trim();
+        Slug = Slug.Trim().ToLowerInvariant();
+    }
+
+    protected override void ConfigureRules(RuleConfigurator<CreateTemplateFormRequest> rules)
+    {
+        rules.RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        rules.RuleFor(x => x.Slug).NotEmpty().MaximumLength(200);
+        rules.RuleFor(x => x.Subject).NotEmpty().MaximumLength(500);
+        rules.RuleFor(x => x.Body).NotEmpty();
+    }
+}
+```
+
+```csharp
+public class CreateTemplateEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app) =>
+        app.MapPost("/templates",
+            // Bound, authorized, prepared, and validated before this runs:
+            async (CreateTemplateFormRequest request, IEmailContracts email) =>
+            {
+                // request.Name is trimmed; all rules have passed.
+                ...
+            })
+            .RequirePermission(EmailPermissions.ManageTemplates);
+}
+```
+
+## The Pipeline
+
+When a handler parameter is a `FormRequest`, the `FormRequestEndpointFilter` intercepts the call and runs these steps in order, for each form-request argument, before the handler:
+
+1. **Bind** — ASP.NET minimal-API model binding deserializes the request (route → query → body) into the form-request's public properties.
+2. **Authorize** — `Authorize(ClaimsPrincipal user)` runs. Returning `false` short-circuits with **403 Forbidden**.
+3. **Prepare** — `Prepare()` normalizes the bound data (trim, lower-case, defaulting).
+4. **Validate** — the cached FluentValidation validator runs. Failures short-circuit with **422 Unprocessable Entity**.
+5. **Handler** — only now does your handler execute, with a normalized and valid request.
+
+The filter is registered automatically — the source generator appends `.AddFormRequestFilter()` to every module's route group, so you never wire it up yourself.
+
+## Defining Rules
+
+Override `ConfigureRules` and use `RuleConfigurator<TSelf>`, a thin wrapper over FluentValidation's `InlineValidator<T>`:
+
+```csharp
+protected override void ConfigureRules(RuleConfigurator<UpdateSettingFormRequest> rules)
+{
+    rules.RuleFor(x => x.Key)
+        .NotEmpty().WithMessage("Setting key is required.")
+        .MaximumLength(256);
+
+    // Conditional rule
+    rules.RuleFor(x => x.Key)
+        .Must(BeValidKey).WithMessage("Invalid key format.")
+        .When(x => !string.IsNullOrEmpty(x.Key));
+
+    rules.RuleFor(x => x.Scope).IsInEnum();
+}
+```
+
+`RuleConfigurator<T>` exposes:
+
+| Method | Purpose |
+|--------|---------|
+| `RuleFor(expr)` | Standard FluentValidation rule builder for a property |
+| `RuleForEach(expr)` | Rules for each item in a collection property |
+| `When(predicate, action)` | Apply the rules in `action` only when `predicate` is true |
+| `Unless(predicate, action)` | Apply the rules in `action` unless `predicate` is true |
+
+The validator is built once per type and cached, so rule configuration runs only on the first request.
+
+## Authorization & Preparation
+
+Both hooks are optional virtual methods on the base `FormRequest`:
+
+```csharp
+public abstract class FormRequest
+{
+    public virtual bool Authorize(ClaimsPrincipal user) => true; // allow by default
+    public virtual void Prepare() { }                            // no-op by default
+}
+```
+
+- **`Authorize`** lets a request enforce per-instance authorization beyond a static permission check — for example, "the target record belongs to the current user". Returning `false` yields a 403 before validation runs.
+- **`Prepare`** normalizes input *before* validation, so your rules can assume clean data (trimmed strings, canonical casing).
+
+`Prepare` always runs before `Validate`, whether the pipeline invokes it (via the filter) or you call `ValidateRulesAsync()` directly in a test.
+
+## Error Responses
+
+The filter is Inertia-aware. The same failure produces a JSON API response or a rendered error page depending on the request:
+
+| Failure | API request | Inertia request |
+|---------|-------------|-----------------|
+| `Authorize` returns `false` | `403` Problem Details | `Error/403` page |
+| Validation fails | `422` Problem Details with an `errors` map | `Error/422` page with errors |
+
+A validation failure on an API endpoint returns RFC 7807 Problem Details:
+
+```json
+{
+  "title": "Validation Error",
+  "status": 422,
+  "detail": "One or more validation errors occurred.",
+  "errors": {
+    "Name": ["Customer name is required."],
+    "Scope": ["'Scope' has an invalid value."]
+  }
+}
+```
+
+See [Error Pages](/guide/error-pages) for the global error-rendering pipeline.
+
+## TypeScript Generation
+
+`[FormRequest]` types are emitted to the module's generated `types.ts` exactly like `[Dto]` types, so the frontend gets a typed interface for the request body for free:
+
+```ts
+// modules/Email/src/SimpleModule.Email/types.ts (generated)
+export interface CreateTemplateFormRequest {
+  name: string;
+  slug: string;
+  subject: string;
+  body: string;
+  isHtml: boolean;
+}
+```
+
+## Source-Generator Rules
+
+The generator discovers `[FormRequest]` classes and enforces two diagnostics at compile time:
+
+| Diagnostic | Rule |
+|-----------|------|
+| `SM0056` | A `[FormRequest]` class must be `sealed` |
+| `SM0057` | A `[FormRequest]` class must extend `FormRequest<TSelf>` |
+
+Declare the class `sealed partial` (partial so the generator can extend it) and the constraint resolves itself.
+
+## Testing
+
+Because the validator is self-contained, you can exercise rules without spinning up the HTTP pipeline. `ValidateRulesAsync()` runs `Prepare()` and then validation:
+
+```csharp
+[Fact]
+public async Task EmptyName_FailsValidation()
+{
+    var request = new CreateTemplateFormRequest { Name = "", Subject = "Hi", Body = "..." };
+
+    var result = await request.ValidateRulesAsync();
+
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+}
+```
+
+Integration tests can assert the end-to-end response shape instead — posting an invalid body and checking for a `422` with the expected field error.
+
+## Relationship to Manual Validation
+
+Form Requests are the recommended way to validate request input for new endpoints. The older pattern — injecting `IValidator<T>` and calling `ValidateAsync` inside the handler — still works and is documented under [Endpoints → Validation](/guide/endpoints#validation). Prefer a Form Request when an endpoint has its own request shape; reach for a standalone `AbstractValidator<T>` when a contract DTO is validated in several places.
+
+## Next Steps
+
+- [Endpoints](/guide/endpoints) — how endpoints are discovered, mapped, and bound.
+- [Contracts & DTOs](/guide/contracts) — the `[Dto]` types that also drive TypeScript generation.
+- [Error Pages](/guide/error-pages) — how `403`/`422` responses are rendered for API and Inertia callers.

--- a/docs/site/guide/identity.md
+++ b/docs/site/guide/identity.md
@@ -199,6 +199,40 @@ builder.Services.AddScoped<IAccountUnlockEmailSender, MailgunAccountUnlockEmailS
 
 The account manage page uses `ISmsSender` for phone verification codes. Default `ConsoleSmsSender` logs to console. Provide a Twilio/Vonage/AWS SNS implementation for production.
 
+## Two-factor authentication and recovery codes
+
+Users manage two-factor authentication from `/Identity/Account/Manage/TwoFactorAuthentication`. Enabling an authenticator app walks through setup → verify a code → view recovery codes. Recovery codes let a user sign in if they lose their authenticator device.
+
+### Generating recovery codes
+
+The generate flow lives at `/Identity/Account/Manage/GenerateRecoveryCodes`:
+
+| Method | Behaviour |
+|--------|-----------|
+| `GET` | Renders the confirmation page (2FA must be enabled) |
+| `POST` | Generates 10 new codes via `UserManager.GenerateNewTwoFactorRecoveryCodesAsync` and renders them once |
+
+Codes are **hashed at rest**, exactly like passwords — the plaintext is shown only at generation time. There is no "retrieve codes" API by design; if a user loses them, they regenerate, which invalidates the previous set.
+
+### Download and print
+
+The page that shows freshly generated codes (`ShowRecoveryCodes`) offers two ways to save them off-screen:
+
+- **Download** — builds a `simplemodule-recovery-codes.txt` file in the browser with a header line (`generated for {email} on {date}`) followed by one code per line.
+- **Print** — calls `window.print()` with a scoped `@media print` stylesheet that hides page chrome and prints only the codes as black-on-white monospace.
+
+Both run entirely client-side; the codes never make a second round-trip to the server.
+
+### Remaining-codes status
+
+The two-factor page reflects how many codes are left:
+
+| Codes remaining | Treatment |
+|-----------------|-----------|
+| 4 or more | Neutral status line ("Recovery codes: N remaining") |
+| 2–3 | Warning alert with a link to regenerate |
+| 0–1 | Danger alert with a link to regenerate |
+
 ## Next Steps
 
 - [Permissions](/guide/permissions) — claims-based authorization layered on top of identity.

--- a/docs/site/guide/settings.md
+++ b/docs/site/guide/settings.md
@@ -71,8 +71,15 @@ Each setting is described by a `SettingDefinition`:
 | `Description` | `string?` | Optional help text |
 | `Group` | `string?` | Groups related settings in the UI |
 | `Scope` | `SettingScope` | Where the setting applies |
-| `DefaultValue` | `string?` | Default value stored as a raw string (e.g. `"90"`, `"true"`, `"SimpleModule"`) — it does not need to be JSON-encoded |
-| `Type` | `SettingType` | Value type for UI rendering |
+| `DefaultValue` | `string?` | Default value stored as a raw string (e.g. `"90"`, `"true"`, `"SimpleModule"`) -- it does not need to be JSON-encoded |
+| `Type` | `SettingType` | Value type -- drives the input control and validation |
+| `AllowedValues` | `IReadOnlyList<string>?` | Permitted values for a `Select` setting |
+| `Min` / `Max` | `double?` | Inclusive bounds for a `Number` setting |
+| `Pattern` | `string?` | Regex applied to `Text` / `Password` / `MultilineText` values |
+| `Required` | `bool` | When `true`, an empty value is rejected |
+| `Sensitive` | `bool` | Masks the value in API responses (see [Sensitive Settings](#sensitive-settings)) |
+| `Order` | `int` | Sort order within a group in the admin UI |
+| `Placeholder` | `string?` | Placeholder text for the input control |
 
 ### SettingScope
 
@@ -93,17 +100,84 @@ public enum SettingScope
 
 ### SettingType
 
-The type determines how the setting is rendered in the admin UI:
+The type determines the input control rendered in the admin UI and the validation applied when a value is saved:
 
 ```csharp
 public enum SettingType
 {
-    Text = 0,   // Single-line text input
-    Number = 1, // Numeric input
-    Bool = 2,   // Toggle switch
-    Json = 3,   // JSON editor
+    Text = 0,          // Single-line text input
+    Number = 1,        // Numeric input (honours Min / Max)
+    Bool = 2,          // Toggle switch
+    Json = 3,          // JSON editor (wide row)
+    Select = 4,        // Dropdown bound to AllowedValues
+    Color = 5,         // Hex colour picker (#RRGGBB)
+    Url = 6,           // Absolute http/https URL
+    Email = 7,         // Email address
+    Password = 8,      // Masked input; usually paired with Sensitive = true
+    MultilineText = 9, // Textarea (wide row)
+    DateTime = 10,     // ISO 8601 date-time
 }
 ```
+
+### Field Types and Validation
+
+Each type maps to a dedicated input component on the frontend and a server-side rule in `SettingValidator`. Values are validated both when written through the API and before persistence:
+
+| Type | Renders as | Validation |
+|------|-----------|------------|
+| `Text` | Text input | `Required`, optional `Pattern` |
+| `Number` | Number input | Must parse as a number; honours `Min` / `Max` |
+| `Bool` | Toggle switch | Must be `true` / `false` |
+| `Json` | JSON editor | Must be valid JSON |
+| `Select` | Dropdown | Must be one of `AllowedValues` |
+| `Color` | Colour picker | Must match `#RRGGBB` |
+| `Url` | URL input | Must be an absolute `http`/`https` URL |
+| `Email` | Email input | Must be a valid email address |
+| `Password` | Masked input | `Required`, optional `Pattern`; set `Sensitive = true` to mask in responses |
+| `MultilineText` | Textarea | `Required`, optional `Pattern` |
+| `DateTime` | Date-time input | Must parse as an ISO 8601 date-time |
+
+`Email`, `Url`, `Color`, and `DateTime` apply their own format check and ignore `Pattern` to avoid duplicate errors. When a value fails validation, write operations return **422 Unprocessable Entity** with the errors keyed by setting key (the service throws `SettingValidationException`, which carries the `Key` and a list of `Errors`).
+
+```csharp
+// A Select with a fixed set of choices
+.Add(new SettingDefinition
+{
+    Key = "app.theme",
+    DisplayName = "Theme",
+    Group = "Appearance",
+    Scope = SettingScope.User,
+    Type = SettingType.Select,
+    AllowedValues = ["light", "dark", "system"],
+    DefaultValue = "system",
+})
+// A bounded Number
+.Add(new SettingDefinition
+{
+    Key = "auditlogs.retention.days",
+    DisplayName = "Retention Days",
+    Group = "Audit Logs",
+    Scope = SettingScope.System,
+    Type = SettingType.Number,
+    Min = 1,
+    Max = 3650,
+    DefaultValue = "90",
+})
+// A sensitive secret
+.Add(new SettingDefinition
+{
+    Key = "email.smtp.password",
+    DisplayName = "SMTP Password",
+    Group = "Email",
+    Scope = SettingScope.System,
+    Type = SettingType.Password,
+    Sensitive = true,
+});
+```
+
+### Sensitive Settings
+
+Mark secrets with `Sensitive = true`. Their stored value is **never returned** by the list/get endpoints -- the DTO's `Value` comes back as `null` and the UI shows a "set" placeholder rather than the secret. To read the actual value at runtime, use the typed contract (`GetSettingAsync<T>`) or the [resolved endpoint](#resolved-and-decoded-values) from server code; do not round-trip secrets through the browser.
 
 ## Real-World Example
 
@@ -153,14 +227,29 @@ The Settings module exposes `ISettingsContracts` for other modules to read and w
 ```csharp
 public interface ISettingsContracts
 {
+    // Read a stored value as a string, or typed
     Task<string?> GetSettingAsync(string key, SettingScope scope, string? userId = null);
     Task<T?> GetSettingAsync<T>(string key, SettingScope scope, string? userId = null);
+
+    // Resolve a user setting through the fallback chain (user -> app -> default)
     Task<string?> ResolveUserSettingAsync(string key, string userId);
-    Task SetSettingAsync(string key, string value, SettingScope scope, string? userId = null);
+    Task<JsonElement?> ResolveUserSettingElementAsync(string key, string userId);
+
+    // Write
+    Task SetSettingAsync(string key, JsonElement value, SettingScope scope, string? userId = null);
+    Task SetManyAsync(IReadOnlyList<BulkSettingUpdate> updates);
     Task DeleteSettingAsync(string key, SettingScope scope, string? userId = null);
-    Task<IEnumerable<Setting>> GetSettingsAsync(SettingsFilter? filter = null);
+    Task ResetToDefaultAsync(string key, SettingScope scope, string? userId = null);
+
+    // DTO-shaped reads (apply masking for sensitive settings)
+    Task<IEnumerable<SettingValueDto>> GetSettingValuesAsync(SettingsFilter? filter = null);
+    Task<SettingValueDto?> GetSettingValueAsync(string key, SettingScope scope, string? userId = null);
 }
 ```
+
+::: warning Values are `JsonElement`
+`SetSettingAsync` takes a `System.Text.Json.JsonElement`, not a string, so values are stored and round-tripped as typed JSON. The DTO reads (`GetSettingValuesAsync` / `GetSettingValueAsync`) return `SettingValueDto`, whose `Value` is `null` for sensitive settings.
+:::
 
 ### Reading Settings
 
@@ -193,18 +282,76 @@ public class MyService(ISettingsContracts settings)
 var theme = await settings.ResolveUserSettingAsync("app.theme", userId);
 ```
 
-### Writing Settings
+### Resolved and Decoded Values
+
+`ResolveUserSettingAsync` returns the resolved value as a string; `ResolveUserSettingElementAsync` returns it as a `JsonElement` (the *decoded* value, even for sensitive settings). The latter backs the `GET /api/settings/{key}/resolved` endpoint, which the UI uses to show a user the effective value (their override, or the inherited default) without exposing raw stored secrets in list responses.
 
 ```csharp
+// Decoded fallback value for the current user
+var theme = await settings.ResolveUserSettingElementAsync("app.theme", userId);
+```
+
+### Writing Settings
+
+Values are passed as `JsonElement`:
+
+```csharp
+using System.Text.Json;
+
+JsonElement Json<T>(T value) => JsonSerializer.SerializeToElement(value);
+
 // Set an application setting
-await settings.SetSettingAsync("app.title", "My App", SettingScope.Application);
+await settings.SetSettingAsync("app.title", Json("My App"), SettingScope.Application);
 
 // Set a user preference
-await settings.SetSettingAsync("app.theme", "dark", SettingScope.User, userId);
+await settings.SetSettingAsync("app.theme", Json("dark"), SettingScope.User, userId);
+
+// Reset to the definition's default (same as deleting the stored value)
+await settings.ResetToDefaultAsync("app.theme", SettingScope.User, userId);
 
 // Delete a user override (reverts to application default)
 await settings.DeleteSettingAsync("app.theme", SettingScope.User, userId);
 ```
+
+### Bulk Updates
+
+`SetManyAsync` writes several settings in one call, validating each. User-scoped entries are rejected -- use the per-user endpoints for those.
+
+```csharp
+await settings.SetManyAsync(
+[
+    new BulkSettingUpdate { Key = "app.title", Scope = SettingScope.Application, Value = Json("My App") },
+    new BulkSettingUpdate { Key = "auditlogs.retention.days", Scope = SettingScope.System, Value = Json(30) },
+]);
+```
+
+## HTTP API
+
+The Settings module exposes a REST surface under `/api/settings`. Read endpoints require authentication; write endpoints require the `Settings.Update` permission.
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/settings` | List settings (filterable by scope/group), with sensitive values masked |
+| `GET` | `/api/settings/{key}?scope=` | Get a single setting (the `scope` query param is required) |
+| `GET` | `/api/settings/{key}/resolved` | Resolved, decoded value for the current user |
+| `GET` | `/api/settings/definitions` | All setting definitions |
+| `PUT` | `/api/settings` | Update one system/application setting |
+| `PUT` | `/api/settings/bulk` | Update many system/application settings |
+| `DELETE` | `/api/settings/{key}?scope=` | Reset a setting to its default |
+| `GET` | `/api/settings/me` | The current user's settings with resolved fallbacks |
+| `PUT` | `/api/settings/me` | Update one of the current user's settings |
+| `DELETE` | `/api/settings/me/{key}` | Clear a user override (revert to the app default) |
+
+The single `PUT`/`DELETE` and the bulk endpoint reject `User`-scoped writes with **400 Bad Request** -- user preferences go through the `/me` endpoints.
+
+## Admin and User UI
+
+Two redesigned pages ship with the module:
+
+- **Admin settings** (`/settings/manage`) -- system and application settings grouped and searchable, with per-scope tabs, a **bulk-edit** mode that batches changes into a single save, scope/override badges, and a per-row reset to default.
+- **User settings** (`/settings/me`) -- the signed-in user's preferences, showing the effective value with an annotation for whether it is the user's override or an inherited default, plus a reset that clears the override.
+
+Both pages render the input control for each `SettingType` automatically and surface validation errors returned by the API inline.
 
 ## Settings Definition Registry
 


### PR DESCRIPTION
Catches the documentation site up with framework PRs merged since the last sync (#208).

## What changed

- **Settings (#211)** — `guide/settings.md`: the 11 `SettingType` field types and their per-type validation, the new `SettingDefinition` metadata (`AllowedValues`, `Min`/`Max`, `Pattern`, `Required`, `Sensitive`, `Order`, `Placeholder`), sensitive-value masking, the `JsonElement`-based `ISettingsContracts`, resolved/decoded values, bulk updates, the full HTTP API reference, and the redesigned admin/user settings UI.
- **Form Requests (#215)** — new `guide/form-requests.md`: the `[FormRequest]` pipeline (bind → authorize → prepare → validate), rule configuration, `403`/`422` responses, TypeScript generation, and the `SM0056`/`SM0057` diagnostics. Cross-linked from the Endpoints "Validation" section and added to the sidebar.
- **Design system v2 (#210)** — `frontend/components.md` & `frontend/styling.md`: add `Stat`, `EmptyState`, `FilterBar`, `SearchInput`, `NumberInput`, and `Kbd`; refresh tokens to OKLCH colours, Geist/Fraunces fonts, the layered shadow scale, and the new motion/z-index/opacity scales; note flat (non-gradient) surfaces and opt-in (`data-interactive`) table row hover.
- **Recovery codes (#203)** — `guide/identity.md`: two-factor recovery-code generation, download/print, and the remaining-codes status.

## Notes

- Identity provider docs (#216) already shipped with that PR (`guide/identity.md` was updated there), so nothing to add for it here beyond the recovery-codes section.
- The shared dev-services note (#217) is deliberately left in `CLAUDE.md` — it's a local-dev convenience tied to a personal `~/Repos` layout, not a framework capability, so it doesn't belong on the public site.

## Verification

`vitepress build` on `docs/site` passes with dead-link checking enabled, so every new internal link and anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
