### PR TITLE
fix(client): keep Node-only build helpers out of the root barrel (#237)

### DIFF
--- a/packages/SimpleModule.Client/src/index.ts
+++ b/packages/SimpleModule.Client/src/index.ts
@@ -1,10 +1,9 @@
-export { defineModuleConfig } from './define-module-config.ts';
+// Browser-runtime exports only. Build-time helpers (defineModuleConfig,
+// vendorBuildPlugin, vendorPaths, defaultVendors) import Node-only APIs
+// (node:fs / node:path / node:module) and must NOT be re-exported here: a page
+// that imports the root barrel would otherwise pull `createRequire` into the
+// browser bundle, throw "createRequire is not a function", and render blank (#237).
+// Import those from '@simplemodule/client/module' and '@simplemodule/client/vite'.
 export { resolvePage } from './resolve-page.ts';
 export { routes } from './routes.ts';
 export { useTranslation } from './use-translation.ts';
-export {
-  defaultVendors,
-  type VendorEntry,
-  vendorBuildPlugin,
-  vendorPaths,
-} from './vite-plugin-vendor.ts';


### PR DESCRIPTION
## Summary

A module page that imports from the **root** `@simplemodule/client` barrel (e.g. `import { useTranslation } from '@simplemodule/client'`) rendered **blank** with `TypeError: createRequire is not a function`.

## Root cause

The root barrel (`src/index.ts`, the `.` export) re-exported build-time helpers — `defineModuleConfig`, `vendorBuildPlugin`, `vendorPaths`, `defaultVendors` — whose modules import Node-only APIs (`node:fs` / `node:path` / `node:module`, e.g. `createRequire(import.meta.url)`). When a page imports the barrel, Vite pulls that Node-only code into the browser bundle (the `createRequire` call hits the `__vite-browser-external` stub and throws at evaluation), so the whole page bundle fails to load → blank page + ~15 extra chunks / ~900 KB.

## Fix

The root barrel now exports only browser-runtime helpers: `resolvePage`, `routes`, `useTranslation`. The build-time helpers stay available via their dedicated subpaths `@simplemodule/client/module` and `@simplemodule/client/vite` — which is exactly how every consumer (module `vite.config.ts`) already imports them, so nothing in the repo or scaffold changes. `useTranslation` (and the other runtime helpers) remain importable from the barrel, so the documented `import { useTranslation } from '@simplemodule/client'` keeps working — it just no longer drags in Node tooling.

## Verification

- `npm run check` — biome + validators + typecheck 13/13
- `npm run build` — all module bundles build
- Definitive bundle probe: a browser (`--platform=browser`) bundle of `import { useTranslation, resolvePage, routes } from '@simplemodule/client'` is now **~12 KB with zero** `createRequire` / `node:*` / `__vite-browser-external` references (was ~900 KB / ~15 chunks).

Closes #237
