### PR TITLE
fix: data-correctness & concurrency bugs (#230, #227, #232, #233)

### DIFF
--- a/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
+++ b/framework/SimpleModule.Database/Interceptors/EntityInterceptor.cs
@@ -88,10 +88,14 @@ public sealed class EntityInterceptor(
 
     private static void SetCreationFields(EntityEntry entry, DateTimeOffset now, string? userId)
     {
-        if (entry.Entity is IHasCreationTime c)
+        // Creation fields are stamped once and then preserved. Only default them
+        // when the caller hasn't set a value, so an explicitly-assigned creator
+        // (e.g. a background job creating a row on behalf of a user, where there is
+        // no HttpContext) isn't clobbered with the ambient — possibly null — user (#230).
+        if (entry.Entity is IHasCreationTime c && c.CreatedAt == default)
             c.CreatedAt = now;
 
-        if (entry.Entity is IAuditable a)
+        if (entry.Entity is IAuditable a && string.IsNullOrEmpty(a.CreatedBy))
             a.CreatedBy = userId;
     }
 

--- a/framework/SimpleModule.Database/ModuleModelBuilderExtensions.cs
+++ b/framework/SimpleModule.Database/ModuleModelBuilderExtensions.cs
@@ -17,8 +17,12 @@ public static class ModuleModelBuilderExtensions
         if (hasOwnConnection)
             return;
 
+        // Honor an explicitly-configured provider; only fall back to sniffing the
+        // connection string when none is set. Otherwise a host that sets
+        // Database:Provider but leaves a connection string that looks like another
+        // provider would pick the wrong schema strategy (#227).
         var connectionString = dbOptions.DefaultConnection;
-        var provider = DatabaseProviderDetector.Detect(connectionString);
+        var provider = DatabaseProviderDetector.Detect(connectionString, dbOptions.Provider);
 
         if (provider == DatabaseProvider.Sqlite)
         {

--- a/framework/SimpleModule.Hosting/Inertia/HtmlFileInertiaPageRenderer.cs
+++ b/framework/SimpleModule.Hosting/Inertia/HtmlFileInertiaPageRenderer.cs
@@ -200,6 +200,8 @@ public sealed class HtmlFileInertiaPageRenderer : IInertiaPageRenderer
           var url=protocol+'//'+location.host+'/dev/live-reload';
           var reconnectDelay=1000;
           var maxReconnectDelay=10000;
+          var maxAttempts=60;
+          var attempts=0;
           var cssVersion=0;
 
           function connect(){
@@ -207,6 +209,7 @@ public sealed class HtmlFileInertiaPageRenderer : IInertiaPageRenderer
             ws.onopen=function(){
               console.log('[LiveReload] Connected');
               reconnectDelay=1000;
+              attempts=0;
             };
             ws.onmessage=function(event){
               try{
@@ -222,6 +225,11 @@ public sealed class HtmlFileInertiaPageRenderer : IInertiaPageRenderer
               }
             };
             ws.onclose=function(){
+              attempts++;
+              if(attempts>maxAttempts){
+                console.warn('[LiveReload] Giving up after '+maxAttempts+' attempts. Reload the page to retry.');
+                return;
+              }
               console.log('[LiveReload] Disconnected, reconnecting in '+(reconnectDelay/1000)+'s...');
               setTimeout(connect,reconnectDelay);
               reconnectDelay=Math.min(reconnectDelay*2,maxReconnectDelay);

--- a/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
+++ b/modules/AuditLogs/src/SimpleModule.AuditLogs/Middleware/AuditMiddleware.cs
@@ -175,32 +175,49 @@ public sealed class AuditMiddleware(RequestDelegate next, IFusionCache cache)
         ISettingsContracts settings
     )
     {
-        var results = await Task.WhenAll(
-            settings.GetSettingAsync("auditlogs.capture.http", Core.Settings.SettingScope.System),
-            settings.GetSettingAsync(
-                "auditlogs.capture.requestbodies",
-                Core.Settings.SettingScope.System
-            ),
-            settings.GetSettingAsync(
-                "auditlogs.capture.querystrings",
-                Core.Settings.SettingScope.System
-            ),
-            settings.GetSettingAsync(
-                "auditlogs.capture.useragent",
-                Core.Settings.SettingScope.System
-            ),
-            settings.GetSettingAsync("auditlogs.excluded.paths", Core.Settings.SettingScope.System)
+        // Read sequentially, NOT via Task.WhenAll: all five reads resolve through
+        // the request's scoped SettingsDbContext, and a DbContext does not allow
+        // concurrent operations ("A second operation was started on this context
+        // instance..."), which surfaced as intermittent 500s on a cold cache (#232).
+        // The values are tiny and per-key cached, so serial reads are negligible.
+        var captureHttpRaw = await settings.GetSettingAsync(
+            "auditlogs.capture.http",
+            Core.Settings.SettingScope.System
+        );
+        var captureBodyRaw = await settings.GetSettingAsync(
+            "auditlogs.capture.requestbodies",
+            Core.Settings.SettingScope.System
+        );
+        var captureQsRaw = await settings.GetSettingAsync(
+            "auditlogs.capture.querystrings",
+            Core.Settings.SettingScope.System
+        );
+        var captureUaRaw = await settings.GetSettingAsync(
+            "auditlogs.capture.useragent",
+            Core.Settings.SettingScope.System
+        );
+        var excludedPathsRaw = await settings.GetSettingAsync(
+            "auditlogs.excluded.paths",
+            Core.Settings.SettingScope.System
         );
 
-        var captureHttp = !string.Equals(results[0], "false", StringComparison.OrdinalIgnoreCase);
+        var captureHttp = !string.Equals(
+            captureHttpRaw,
+            "false",
+            StringComparison.OrdinalIgnoreCase
+        );
 
-        var captureBody = !string.Equals(results[1], "false", StringComparison.OrdinalIgnoreCase);
+        var captureBody = !string.Equals(
+            captureBodyRaw,
+            "false",
+            StringComparison.OrdinalIgnoreCase
+        );
 
-        var captureQs = !string.Equals(results[2], "false", StringComparison.OrdinalIgnoreCase);
+        var captureQs = !string.Equals(captureQsRaw, "false", StringComparison.OrdinalIgnoreCase);
 
-        var captureUa = string.Equals(results[3], "true", StringComparison.OrdinalIgnoreCase);
+        var captureUa = string.Equals(captureUaRaw, "true", StringComparison.OrdinalIgnoreCase);
 
-        return (captureHttp, captureBody, captureQs, captureUa, results[4]);
+        return (captureHttp, captureBody, captureQs, captureUa, excludedPathsRaw);
     }
 
     private static string[] ParseExcludedPaths(string? rawPaths)

--- a/modules/AuditLogs/tests/SimpleModule.AuditLogs.Tests/Unit/AuditMiddlewareTests.cs
+++ b/modules/AuditLogs/tests/SimpleModule.AuditLogs.Tests/Unit/AuditMiddlewareTests.cs
@@ -54,9 +54,55 @@ public sealed class AuditMiddlewareTests : IDisposable
             .Received(1)
             .GetSettingAsync("auditlogs.excluded.paths", Arg.Any<SettingScope>());
 
-        // Verify all settings were fetched via Task.WhenAll (batch call)
-        // Total calls should be exactly 5
+        // Total calls should be exactly 5 (one per setting key)
         await settings.Received(5).GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReadsSettingsSequentially_NeverConcurrentlyOnSharedContext()
+    {
+        // The five settings reads share the request's scoped SettingsDbContext.
+        // A DbContext forbids concurrent operations, so they must run one at a
+        // time — otherwise EF throws "A second operation was started..." and the
+        // request 500s intermittently (#232). This stub fails if it ever observes
+        // more than one read in flight at once.
+        var settings = Substitute.For<ISettingsContracts>();
+        var channel = new AuditChannel();
+        var next = Substitute.For<RequestDelegate>();
+
+        var context = new DefaultHttpContext();
+        context.RequestServices = CreateServiceProvider(settings, channel);
+
+        var gate = new object();
+        var inFlight = 0;
+        var maxInFlight = 0;
+
+        settings
+            .GetSettingAsync(Arg.Any<string>(), Arg.Any<SettingScope>())
+            .Returns(_ => TrackedReadAsync());
+
+        async Task<string?> TrackedReadAsync()
+        {
+            lock (gate)
+            {
+                inFlight++;
+                maxInFlight = Math.Max(maxInFlight, inFlight);
+            }
+            await Task.Delay(25); // widen the window so any overlap is observed
+            lock (gate)
+            {
+                inFlight--;
+            }
+            return "true";
+        }
+
+        var middleware = new AuditMiddleware(next, _cache);
+
+        await middleware.InvokeAsync(context);
+
+        maxInFlight
+            .Should()
+            .Be(1, "settings reads share one scoped DbContext and must not overlap");
     }
 
     [Fact]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,21 +1,38 @@
-# CLI Bug Fixes (GitHub issues)
+# Data-correctness / concurrency bug fixes (#232, #230, #227, #233) [+ #229 separate]
 
-Branch: claude/cli-bug-fixes-2OKyG
+Branch: fix/data-correctness-bugs (off main). One commit per issue.
 
-- [x] #218 Generated event records implement `IEvent` → now derive from `DomainEvent` (FallbackEventClass)
-- [x] #225 `sm new project` references `/favicon.svg` but ships none → embed + write `wwwroot/favicon.svg`
-- [x] #219 Scaffold pinned `@simplemodule/*` npm deps to framework (NuGet) version → new `NpmVersionResolver` resolves the latest *published* npm version; threaded through `ProjectTemplates`/`ScaffoldProject`
-- [x] #228 Module `AssemblyName` = `SimpleModule.X` but dir basename = `X` → bundle 404. Set module AssemblyName to bare `X` AND contracts to `X.Contracts` (required so the generator's `module + ".Contracts"` pairing still discovers contract impls — otherwise SM0025)
-- [x] #221 `SimpleModule.Hosting.targets` undefined `$(RepoRoot)` + monorepo paths → added RepoRoot fallback (nearest package.json) + overridable `SimpleModuleThemeCss`/`SimpleModuleModulesDir`/`SimpleModuleRoutesOutput` props with consumer defaults; monorepo overrides them in `Directory.Build.props` (scoped via `packages/` check)
+## Plan
+- [ ] **#230** `EntityInterceptor` overwrites `CreatedBy` from HttpContext → background jobs can't create user-owned rows
+  - [ ] Failing test: pre-set `CreatedBy` with no HTTP user is preserved
+  - [ ] Fix: only set `CreatedBy` when unset; guard `CreatedAt == default`
+- [ ] **#227** `ApplyModuleSchema` ignores `DatabaseOptions.Provider`
+  - [ ] Failing test: explicit Provider overrides SQLite-looking connection string
+  - [ ] Fix: pass `dbOptions.Provider` + module's effective connection to `Detect`
+- [ ] **#232** `AuditMiddleware` races `SettingsDbContext` (Task.WhenAll over 5 reads) → 500s
+  - [ ] Failing test: concurrency-guard stub `ISettingsContracts` (fails if >1 in-flight)
+  - [ ] Fix: read the 5 settings sequentially
+- [ ] **#233** live-reload WS 302→infinite retry
+  - [ ] Fix: `.AllowAnonymous()` on `/dev/live-reload` (root cause); + client give-up cap
+- [ ] CI green → PR
 
-## Verification
-- [x] dotnet build CLI — succeeds
-- [x] dotnet test CLI tests — 136/136 pass (incl. scaffold `dotnet build` against published NuGet, now green)
-- [x] dotnet build template host — succeeds; integrated Vite + Tailwind build runs (validates #221 targets)
+## Deferred to its own PR
+- **#229** child entity (no DbSet) gets wrong/no schema prefix in generated HostDbContext — latent (no in-tree repro); generator change emitting EF-model traversal, higher risk. Handle carefully after this PR.
 
 ## Review
-- #228 root cause was subtler than the issue described: bare module AssemblyName alone breaks
-  the generator's module↔contracts pairing (ContractFinder uses `moduleAssembly.Name + ".Contracts"`).
-  Both assembly names must go bare together; namespaces stay `SimpleModule.X(.Contracts)`.
-- #219 falls back to the framework version when the npm registry is unreachable (offline),
-  preserving deterministic test behavior (ScaffoldProject's npmVersion defaults to frameworkVersion).
+
+Four fixes, one commit each, all CI green (build 0 errors, tests 0 failures, npm check + e2e 66/66).
+
+- **#230** `EntityInterceptor.SetCreationFields` now only defaults `CreatedBy`/`CreatedAt` when unset → background jobs can set an owner. +2 tests (Database 89).
+- **#227** `ApplyModuleSchema` passes `dbOptions.Provider` to `Detect` → explicit provider wins. +1 test.
+- **#232** `AuditMiddleware` reads its 5 settings sequentially (was `Task.WhenAll` on one scoped DbContext → races). +1 concurrency-guard test (AuditLogs 38).
+- **#233** `/dev/live-reload` endpoint `.AllowAnonymous()` (root cause: auth fallback 302'd the handshake) + client gives up after 60 attempts. +1 endpoint-metadata test (DevTools 35).
+
+Deferred: **#229** (child entity schema prefix in generated HostDbContext) — latent, riskier generator change; its own PR.
+
+## Verification (done)
+- [x] `dotnet build` — 0 errors
+- [x] `dotnet test --no-build` — 0 failures
+- [x] `npm run check` — green; typecheck 13/13
+- [x] `npm run build` — clean
+- [x] `npm run test:smoke -w tests/e2e` — 66 passed

--- a/tests/SimpleModule.Database.Tests/EntityInterceptorTests.cs
+++ b/tests/SimpleModule.Database.Tests/EntityInterceptorTests.cs
@@ -60,6 +60,35 @@ public sealed partial class EntityInterceptorTests
     }
 
     [Fact]
+    public async Task Added_Auditable_Entity_Preserves_Explicit_CreatedBy_Without_Current_User()
+    {
+        // A background job (no HTTP user) creating a row on behalf of a user sets
+        // CreatedBy itself. The interceptor must not clobber it with null (#230).
+        await using var fixture = CreateFixture(); // no current user
+        var entity = new AuditableTestEntity { Name = "Test", CreatedBy = "owner-456" };
+
+        fixture.Context.AuditableEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedBy.Should().Be("owner-456");
+    }
+
+    [Fact]
+    public async Task Added_Auditable_Entity_Preserves_Explicit_CreatedBy_Over_Current_User()
+    {
+        // An explicitly-set creator wins over the ambient HTTP user, but the
+        // modification stamp still reflects who performed this save.
+        await using var fixture = CreateFixture(TestUserId);
+        var entity = new AuditableTestEntity { Name = "Test", CreatedBy = "owner-456" };
+
+        fixture.Context.AuditableEntities.Add(entity);
+        await fixture.Context.SaveChangesAsync();
+
+        entity.CreatedBy.Should().Be("owner-456");
+        entity.UpdatedBy.Should().Be(TestUserId);
+    }
+
+    [Fact]
     public async Task Modified_Auditable_Entity_Updates_UpdatedBy_Only()
     {
         await using var fixture = CreateFixture(TestUserId);

--- a/tests/SimpleModule.Database.Tests/ModuleModelBuilderExtensionsTests.cs
+++ b/tests/SimpleModule.Database.Tests/ModuleModelBuilderExtensionsTests.cs
@@ -57,6 +57,33 @@ public sealed class ModuleModelBuilderExtensionsTests : IDisposable
     }
 
     [Fact]
+    public void ExplicitProvider_OverridesConnectionStringHeuristic()
+    {
+        // DefaultConnection looks like SQLite, but Provider is set explicitly to
+        // PostgreSql. The explicit provider must win, so entities get a schema —
+        // not a SQLite table-name prefix (#227).
+        var options = new DbContextOptionsBuilder<SharedPostgresDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        var dbOptions = Options.Create(
+            new DatabaseOptions
+            {
+                DefaultConnection = "Data Source=app.db", // looks like SQLite
+                Provider = "PostgreSql", // explicit override wins
+            }
+        );
+        using var db = new SharedPostgresDbContext(options, dbOptions);
+
+        var schemas = db.Model.GetEntityTypes().Select(e => e.GetSchema()).Distinct().ToList();
+
+        schemas.Should().AllBe("testmodule");
+        db.Model.GetEntityTypes()
+            .Select(e => e.GetTableName())
+            .Should()
+            .NotContain(t => t!.StartsWith("TestModule_"));
+    }
+
+    [Fact]
     public void SharedPostgresDb_SetsSchemaToLowercaseModuleName()
     {
         var options = new DbContextOptionsBuilder<SharedPostgresDbContext>()

--- a/tests/SimpleModule.DevTools.Tests/MapLiveReloadTests.cs
+++ b/tests/SimpleModule.DevTools.Tests/MapLiveReloadTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SimpleModule.DevTools.Tests;
+
+public sealed class MapLiveReloadTests
+{
+    [Fact]
+    public async Task MapLiveReload_Endpoint_IsAnonymous()
+    {
+        // The framework authenticates by default, so the live-reload WebSocket must
+        // opt out — otherwise the handshake gets a 302 to login and the browser
+        // client reconnects forever, flooding the console (#233).
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Services.AddSingleton<LiveReloadServer>();
+        await using var app = builder.Build();
+
+        app.MapLiveReload();
+
+        var endpoint = ((IEndpointRouteBuilder)app)
+            .DataSources.SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(e => e.RoutePattern.RawText == "/dev/live-reload");
+
+        endpoint
+            .Metadata.GetMetadata<IAllowAnonymous>()
+            .Should()
+            .NotBeNull("the dev live-reload socket must not be behind the auth fallback policy");
+    }
+}

--- a/tools/SimpleModule.DevTools/LiveReloadServer.cs
+++ b/tools/SimpleModule.DevTools/LiveReloadServer.cs
@@ -235,19 +235,24 @@ public static class LiveReloadEndpointExtensions
         app.UseWebSockets();
 
         app.Map(
-            LiveReloadPath,
-            async (HttpContext context, LiveReloadServer server) =>
-            {
-                if (!context.WebSockets.IsWebSocketRequest)
+                LiveReloadPath,
+                async (HttpContext context, LiveReloadServer server) =>
                 {
-                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                    return;
-                }
+                    if (!context.WebSockets.IsWebSocketRequest)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return;
+                    }
 
-                using var ws = await context.WebSockets.AcceptWebSocketAsync();
-                await server.HandleWebSocketAsync(ws);
-            }
-        );
+                    using var ws = await context.WebSockets.AcceptWebSocketAsync();
+                    await server.HandleWebSocketAsync(ws);
+                }
+            )
+            // The dev live-reload socket must be public: the framework's
+            // authenticated-by-default fallback policy would otherwise challenge the
+            // handshake with a 302 to the login page (never a 101 upgrade), so the
+            // browser client reconnects forever, flooding the console (#233).
+            .AllowAnonymous();
 
         return app;
     }


### PR DESCRIPTION
A batch of data-correctness / concurrency bug fixes. One commit per issue, each with a regression test; full local CI green.

## What's fixed

### `fix(database): preserve explicitly-set CreatedBy in EntityInterceptor` — #230
`EntityInterceptor` stamped `CreatedBy` from the current `HttpContext` user unconditionally on insert. A background job (no `HttpContext`) creating a row on behalf of a user couldn't set `CreatedBy` — the interceptor overwrote it with `null`. Creation fields are now only defaulted when unset (`CreatedBy` only if null/empty, `CreatedAt` only if default); modification fields (`UpdatedBy`/`UpdatedAt`) are unchanged.

### `fix(database): honor DatabaseOptions.Provider in ApplyModuleSchema` — #227
`ApplyModuleSchema` detected the provider purely by sniffing `DefaultConnection`, ignoring an explicitly-configured `DatabaseOptions.Provider`. A host that set `Database:Provider` but left a connection string resembling another provider got the wrong schema strategy (table prefixes vs real schemas). It now passes `dbOptions.Provider` to `DatabaseProviderDetector.Detect` — explicit wins, sniffing is the fallback (consistent with `AddModuleDbContext` and the generated `HostDbContext`).

### `fix(auditlogs): read audit settings sequentially to avoid DbContext race` — #232
`AuditMiddleware` loaded its five capture settings via `Task.WhenAll`. All five reads resolve through the request's scoped `SettingsDbContext`, and a `DbContext` forbids concurrent operations — on a cold cache the parallel reads raced ("A second operation was started on this context instance...") and surfaced as **intermittent 500s on any request**. The reads are now sequential (values are tiny and per-key cached, so the cost is negligible). Regression test uses a concurrency-tracking settings stub that fails if more than one read is ever in flight.

### `fix(devtools): stop live-reload WebSocket retry flood on 302` — #233
The `/dev/live-reload` WebSocket was mapped without `.AllowAnonymous()`, so the framework's authenticated-by-default fallback policy challenged the handshake with a 302 to login instead of a 101 upgrade — and the browser client reconnected ~1/s forever, flooding the console. Root cause fixed with `.AllowAnonymous()`; the client also now gives up after 60 attempts (resetting on a successful connect) as defense-in-depth. Dev-only. Test asserts the endpoint carries `IAllowAnonymous` metadata.

## Verification (local CI, all green)
- `dotnet build` — 0 errors
- `dotnet test --no-build` — 0 failures
- `npm run check` — biome, validators, typecheck 13/13
- `npm run build` — clean
- `npm run test:smoke -w tests/e2e` — 66 passed

## Out of scope / follow-up
- **#229** (a child entity reachable only via navigation — `[Dto]` with `Id`, no `DbSet` — can get the wrong/no schema prefix in the generated `HostDbContext`) is a latent issue with no current in-tree repro; the fix is a riskier generator change (emitting EF-model traversal). Tracked for its own PR.

Closes #230
Closes #227
Closes #232
Closes #233
