### PR TITLE
fix(docs): make VitePress deploy self-contained (drop @simplemodule/tsconfig from root tsconfig)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,17 @@
 {
-  "extends": "@simplemodule/tsconfig/base",
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "paths": {
       "@/*": ["./template/SimpleModule.Host/ClientApp/*"]
     }


### PR DESCRIPTION
## Problem

The docs site deployment (Cloudflare Pages, `npx vitepress build` in `docs/site`) fails/warns with:

```
▲ [WARNING] Cannot find base config file "@simplemodule/tsconfig/base" [tsconfig.json]
    ../../tsconfig.json:2:13:
```

The deploy installs **only** `docs/site` dependencies, so the workspace package `@simplemodule/tsconfig` is not present. VitePress loads `.vitepress/config.ts` through esbuild, and esbuild reads the **repo-root** `tsconfig.json`, whose `extends: "@simplemodule/tsconfig/base"` is then unresolvable.

A docs-local `tsconfig.json` (in `docs/site/` or `.vitepress/`) does **not** shield this — esbuild reads the repo-root `tsconfig.json` regardless (verified: the warning still fires with a local tsconfig present). So the reference has to be removed at its source.

## Fix

Inline the exact `@simplemodule/tsconfig/base` compiler options into the root `tsconfig.json` and drop the `extends`. The docs/VitePress build no longer references `@simplemodule/tsconfig`.

## Verification

- **Faithful Cloudflare-layout repro** (vitepress installed at root, `@simplemodule/tsconfig` absent, full docs content): before → the exact warning above; after → `EXIT CODE: 0`, **0** base-config warnings, **0** warnings total, `dist/index.html` produced.
- **Behavior-preserving**: `tsc --showConfig` for the old `extends`-based config and the new inlined config produce **byte-identical** effective compiler options, so ClientApp/IDE/repo tooling is unaffected.