### PR TITLE
fix: downstream consumability bugs (#236, #220, #222, #223, #224)

### DIFF
--- a/framework/SimpleModule.Core/ManualContractRegistrationAttribute.cs
+++ b/framework/SimpleModule.Core/ManualContractRegistrationAttribute.cs
@@ -1,0 +1,29 @@
+namespace SimpleModule.Core;
+
+/// <summary>
+/// Marks a contract-interface implementation as registered manually by its owning
+/// module — typically because the module wires it conditionally (e.g. one
+/// implementation per configured provider) inside <c>ConfigureServices</c> rather
+/// than relying on the source generator's auto-registration.
+/// </summary>
+/// <remarks>
+/// <para>For a class carrying this attribute, the generator:</para>
+/// <list type="bullet">
+/// <item>does not auto-register it in the DI container (the module does so itself);</item>
+/// <item>excludes it from <c>SM0026</c> "multiple implementations" — a contract may have
+/// several provider-specific implementations that are chosen at runtime;</item>
+/// <item>excludes it from <c>SM0028</c> "implementation must be public" — the class can stay
+/// <c>internal</c> to its module since it is registered from within the same assembly.</item>
+/// </list>
+/// <para>The contract is still considered implemented, so <c>SM0025</c> "no implementation"
+/// does not fire. Apply this to every implementation of a contract that the module
+/// registers manually so the generator never tries to auto-wire any of them.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [ManualContractRegistration]
+/// internal sealed class ExternalUserService : IUserContracts { ... }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class ManualContractRegistrationAttribute : Attribute;

--- a/framework/SimpleModule.Core/RateLimiting/RateLimitDefaults.cs
+++ b/framework/SimpleModule.Core/RateLimiting/RateLimitDefaults.cs
@@ -1,0 +1,53 @@
+namespace SimpleModule.Core.RateLimiting;
+
+/// <summary>
+/// Permissive baseline definitions for the named rate-limit policies that
+/// framework endpoints attach (currently <see cref="RateLimitPolicies.AuthStrict"/>
+/// on the auth pages). These guarantee the policy names are always registered,
+/// even when the optional <c>SimpleModule.RateLimiting</c> module isn't installed,
+/// so the endpoints don't fail at request time with "no such policy exists" (#222).
+/// When <c>SimpleModule.RateLimiting</c> is present, its own definitions take
+/// precedence — see <see cref="EnsureFrameworkDefaults"/>.
+/// </summary>
+public static class RateLimitDefaults
+{
+    /// <summary>
+    /// The framework-default policies, keyed by name. Values mirror the
+    /// <c>SimpleModule.RateLimiting</c> module's own <c>auth-strict</c> baseline so
+    /// behaviour is identical whether or not that module is installed.
+    /// </summary>
+    public static IReadOnlyList<RateLimitPolicyDefinition> FrameworkPolicies { get; } =
+    [
+        new RateLimitPolicyDefinition
+        {
+            Name = RateLimitPolicies.AuthStrict,
+            PolicyType = RateLimitPolicyType.FixedWindow,
+            Target = RateLimitTarget.Ip,
+            PermitLimit = 10,
+            Window = TimeSpan.FromMinutes(1),
+        },
+    ];
+
+    /// <summary>
+    /// Adds each framework default to <paramref name="registry"/> only when a policy
+    /// of the same name is not already present, so module-supplied definitions always
+    /// win. No-op if the registry can't be written to.
+    /// </summary>
+    public static void EnsureFrameworkDefaults(IRateLimitPolicyRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        if (registry is not IRateLimitBuilder builder)
+        {
+            return;
+        }
+
+        foreach (var policy in FrameworkPolicies)
+        {
+            if (registry.GetPolicy(policy.Name) is null)
+            {
+                builder.Add(policy);
+            }
+        }
+    }
+}

--- a/framework/SimpleModule.Generator/Discovery/DiscoveryDataBuilder.cs
+++ b/framework/SimpleModule.Generator/Discovery/DiscoveryDataBuilder.cs
@@ -122,6 +122,7 @@ internal static class DiscoveryDataBuilder
                     c.IsPublic,
                     c.IsAbstract,
                     c.DependsOnDbContext,
+                    c.IsManuallyRegistered,
                     c.Location,
                     c.Lifetime
                 ))

--- a/framework/SimpleModule.Generator/Discovery/Finders/ContractFinder.cs
+++ b/framework/SimpleModule.Generator/Discovery/Finders/ContractFinder.cs
@@ -83,6 +83,7 @@ internal static class ContractFinder
                                 DependsOnDbContext = DbContextFinder.HasDbContextConstructorParam(
                                     typeSymbol
                                 ),
+                                IsManuallyRegistered = HasManualRegistrationAttribute(typeSymbol),
                                 Location = SymbolHelpers.GetSourceLocation(typeSymbol),
                                 Lifetime = GetContractLifetime(typeSymbol),
                             }
@@ -91,6 +92,26 @@ internal static class ContractFinder
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// True when the type carries [ManualContractRegistration]. Such implementations
+    /// are wired manually by their owning module, so the generator must not
+    /// auto-register them and must skip the SM0026/SM0028 contract diagnostics.
+    /// </summary>
+    internal static bool HasManualRegistrationAttribute(INamedTypeSymbol typeSymbol)
+    {
+        foreach (var attr in typeSymbol.GetAttributes())
+        {
+            var attrName = attr.AttributeClass?.ToDisplayString(
+                SymbolDisplayFormat.FullyQualifiedFormat
+            );
+            if (attrName == "global::SimpleModule.Core.ManualContractRegistrationAttribute")
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/framework/SimpleModule.Generator/Discovery/Records/DataRecords.cs
+++ b/framework/SimpleModule.Generator/Discovery/Records/DataRecords.cs
@@ -102,6 +102,7 @@ internal readonly record struct ContractImplementationRecord(
     bool IsPublic,
     bool IsAbstract,
     bool DependsOnDbContext,
+    bool IsManuallyRegistered,
     SourceLocationRecord? Location,
     int Lifetime
 );

--- a/framework/SimpleModule.Generator/Discovery/Records/WorkingTypes.cs
+++ b/framework/SimpleModule.Generator/Discovery/Records/WorkingTypes.cs
@@ -102,6 +102,13 @@ internal sealed class ContractImplementationInfo
     public bool IsPublic { get; set; }
     public bool IsAbstract { get; set; }
     public bool DependsOnDbContext { get; set; }
+
+    /// <summary>
+    /// True when the class carries [ManualContractRegistration] — the owning module
+    /// registers it itself, so the generator skips auto-registration and the
+    /// SM0026/SM0028 contract diagnostics for it.
+    /// </summary>
+    public bool IsManuallyRegistered { get; set; }
     public SourceLocationRecord? Location { get; set; }
     public int Lifetime { get; set; } = 1; // Default: Scoped (ServiceLifetime.Scoped = 1)
 }

--- a/framework/SimpleModule.Generator/Emitters/ContractRegistryEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/ContractRegistryEmitter.cs
@@ -20,10 +20,12 @@ internal sealed class ContractRegistryEmitter : IEmitter
 
         // Group by interface and only include interfaces with exactly one valid implementation
         // (matching what ModuleExtensionsEmitter actually registers with the DI container).
+        // Manually-registered implementations are excluded for the same reason they're
+        // excluded from auto-registration — the module wires them conditionally.
         var implsByInterface = new Dictionary<string, List<ContractImplementationRecord>>();
         foreach (var impl in data.ContractImplementations)
         {
-            if (!impl.IsPublic || impl.IsAbstract)
+            if (!impl.IsPublic || impl.IsAbstract || impl.IsManuallyRegistered)
                 continue;
 
             if (!implsByInterface.TryGetValue(impl.InterfaceFqn, out var list))

--- a/framework/SimpleModule.Generator/Emitters/Diagnostics/ContractAndDtoChecks.cs
+++ b/framework/SimpleModule.Generator/Emitters/Diagnostics/ContractAndDtoChecks.cs
@@ -89,6 +89,14 @@ internal static class ContractAndDtoChecks
         // SM0029: Abstract implementations
         foreach (var impl in data.ContractImplementations)
         {
+            // [ManualContractRegistration] implementations are wired by their module
+            // (often conditionally), not auto-registered, so visibility/abstractness
+            // constraints that exist purely for cross-assembly auto-wiring don't apply.
+            if (impl.IsManuallyRegistered)
+            {
+                continue;
+            }
+
             if (!impl.IsPublic)
             {
                 context.ReportDiagnostic(
@@ -135,13 +143,16 @@ internal static class ContractAndDtoChecks
             }
         }
 
-        // SM0026: Multiple valid implementations for the same interface
+        // SM0026: Multiple valid implementations for the same interface.
+        // Manually-registered implementations are excluded: a provider-swappable
+        // contract legitimately has several implementations that the module selects
+        // between at runtime (e.g. local vs external identity provider).
         foreach (var kvp in implsByInterface)
         {
             var validImpls = new List<ContractImplementationRecord>();
             foreach (var impl in kvp.Value)
             {
-                if (impl.IsPublic && !impl.IsAbstract)
+                if (impl.IsPublic && !impl.IsAbstract && !impl.IsManuallyRegistered)
                     validImpls.Add(impl);
             }
 

--- a/framework/SimpleModule.Generator/Emitters/ModuleExtensionsEmitter.cs
+++ b/framework/SimpleModule.Generator/Emitters/ModuleExtensionsEmitter.cs
@@ -103,11 +103,13 @@ internal sealed class ModuleExtensionsEmitter : IEmitter
         sb.AppendLine();
         sb.AppendLine("        // Auto-discovered contract implementations");
 
-        // Group by interface FQN and only emit if exactly one valid implementation
+        // Group by interface FQN and only emit if exactly one valid implementation.
+        // Manually-registered implementations are skipped — their module wires them
+        // itself in ConfigureServices (often conditionally per provider).
         var implsByInterface = new Dictionary<string, List<ContractImplementationRecord>>();
         foreach (var impl in data.ContractImplementations)
         {
-            if (!impl.IsPublic || impl.IsAbstract)
+            if (!impl.IsPublic || impl.IsAbstract || impl.IsManuallyRegistered)
                 continue;
 
             if (!implsByInterface.TryGetValue(impl.InterfaceFqn, out var list))

--- a/framework/SimpleModule.Hosting/RateLimiting/RateLimitingSetup.cs
+++ b/framework/SimpleModule.Hosting/RateLimiting/RateLimitingSetup.cs
@@ -22,6 +22,13 @@ public static class RateLimitingSetup
         IRateLimitPolicyRegistry registry
     )
     {
+        // Seed framework defaults (e.g. auth-strict) so policy names referenced by
+        // framework endpoints are always registered, even without the optional
+        // SimpleModule.RateLimiting module. Modules that defined the policy already
+        // win — see RateLimitDefaults. Without this, auth endpoints 500 with
+        // "no such policy exists" when RateLimiting isn't installed (#222).
+        RateLimitDefaults.EnsureFrameworkDefaults(registry);
+
         services.AddSingleton(registry);
 
         services.AddRateLimiter(options =>

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionContractsAdapter.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionContractsAdapter.cs
@@ -1,9 +1,11 @@
+using SimpleModule.Core;
 using SimpleModule.Identity.Contracts;
 using SimpleModule.OpenIddict.Contracts;
 
 namespace SimpleModule.OpenIddict.Services;
 
 #pragma warning disable CA1812
+[ManualContractRegistration]
 internal sealed class OpenIddictSessionContractsAdapter(ISessionContracts inner)
     : IOpenIddictSessionContracts
 {

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionService.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSessionService.cs
@@ -1,4 +1,5 @@
 using OpenIddict.Abstractions;
+using SimpleModule.Core;
 using SimpleModule.Identity.Contracts;
 using SimpleModule.OpenIddict.Contracts;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -6,6 +7,7 @@ using static OpenIddict.Abstractions.OpenIddictConstants;
 namespace SimpleModule.OpenIddict.Services;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed class OpenIddictSessionService(
     IOpenIddictTokenManager tokenManager,
     IOpenIddictApplicationManager appManager

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitRuleCache.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitRuleCache.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,10 +31,27 @@ internal sealed partial class RateLimitRuleCache(
         await using var scope = scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<RateLimitingDbContext>();
 
-        var rules = await db
-            .Rules.AsNoTracking()
-            .Where(r => r.IsEnabled)
-            .ToListAsync(cancellationToken);
+        List<RateLimitRule> rules;
+        try
+        {
+            rules = await db
+                .Rules.AsNoTracking()
+                .Where(r => r.IsEnabled)
+                .ToListAsync(cancellationToken);
+        }
+        catch (DbException ex)
+        {
+            // The RateLimiting_Rules table may not exist yet — e.g. the module was
+            // added to a dev DB previously created by EnsureCreated(), which does
+            // not add tables to an existing database. Because RefreshAsync runs from
+            // IHostedService.StartAsync, throwing here would crash the whole host
+            // (#223). Degrade to "no DB-defined rules"; static policies from
+            // ConfigureRateLimits still apply, and the cache self-heals on the next
+            // refresh once the schema exists. DbException covers SQLite/Postgres/
+            // SQL Server "missing relation" without swallowing logic errors.
+            LogTableUnavailable(logger, ex);
+            return;
+        }
 
         var compiled = rules
             .Select(Compile)
@@ -141,4 +159,11 @@ internal sealed partial class RateLimitRuleCache(
         Message = "Rate-limit rule cache refreshed: {Count} enabled rules loaded"
     )]
     private static partial void LogRefreshed(ILogger logger, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rate-limit rules table unavailable; serving static policies only "
+            + "until the schema is created. Run migrations or recreate the dev database."
+    )]
+    private static partial void LogTableUnavailable(ILogger logger, Exception exception);
 }

--- a/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingModule.cs
+++ b/modules/RateLimiting/src/SimpleModule.RateLimiting/RateLimitingModule.cs
@@ -1,6 +1,10 @@
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using SimpleModule.Core;
 using SimpleModule.Core.RateLimiting;
 using SimpleModule.Database;
@@ -27,6 +31,29 @@ public class RateLimitingModule : IModule
             sp.GetRequiredService<RateLimitRuleCache>()
         );
         services.AddHostedService(sp => sp.GetRequiredService<RateLimitRuleCache>());
+    }
+
+    public void ConfigureHost(IHost host)
+    {
+        // Ensure the RateLimiting_Rules table exists before the rule cache's
+        // hosted service queries it on startup (dev convenience; prod uses
+        // migrations). ConfigureHost runs in the StartingAsync lifecycle phase,
+        // strictly before any IHostedService.StartAsync, so the table is present
+        // by the time RateLimitRuleCache reads it. Mirrors BackgroundJobsModule.
+        using var scope = host.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RateLimitingDbContext>();
+        if (!db.Database.EnsureCreated())
+        {
+            try
+            {
+                db.GetService<IRelationalDatabaseCreator>()?.CreateTables();
+            }
+#pragma warning disable CA1031
+            catch
+            { /* tables already exist */
+            }
+#pragma warning restore CA1031
+        }
     }
 
     public void ConfigureRateLimits(IRateLimitBuilder builder)

--- a/modules/RateLimiting/tests/SimpleModule.RateLimiting.Tests/RateLimitRuleCacheTests.cs
+++ b/modules/RateLimiting/tests/SimpleModule.RateLimiting.Tests/RateLimitRuleCacheTests.cs
@@ -118,6 +118,47 @@ public sealed class RateLimitRuleCacheTests : IAsyncLifetime, IDisposable
     }
 
     [Fact]
+    public async Task RefreshAsync_DoesNotThrow_WhenTableMissing()
+    {
+        // Simulates a legacy dev DB created by EnsureCreated() before the
+        // RateLimiting module was added: the RateLimiting_Rules table is absent.
+        // RefreshAsync runs from IHostedService.StartAsync, so an unhandled
+        // exception here crashes the whole host (#223). It must degrade to "no
+        // DB-defined rules" instead.
+        var dbOptions = new DbContextOptionsBuilder<RateLimitingDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        var databaseOptions = Options.Create(
+            new DatabaseOptions
+            {
+                ModuleConnections = new Dictionary<string, string>
+                {
+                    ["RateLimiting"] = "Data Source=:memory:",
+                },
+            }
+        );
+        using var db = new RateLimitingDbContext(dbOptions, databaseOptions);
+        await db.Database.OpenConnectionAsync(); // keep the :memory: DB alive, but DON'T EnsureCreated
+        try
+        {
+            using var services = new ServiceCollection().AddSingleton(db).BuildServiceProvider();
+            var cache = new RateLimitRuleCache(
+                services.GetRequiredService<IServiceScopeFactory>(),
+                NullLogger<RateLimitRuleCache>.Instance
+            );
+
+            var startup = async () => await cache.StartAsync(CancellationToken.None);
+
+            await startup.Should().NotThrowAsync();
+            cache.FindForPath("/api/users").Should().BeNull();
+        }
+        finally
+        {
+            await db.Database.CloseConnectionAsync();
+        }
+    }
+
+    [Fact]
     public async Task RefreshAsync_PicksUpNewRules()
     {
         await _cache.RefreshAsync();

--- a/modules/Users/src/SimpleModule.Users/RoleAdminService.cs
+++ b/modules/Users/src/SimpleModule.Users/RoleAdminService.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using SimpleModule.Core;
 using SimpleModule.Core.Exceptions;
 using SimpleModule.Users.Contracts;
 
 namespace SimpleModule.Users;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed class RoleAdminService(
     RoleManager<ApplicationRole> roleManager,
     UserManager<ApplicationUser> userManager

--- a/modules/Users/src/SimpleModule.Users/Services/ExternalRoleAdminService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/ExternalRoleAdminService.cs
@@ -1,8 +1,10 @@
+using SimpleModule.Core;
 using SimpleModule.Users.Contracts;
 
 namespace SimpleModule.Users.Services;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed class ExternalRoleAdminService : IRoleAdminContracts
 {
     public Task<IReadOnlyList<RoleDto>> GetAllRolesAsync()

--- a/modules/Users/src/SimpleModule.Users/Services/ExternalUserAdminService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/ExternalUserAdminService.cs
@@ -4,6 +4,7 @@ using SimpleModule.Users.Contracts;
 namespace SimpleModule.Users.Services;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed class ExternalUserAdminService : IUserAdminContracts
 {
     public Task<PagedResult<AdminUserDto>> GetUsersPagedAsync(

--- a/modules/Users/src/SimpleModule.Users/Services/ExternalUserService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/ExternalUserService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using SimpleModule.Core;
 using SimpleModule.Users.Contracts;
 using SimpleModule.Users.Contracts.Events;
 using Wolverine;
@@ -7,6 +8,7 @@ using Wolverine;
 namespace SimpleModule.Users.Services;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed partial class ExternalUserService(
     UsersDbContext db,
     IMessageBus bus,

--- a/modules/Users/src/SimpleModule.Users/UserAdminService.cs
+++ b/modules/Users/src/SimpleModule.Users/UserAdminService.cs
@@ -9,6 +9,7 @@ using Wolverine;
 namespace SimpleModule.Users;
 
 #pragma warning disable CA1812 // Instantiated via DI
+[ManualContractRegistration]
 internal sealed class UserAdminService(
     UserManager<ApplicationUser> userManager,
     UsersDbContext db,

--- a/modules/Users/src/SimpleModule.Users/UserService.cs
+++ b/modules/Users/src/SimpleModule.Users/UserService.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using SimpleModule.Core;
 using SimpleModule.Users.Contracts;
 using SimpleModule.Users.Contracts.Events;
 using Wolverine;
@@ -9,6 +10,7 @@ namespace SimpleModule.Users;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes (instantiated via DI)
 
+[ManualContractRegistration]
 internal sealed partial class UserService(
     UserManager<ApplicationUser> userManager,
     RoleManager<ApplicationRole> roleManager,

--- a/packages/SimpleModule.Client/src/resolve-page.ts
+++ b/packages/SimpleModule.Client/src/resolve-page.ts
@@ -1,14 +1,24 @@
+// Caches the assembly name that successfully served a module's bundle, keyed by
+// the module's short name. Inertia calls resolvePage on every navigation, so
+// without this the "wrong" candidate would 404 again on every page load for that
+// module. We only ever store a name that actually resolved.
+const resolvedAssemblies = new Map<string, string>();
+
 export async function resolvePage(name: string) {
   const moduleName = name.split('/')[0];
   const cacheBuster = (document.querySelector('meta[name="cache-buster"]') as HTMLMetaElement)
     ?.content;
   const suffix = cacheBuster ? `?v=${cacheBuster}` : '';
 
-  // Downstream apps frequently ship modules under a bare assembly name
-  // (e.g. "Customers", "Invoices") rather than the framework's "SimpleModule.X"
-  // convention. Try the bare name first, then fall back to the prefixed form
-  // so framework modules continue to resolve.
-  const candidates = [moduleName, `SimpleModule.${moduleName}`];
+  // Framework modules serve their bundle under the assembly-qualified path
+  // "SimpleModule.<Module>" (their RCL AssemblyName), whereas downstream apps
+  // frequently ship modules under a bare assembly name (e.g. "Customers"). Try
+  // the assembly-qualified form first so framework modules — the common, always-
+  // present case — resolve without a 404 (#224), then fall back to the bare name
+  // for consumer modules. Once a module resolves, reuse that name directly so
+  // later navigations never re-probe.
+  const cached = resolvedAssemblies.get(moduleName);
+  const candidates = cached ? [cached] : [`SimpleModule.${moduleName}`, moduleName];
   // biome-ignore lint/suspicious/noExplicitAny: matches existing dynamic-import shape
   let mod: any;
   let assemblyName = candidates[0];
@@ -20,6 +30,7 @@ export async function resolvePage(name: string) {
         `/_content/${candidate}/${candidate}.pages.js${suffix}`
       );
       assemblyName = candidate;
+      resolvedAssemblies.set(moduleName, candidate);
       break;
     } catch (err) {
       lastError = err;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,21 +1,47 @@
-# CLI Bug Fixes (GitHub issues)
+# Downstream-blocking bug fixes (#236, #220, #222, #223, #224)
 
-Branch: claude/cli-bug-fixes-2OKyG
+Goal: make the framework consumable by a downstream host again. One branch, one commit per issue, one PR closing all five (follows PR #231 precedent).
 
-- [x] #218 Generated event records implement `IEvent` → now derive from `DomainEvent` (FallbackEventClass)
-- [x] #225 `sm new project` references `/favicon.svg` but ships none → embed + write `wwwroot/favicon.svg`
-- [x] #219 Scaffold pinned `@simplemodule/*` npm deps to framework (NuGet) version → new `NpmVersionResolver` resolves the latest *published* npm version; threaded through `ProjectTemplates`/`ScaffoldProject`
-- [x] #228 Module `AssemblyName` = `SimpleModule.X` but dir basename = `X` → bundle 404. Set module AssemblyName to bare `X` AND contracts to `X.Contracts` (required so the generator's `module + ".Contracts"` pairing still discovers contract impls — otherwise SM0025)
-- [x] #221 `SimpleModule.Hosting.targets` undefined `$(RepoRoot)` + monorepo paths → added RepoRoot fallback (nearest package.json) + overridable `SimpleModuleThemeCss`/`SimpleModuleModulesDir`/`SimpleModuleRoutesOutput` props with consumer defaults; monorepo overrides them in `Directory.Build.props` (scoped via `packages/` check)
+## Plan
+
+- [ ] **#223** RateLimitRuleCache crashes host on missing `RateLimiting_Rules` table
+  - [ ] Failing test: cache `RefreshAsync` against a context whose table was NOT created → must not throw, `FindForPath` returns null
+  - [ ] Fix: `catch (DbException)` in `RefreshAsync` (provider-agnostic), log warning, keep empty rules
+  - [ ] Add `ConfigureHost` to `RateLimitingModule` to create the table on legacy EnsureCreated DBs (mirror BackgroundJobs)
+- [ ] **#222** auth-strict policy missing when RateLimiting not installed → login 500
+  - [ ] Failing test: host pipeline without RateLimiting module, assert `auth-strict` policy resolvable
+  - [ ] Fix: seed framework-default `auth-strict` in `RateLimitingSetup.AddSimpleModuleRateLimiting` only if absent
+- [ ] **#224** Inertia resolver 404s on `/_content/<ShortName>/` before `SimpleModule.<Module>`
+  - [ ] Fix: reverse candidate order in `packages/SimpleModule.Client/src/resolve-page.ts`
+  - [ ] Check/adjust any resolve-page tests
+- [ ] **#236 / #220** SM0026 (dup impl) + SM0028 (internal impl) make framework unconsumable
+  - [ ] Add `[ManualContractRegistration]` attribute to SimpleModule.Core
+  - [ ] Generator: record flag in ContractFinder; skip SM0025/0026/0028 + auto-registration for manual impls; contract still counts as satisfied
+  - [ ] Generator unit test: two manual impls of one contract → no SM0026/0028, no auto-register, no SM0025
+  - [ ] Mark the 8 provider-swappable impls (Users/OpenIddict) with the attribute
+  - [ ] Verify Host build clean; confirm SM0028 from Users/OpenIddict gone
 
 ## Verification
-- [x] dotnet build CLI — succeeds
-- [x] dotnet test CLI tests — 136/136 pass (incl. scaffold `dotnet build` against published NuGet, now green)
-- [x] dotnet build template host — succeeds; integrated Vite + Tailwind build runs (validates #221 targets)
+- [ ] `dotnet build` clean
+- [ ] `dotnet test` for touched modules + generator
+- [ ] `npm run check` for resolver change
+- [ ] Full local CI before PR
 
 ## Review
-- #228 root cause was subtler than the issue described: bare module AssemblyName alone breaks
-  the generator's module↔contracts pairing (ContractFinder uses `moduleAssembly.Name + ".Contracts"`).
-  Both assembly names must go bare together; namespaces stay `SimpleModule.X(.Contracts)`.
-- #219 falls back to the framework version when the npm registry is unreachable (offline),
-  preserving deterministic test behavior (ScaffoldProject's npmVersion defaults to frameworkVersion).
+
+All five downstream-blocking bugs fixed, one commit each, all CI green.
+
+- **#223** — `RefreshAsync` now catches `DbException` (provider-agnostic) and `RateLimitingModule.ConfigureHost` ensures the table exists. Regression test added. RateLimiting tests 28/28.
+- **#222** — `RateLimitDefaults.EnsureFrameworkDefaults` (Core) seeds `auth-strict` in `AddSimpleModuleRateLimiting` (always emitted by the generator) only if absent; module definitions still win. Core tests +2.
+- **#236 / #220** — `[ManualContractRegistration]` (Core); generator skips auto-registration + SM0026/SM0028 for marked impls while keeping the contract satisfied (no SM0025). Applied to the 8 Users/OpenIddict provider-swappable impls (they stay `internal`). Verified: with SM0028 un-suppressed, the 7 Users/OpenIddict errors are gone (only the pre-existing #97 BackgroundJobs `DefaultJobExecutionContext` remains — out of scope). Generator tests +2 (208 total).
+- **#224** — resolver tries `SimpleModule.<Module>` first, then bare name; caches resolved assembly per module. Frontend check green; e2e smoke 66/66.
+
+Notes / follow-ups:
+- **#97** (`DefaultJobExecutionContext` internal → SM0028) is the same class of issue and could use `[ManualContractRegistration]`; left out of scope here. Once fixed, `SM0028` can be removed from the Host's `NoWarn` to guard against regressions.
+
+## Verification (done)
+- [x] `npm run check` — green (biome, validate-pages, i18n, framework-scope, typecheck 13/13)
+- [x] `npm run build` — all module bundles built
+- [x] `dotnet build` — 0 errors
+- [x] `dotnet test --no-build` — 0 failures across all projects
+- [x] `npm run test:smoke -w tests/e2e` — 66 passed

--- a/tests/SimpleModule.Core.Tests/RateLimiting/RateLimitDefaultsTests.cs
+++ b/tests/SimpleModule.Core.Tests/RateLimiting/RateLimitDefaultsTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using SimpleModule.Core.RateLimiting;
+
+namespace SimpleModule.Core.Tests.RateLimiting;
+
+public sealed class RateLimitDefaultsTests
+{
+    [Fact]
+    public void EnsureFrameworkDefaults_RegistersAuthStrict_WhenRegistryEmpty()
+    {
+        // Simulates a host WITHOUT the SimpleModule.RateLimiting module: the
+        // generator hands AddSimpleModuleRateLimiting an empty registry. The
+        // auth-strict policy that framework auth endpoints attach must still be
+        // registered, otherwise login 500s with "no such policy exists" (#222).
+        var registry = new RateLimitPolicyRegistry();
+
+        RateLimitDefaults.EnsureFrameworkDefaults(registry);
+
+        var policy = registry.GetPolicy(RateLimitPolicies.AuthStrict);
+        policy.Should().NotBeNull();
+        policy!.PolicyType.Should().Be(RateLimitPolicyType.FixedWindow);
+        policy.Target.Should().Be(RateLimitTarget.Ip);
+        policy.PermitLimit.Should().Be(10);
+        policy.Window.Should().Be(TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void EnsureFrameworkDefaults_DoesNotOverride_ModuleSuppliedPolicy()
+    {
+        // When SimpleModule.RateLimiting is installed it defines auth-strict before
+        // AddSimpleModuleRateLimiting runs; the module's definition must win.
+        var registry = new RateLimitPolicyRegistry();
+        ((IRateLimitBuilder)registry).Add(
+            new RateLimitPolicyDefinition
+            {
+                Name = RateLimitPolicies.AuthStrict,
+                PolicyType = RateLimitPolicyType.SlidingWindow,
+                PermitLimit = 999,
+            }
+        );
+
+        RateLimitDefaults.EnsureFrameworkDefaults(registry);
+
+        var policy = registry.GetPolicy(RateLimitPolicies.AuthStrict);
+        policy!.PermitLimit.Should().Be(999);
+        policy.PolicyType.Should().Be(RateLimitPolicyType.SlidingWindow);
+    }
+}

--- a/tests/SimpleModule.Generator.Tests/ContractAutoDiscoveryTests.cs
+++ b/tests/SimpleModule.Generator.Tests/ContractAutoDiscoveryTests.cs
@@ -278,6 +278,109 @@ public class ContractAutoDiscoveryTests
     }
 
     [Fact]
+    public void ManualImplementations_DoNotEmitContractDiagnostics()
+    {
+        // A module with a provider-swappable contract ships several implementations
+        // and registers one conditionally in ConfigureServices. Marking each with
+        // [ManualContractRegistration] must suppress SM0026 (multiple impls) and
+        // SM0028 (impl must be public) while still satisfying the contract so SM0025
+        // (no impl) does not fire. Mirrors the Users/OpenIddict provider design (#236).
+        var contractsSource = """
+            namespace TestAssembly.Contracts
+            {
+                public interface IProductContracts
+                {
+                    void DoSomething();
+                }
+            }
+            """;
+
+        var hostSource = """
+            using SimpleModule.Core;
+            using Microsoft.Extensions.DependencyInjection;
+            using TestAssembly.Contracts;
+
+            namespace TestAssembly
+            {
+                [Module("TestAssembly")]
+                public class TestAssemblyModule : IModule
+                {
+                    public void ConfigureServices(IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
+                }
+
+                [ManualContractRegistration]
+                public sealed class LocalProductService : IProductContracts
+                {
+                    public void DoSomething() { }
+                }
+
+                [ManualContractRegistration]
+                internal sealed class ExternalProductService : IProductContracts
+                {
+                    public void DoSomething() { }
+                }
+            }
+            """;
+
+        var compilation = CreateMultiAssemblyCompilation(contractsSource, hostSource);
+        var (_, diagnostics) = GeneratorTestHelper.RunGeneratorWithDiagnostics(compilation);
+
+        diagnostics.Should().NotContain(d => d.Id == "SM0025");
+        diagnostics.Should().NotContain(d => d.Id == "SM0026");
+        diagnostics.Should().NotContain(d => d.Id == "SM0028");
+    }
+
+    [Fact]
+    public void ManualImplementation_IsNotAutoRegistered()
+    {
+        // A [ManualContractRegistration] implementation must not be auto-wired by the
+        // generator — its module registers it itself, so a generated AddScoped would
+        // double-register (or pick the wrong provider).
+        var contractsSource = """
+            namespace TestAssembly.Contracts
+            {
+                public interface IProductContracts
+                {
+                    void DoSomething();
+                }
+            }
+            """;
+
+        var hostSource = """
+            using SimpleModule.Core;
+            using Microsoft.Extensions.DependencyInjection;
+            using TestAssembly.Contracts;
+
+            namespace TestAssembly
+            {
+                [Module("TestAssembly")]
+                public class TestAssemblyModule : IModule
+                {
+                    public void ConfigureServices(IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
+                }
+
+                [ManualContractRegistration]
+                public sealed class ProductService : IProductContracts
+                {
+                    public void DoSomething() { }
+                }
+            }
+            """;
+
+        var compilation = CreateMultiAssemblyCompilation(contractsSource, hostSource);
+        var result = GeneratorTestHelper.RunGenerator(compilation);
+
+        var moduleExt = result
+            .GeneratedTrees.First(t =>
+                t.FilePath.EndsWith("ModuleExtensions.g.cs", StringComparison.Ordinal)
+            )
+            .GetText()
+            .ToString();
+
+        moduleExt.Should().NotContain("ProductService");
+    }
+
+    [Fact]
     public void AbstractImplementation_EmitsSM0029()
     {
         var contractsSource = """


### PR DESCRIPTION
Fixes the cluster of bugs that make the framework unconsumable by a downstream host. One commit per issue.

## What's fixed

### `fix(ratelimiting): tolerate missing RateLimiting_Rules table on startup` — #223
`RateLimitRuleCache` is an `IHostedService` that queried `RateLimiting_Rules` in `StartAsync`. On a dev DB created by `EnsureCreated()` before the module was added, the table is absent and the unhandled `SqliteException` crashed the whole host.
- `RefreshAsync` now catches `DbException` (provider-agnostic: SQLite/Postgres/SQL Server), logs a warning, and degrades to "no DB-defined rules" — static `ConfigureRateLimits` policies still apply and the cache self-heals on the next refresh.
- `RateLimitingModule.ConfigureHost` now ensures the table exists (mirrors `BackgroundJobsModule`), so admin-defined rules persist on legacy `EnsureCreated` DBs. `ConfigureHost` runs before hosted services start.
- Regression test added.

### `fix(ratelimiting): always register auth-strict policy ...` — #222
Auth endpoints (Users/OpenIddict) attach the `auth-strict` named policy, but only the optional `SimpleModule.RateLimiting` module registered it — so a host with auth but **not** RateLimiting returned **HTTP 500 on login** ("no such policy exists").
- New `RateLimitDefaults` helper in Core; `AddSimpleModuleRateLimiting` (always emitted by the generator) seeds framework-default policies into the registry **only if absent**, so RateLimiting's own definitions still win when installed.
- The default `auth-strict` mirrors the module's baseline (FixedWindow, IP, 10/min). Tests added.

### `fix(generator): support provider-swappable contracts ...` — #236, #220
After #216 the Users/OpenIddict modules ship **two implementations per contract** (local + External / OpenIddict + Keycloak adapter), chosen at runtime by `Identity:Provider`. They were marked `internal` to dodge auto-registration, which trips **SM0028** in any downstream host (the framework's own host hides it with `NoWarn`; the CLI scaffold strips `NoWarn`). Making them public would instead trip **SM0026**.
- New `[ManualContractRegistration]` attribute (Core). For a class carrying it the generator **skips auto-registration, SM0026 and SM0028**, while the contract still counts as implemented (no SM0025).
- Applied to the eight provider-swappable impls in Users/OpenIddict — they stay `internal` and keep their existing conditional `ConfigureServices` registration.
- Verified: with `SM0028` temporarily un-suppressed, all 7 Users/OpenIddict errors are gone. Generator tests added.

### `fix(client): resolve framework page bundles without a guaranteed 404` — #224
The Inertia resolver tried the bare `/_content/<Module>/...` path before the assembly-qualified `/_content/SimpleModule.<Module>/...`, so framework modules 404'd on every navigation before the fallback.
- Try `SimpleModule.<Module>` first (the common case), fall back to the bare name for consumer-scaffolded modules.
- Cache the resolved assembly name per module, eliminating the once-per-navigation 404 for either naming.

## Verification (local CI, all green)
- `npm run check` — biome, validate-pages, i18n, framework-scope, typecheck (13/13)
- `npm run build` — all module bundles
- `dotnet build` — 0 errors
- `dotnet test --no-build` — 0 failures (Generator 208, Core 249, Users 61, OpenIddict 32, RateLimiting 28, …)
- `npm run test:smoke -w tests/e2e` — 66 passed (login + every module page resolve in-browser)

## Out of scope / follow-up
- **#97** — `BackgroundJobs.DefaultJobExecutionContext` trips the same SM0028 (it's `internal`). It can take the same `[ManualContractRegistration]` attribute; once done, `SM0028` can be dropped from the Host's `NoWarn` to guard against regressions.


Closes #236
Closes #220
Closes #222
Closes #223
Closes #224
