### PR TITLE
fix: critical issues — page-registry guard, deployment-security hardening, DbContext races/outbox, docs/CI reconciliation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,26 @@ jobs:
       - name: Test
         run: dotnet test --no-build
 
+  vulnerable-packages:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - run: dotnet restore
+
+      - name: Audit NuGet packages for known vulnerabilities
+        run: |
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerable.txt
+          if grep -q "has the following vulnerable packages" vulnerable.txt; then
+            echo "::error::Vulnerable NuGet packages found — see log above"
+            exit 1
+          fi
+
   e2e:
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '24 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,34 +87,32 @@ dotnet test --filter "FullyQualifiedName~ClassName"    # single test class
 dotnet test --filter "FullyQualifiedName~MethodName"   # single test method
 ```
 
-Test stack: xUnit.v3, FluentAssertions, Bogus, Microsoft.AspNetCore.Mvc.Testing. SQLite in-memory for unit tests, PostgreSQL for integration tests in CI.
+Test stack: xUnit.v3, FluentAssertions, Bogus, Microsoft.AspNetCore.Mvc.Testing. SQLite in-memory for unit and integration tests (a PostgreSQL CI leg is a known gap — the test factory is SQLite-only today).
 
 ### Benchmarks (BenchmarkDotNet)
 
 ```bash
 dotnet run -c Release --project tests/SimpleModule.Benchmarks          # all benchmarks
-dotnet run -c Release --project tests/SimpleModule.Benchmarks -- --filter "*Products*"  # specific module
+dotnet run -c Release --project tests/SimpleModule.Benchmarks -- --filter "*Users*"  # specific module
 ```
 
-Micro-benchmarks for every module: endpoint latency (CRUD operations via in-process TestServer), JSON serialization/deserialization of DTOs. Uses `SimpleModuleWebApplicationFactory` with test auth headers for low-overhead measurement.
+Micro-benchmarks for Admin, AuditLogs, FileStorage, Settings, and Users: endpoint latency (CRUD operations via in-process TestServer), JSON serialization/deserialization of DTOs. Uses `SimpleModuleWebApplicationFactory` with test auth headers for low-overhead measurement.
 
 ### Load Tests (NBomber)
 
 ```bash
-dotnet test tests/SimpleModule.LoadTests                               # all 11 scenarios (50 concurrent, ~5 min)
-dotnet test tests/SimpleModule.LoadTests --filter "Products_Crud"      # single scenario
+dotnet test tests/SimpleModule.LoadTests                               # all scenarios
+dotnet test tests/SimpleModule.LoadTests --filter "Users_Crud"         # single scenario
 ```
 
-HTTP load tests using real OAuth Bearer tokens acquired via ROPC (password grant) from OpenIddict. Runs against the full ASP.NET pipeline with file-based SQLite in WAL mode. 11 scenarios covering all modules at 50 concurrent copies:
+HTTP load tests using real OAuth Bearer tokens acquired via ROPC (password grant) from OpenIddict. Runs against the full ASP.NET pipeline with file-based SQLite in WAL mode. Six scenarios (`tests/SimpleModule.LoadTests/Scenarios/`), each runnable individually or combined via `All_Scenarios`:
 
-- **Products, Orders, Users** — full CRUD lifecycle (create → read → update → delete)
-- **Settings** — read operations (settings, definitions, menus, available pages)
-- **AuditLogs, FileStorage** — read operations (list, get by ID, folders)
-- **PageBuilder** — full lifecycle (create → get → update → publish → unpublish → delete + tags/templates)
-- **Admin** — role create/delete (handles 302 redirects)
-- **FeatureFlags** — get all flags, check flag status
-- **Marketplace** — search and browse (anonymous)
-- **Mixed Realistic** — weighted workload (70% reads, 20% creates, 10% updates)
+- **Users** (`Users_Crud`) — full CRUD lifecycle
+- **Settings** (`Settings_Ops`) — read operations
+- **AuditLogs** (`AuditLogs_Read`) — read operations
+- **FileStorage** (`Files_Ops`) — file operations
+- **Admin** (`Admin_Ops`) — role create/delete (handles 302 redirects)
+- **FeatureFlags** (`FeatureFlags_Ops`) — get all flags, check flag status
 
 **Key infrastructure:**
 - `LoadTestWebApplicationFactory` — extends `WebApplicationFactory` with file-based SQLite + WAL, seeds OAuth client/user/permissions, acquires Bearer tokens via `/connect/token`
@@ -131,13 +129,13 @@ HTTP load tests using real OAuth Bearer tokens acquired via ROPC (password grant
 
 ### Frontend (React + Inertia.js)
 
-- **ClientApp** (`template/SimpleModule.Host/ClientApp/app.tsx`) — Inertia bootstrap. Resolves pages by splitting route name (e.g., `Products/Browse` → imports `/_content/Products/Products.pages.js`).
+- **ClientApp** (`template/SimpleModule.Host/ClientApp/app.tsx`) — Inertia bootstrap. Resolves pages by splitting route name (e.g., `Tenants/Browse` → imports `/_content/Tenants/Tenants.pages.js`).
 - **Module pages** — Each module builds its React pages via Vite in library mode → `{ModuleName}.pages.js` in module's `wwwroot/`. Entry point: `Pages/index.ts` exporting a `pages` record mapping route names to components.
 - **Type generation** — `[Dto]` types → source generator embeds TS interfaces → `scripts/extract-ts-types.mjs` writes `.ts` files to `ClientApp/types/`.
 
 ### Request Flow
 
-1. ASP.NET route handler calls `Inertia.Render("Products/Browse", props)`
+1. ASP.NET route handler calls `Inertia.Render("Tenants/Browse", props)`
 2. Inertia middleware renders static HTML shell with embedded JSON props
 3. React ClientApp dynamically imports module's `pages.js` bundle
 4. Component hydrates with server-provided props
@@ -177,15 +175,15 @@ When you add a new `IViewEndpoint`, you **must** register it in your module's `P
 **Pattern:**
 
 ```typescript
-// modules/Products/src/Products/Pages/index.ts
-export const pages: Record<string, any> = {
-    "Products/Browse": () => import("./Browse"),
-    "Products/Manage": () => import("./Manage"),
-    "Products/Create": () => import("./Create"),
+// modules/Tenants/src/SimpleModule.Tenants/Pages/index.ts
+export const pages: Record<string, unknown> = {
+  'Tenants/Browse': () => import('./Browse'),
+  'Tenants/Manage': () => import('./Manage'),
+  'Tenants/Create': () => import('./Create'),
 };
 ```
 
-**The Rule:** For every `IViewEndpoint` with `Inertia.Render("Products/Something", ...)`, add a matching entry in `pages`. The component name in Inertia.Render (e.g., `"Products/Manage"`) is your key.
+**The Rule:** For every `IViewEndpoint` with `Inertia.Render("Tenants/Something", ...)`, add a matching entry in `pages`. The component name in Inertia.Render (e.g., `"Tenants/Manage"`) is your key.
 
 **Validation:** After adding endpoints, run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,28 @@ services:
     ports:
       - "8080:8080"
     environment:
-      # Development enables auto-migration. For production, apply migrations
-      # externally and set to Production.
+      # Development enables auto-migration and ephemeral signing keys for a
+      # local quickstart. Do NOT expose this stack to the internet as-is: set
+      # ASPNETCORE_ENVIRONMENT=Production (which additionally enforces signing
+      # certificates and refuses the password grant), apply migrations
+      # externally, and configure ForwardedHeaders__KnownProxies for your
+      # reverse proxy.
       ASPNETCORE_ENVIRONMENT: Development
       Database__DefaultConnection: "Host=postgres;Port=5432;Database=simplemodule;Username=simplemodule;Password=${POSTGRES_PASSWORD:-simplemodule}"
       Database__Provider: PostgreSQL
       # Set to your public URL so OpenIddict registers correct redirect URIs.
       # Examples: https://app.simplemodule.dev, http://localhost:8080
       OpenIddict__BaseUrl: ${APP_BASE_URL:-http://localhost:8080}
+      # The ROPC password grant stays off even in this Development quickstart —
+      # combined with seeded credentials it would hand out fully-privileged
+      # tokens with a single POST /connect/token.
+      OpenIddict__AllowPasswordGrant: "false"
+      # Required: password for the seeded admin account. There is deliberately
+      # no default — put SEED_ADMIN_PASSWORD in your .env file.
+      Seed__AdminPassword: ${SEED_ADMIN_PASSWORD:?Set SEED_ADMIN_PASSWORD in .env}
+      # Optional: password for the seeded demo user (outside Development the
+      # demo user is skipped entirely when this is unset).
+      Seed__UserPassword: ${SEED_USER_PASSWORD:-}
       # api stays in Producer mode — it enqueues jobs but never runs them.
       # All IModuleJob execution lives in the worker service below.
       BackgroundJobs__WorkerMode: Producer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
       # local quickstart. Do NOT expose this stack to the internet as-is: set
       # ASPNETCORE_ENVIRONMENT=Production (which additionally enforces signing
       # certificates and refuses the password grant), apply migrations
-      # externally, and configure ForwardedHeaders__KnownProxies for your
-      # reverse proxy.
+      # externally, and trust your reverse proxy via a comma-separated
+      # ForwardedHeaders__KnownProxies=10.0.0.5,10.0.0.6 (or
+      # ForwardedHeaders__KnownNetworks=10.0.0.0/8). Without it X-Forwarded-For
+      # is ignored and per-IP rate limiting keys every client to the proxy IP.
       ASPNETCORE_ENVIRONMENT: Development
       Database__DefaultConnection: "Host=postgres;Port=5432;Database=simplemodule;Username=simplemodule;Password=${POSTGRES_PASSWORD:-simplemodule}"
       Database__Provider: PostgreSQL
@@ -53,6 +55,13 @@ services:
       Database__DefaultConnection: "Host=postgres;Port=5432;Database=simplemodule;Username=simplemodule;Password=${POSTGRES_PASSWORD:-simplemodule}"
       Database__Provider: PostgreSQL
       BackgroundJobs__WorkerMode: Consumer
+      # The worker runs the same module set as the api, including the user
+      # seeder. It must see the SAME seed passwords — otherwise whichever
+      # process wins the startup race seeds the admin account, and a worker
+      # without these would silently seed the compiled-in default password,
+      # defeating the api's required SEED_ADMIN_PASSWORD.
+      Seed__AdminPassword: ${SEED_ADMIN_PASSWORD:?Set SEED_ADMIN_PASSWORD in .env}
+      Seed__UserPassword: ${SEED_USER_PASSWORD:-}
     volumes:
       - storage_data:/app/storage
     depends_on:

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -431,8 +431,8 @@ xUnit.v3, FluentAssertions, Bogus, `SimpleModuleWebApplicationFactory`.
 
 ### Database
 
-- SQLite in-memory locally, PostgreSQL in CI.
-- Both providers tested in CI.
+- SQLite in-memory for unit and integration tests (shared connection per test factory).
+- A PostgreSQL CI test leg is planned but not yet implemented — `SimpleModuleWebApplicationFactory` currently supports SQLite only.
 
 ### Rules
 
@@ -600,7 +600,8 @@ All SM diagnostics are emitted by the Roslyn source generator at compile time. `
 - `TreatWarningsAsErrors` is enabled globally via `Directory.Build.props`.
 - `AnalysisLevel=latest-all`, `AnalysisMode=All`.
 - Suppressed rules live in `.editorconfig`.
-- Tests run against both SQLite and PostgreSQL in CI.
+- CI tests run against SQLite. A PostgreSQL leg (postgres service + provider switch in the test factory) is a known gap.
+- CodeQL, Dependabot, and a vulnerable-package audit run in CI for security scanning.
 
 ---
 

--- a/framework/SimpleModule.Core/Hosting/HostEnvironmentExtensions.cs
+++ b/framework/SimpleModule.Core/Hosting/HostEnvironmentExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+
+namespace SimpleModule.Core.Hosting;
+
+/// <summary>
+/// Shared environment classification for the framework's fail-fast guards.
+/// </summary>
+public static class HostEnvironmentExtensions
+{
+    /// <summary>
+    /// The well-known name for the test environment used by the in-process
+    /// <c>WebApplicationFactory</c> harnesses.
+    /// </summary>
+    public const string TestingEnvironmentName = "Testing";
+
+    /// <summary>
+    /// True for the developer-machine and CI/test environments — Development and
+    /// Testing — where compiled-in defaults (seed passwords, ephemeral signing
+    /// keys, the ROPC password grant) are acceptable conveniences.
+    /// <para>
+    /// Every other environment (Staging, QA, Production, or any custom name) is
+    /// treated as a real deployment: the security guards require explicit
+    /// configuration and refuse the unsafe defaults. Using a single predicate
+    /// keeps <c>UserSeedService</c> and <c>OpenIddictProductionGuard</c>
+    /// consistent — a deployment is never hardened by one guard and waved
+    /// through by the other.
+    /// </para>
+    /// </summary>
+    public static bool IsLocalOrTest(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return environment.IsDevelopment() || environment.IsEnvironment(TestingEnvironmentName);
+    }
+}

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.Helpers.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.Helpers.cs
@@ -16,6 +16,30 @@ public static partial class SimpleModuleHostExtensions
     private const string ModuleContentPathPrefix = "/_content/";
     private const string ModuleScriptExtension = ".mjs";
 
+    /// <summary>
+    /// Reads a config list that may be expressed either as a JSON/indexed array
+    /// (<c>ForwardedHeaders:KnownProxies:0</c>) or as a single comma-separated
+    /// scalar (<c>ForwardedHeaders__KnownProxies=10.0.0.5,10.0.0.6</c>, the form
+    /// natural for environment variables). Binding only the array form silently
+    /// dropped scalar env vars, leaving the proxy untrusted.
+    /// </summary>
+    private static string[] ReadConfigList(IConfigurationSection section, string key)
+    {
+        var array = section.GetSection(key).Get<string[]>();
+        if (array is { Length: > 0 })
+        {
+            return array;
+        }
+
+        var scalar = section[key];
+        return string.IsNullOrWhiteSpace(scalar)
+            ? []
+            : scalar.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            );
+    }
+
     private static IResult RenderErrorPage(int statusCode)
     {
         var (title, message) = statusCode switch

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -75,14 +75,30 @@ public static partial class SimpleModuleHostExtensions
                 return;
             }
 
-            foreach (var proxy in section.GetSection("KnownProxies").Get<string[]>() ?? [])
+            foreach (var proxy in ReadConfigList(section, "KnownProxies"))
             {
-                fhOptions.KnownProxies.Add(System.Net.IPAddress.Parse(proxy));
+                if (!System.Net.IPAddress.TryParse(proxy, out var address))
+                {
+                    throw new InvalidOperationException(
+                        $"ForwardedHeaders:KnownProxies contains '{proxy}', which is not a valid "
+                            + "IP address."
+                    );
+                }
+
+                fhOptions.KnownProxies.Add(address);
             }
 
-            foreach (var network in section.GetSection("KnownNetworks").Get<string[]>() ?? [])
+            foreach (var network in ReadConfigList(section, "KnownNetworks"))
             {
-                fhOptions.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(network));
+                if (!System.Net.IPNetwork.TryParse(network, out var ipNetwork))
+                {
+                    throw new InvalidOperationException(
+                        $"ForwardedHeaders:KnownNetworks contains '{network}', which is not a valid "
+                            + "CIDR network (e.g. 10.0.0.0/8)."
+                    );
+                }
+
+                fhOptions.KnownIPNetworks.Add(ipNetwork);
             }
         });
 

--- a/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
+++ b/framework/SimpleModule.Hosting/SimpleModuleHostExtensions.cs
@@ -57,9 +57,33 @@ public static partial class SimpleModuleHostExtensions
         {
             fhOptions.ForwardedHeaders =
                 ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-            // Allow any proxy in containerized/cloud environments
-            fhOptions.KnownIPNetworks.Clear();
-            fhOptions.KnownProxies.Clear();
+
+            // Proxy trust must be explicit. The previous behavior cleared
+            // KnownProxies/KnownIPNetworks, which let any client spoof
+            // X-Forwarded-For and bypass per-IP rate limiting. By default only
+            // loopback is trusted (the ASP.NET Core default); deployments behind
+            // a reverse proxy list it under ForwardedHeaders:KnownProxies /
+            // ForwardedHeaders:KnownNetworks, or — for closed networks where the
+            // proxy address is not static — opt into
+            // ForwardedHeaders:TrustAllProxies.
+            var section = builder.Configuration.GetSection("ForwardedHeaders");
+
+            if (section.GetValue<bool>("TrustAllProxies"))
+            {
+                fhOptions.KnownIPNetworks.Clear();
+                fhOptions.KnownProxies.Clear();
+                return;
+            }
+
+            foreach (var proxy in section.GetSection("KnownProxies").Get<string[]>() ?? [])
+            {
+                fhOptions.KnownProxies.Add(System.Net.IPAddress.Parse(proxy));
+            }
+
+            foreach (var network in section.GetSection("KnownNetworks").Get<string[]>() ?? [])
+            {
+                fhOptions.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(network));
+            }
         });
 
         builder.Services.AddProblemDetails();
@@ -139,7 +163,10 @@ public static partial class SimpleModuleHostExtensions
         // cleared by `sm up`. Resolved as singleton because it caches state
         // for a short interval.
         builder.Services.Configure<MaintenanceModeOptions>(_ => { });
-        builder.Services.TryAddSingleton<IMaintenanceStateProvider, FileSystemMaintenanceStateProvider>();
+        builder.Services.TryAddSingleton<
+            IMaintenanceStateProvider,
+            FileSystemMaintenanceStateProvider
+        >();
 
         if (options.EnableHealthChecks)
         {

--- a/modules/Admin/src/SimpleModule.Admin/AdminService.cs
+++ b/modules/Admin/src/SimpleModule.Admin/AdminService.cs
@@ -10,14 +10,16 @@ public sealed class AdminService(IUserAdminContracts userAdmin, IRoleAdminContra
         CancellationToken cancellationToken = default
     )
     {
-        var usersTask = userAdmin.GetUsersPagedAsync(null, 1, 1);
-        var activeTask = userAdmin.GetUsersPagedAsync(null, 1, 1, filterStatus: "active");
-        var rolesTask = roleAdmin.GetAllRolesAsync();
-        await Task.WhenAll(usersTask, activeTask, rolesTask).ConfigureAwait(false);
-
-        var usersPage = await usersTask.ConfigureAwait(false);
-        var activePage = await activeTask.ConfigureAwait(false);
-        var roles = await rolesTask.ConfigureAwait(false);
+        // Await sequentially, not via Task.WhenAll: IUserAdminContracts and
+        // IRoleAdminContracts are both backed by the same scoped UsersDbContext,
+        // and EF Core forbids concurrent operations on one DbContext instance.
+        // Parallel awaits here intermittently threw "A second operation was
+        // started on this context instance..." → HTTP 500 (same class as #242).
+        var usersPage = await userAdmin.GetUsersPagedAsync(null, 1, 1).ConfigureAwait(false);
+        var activePage = await userAdmin
+            .GetUsersPagedAsync(null, 1, 1, filterStatus: "active")
+            .ConfigureAwait(false);
+        var roles = await roleAdmin.GetAllRolesAsync().ConfigureAwait(false);
 
         return new AdminOverviewDto
         {

--- a/modules/Admin/src/SimpleModule.Admin/Pages/Admin/UsersEditEndpoint.cs
+++ b/modules/Admin/src/SimpleModule.Admin/Pages/Admin/UsersEditEndpoint.cs
@@ -35,14 +35,15 @@ public class UsersEditEndpoint : IViewEndpoint
                     if (user is null)
                         return TypedResults.NotFound();
 
-                    var rolesTask = roleAdmin.GetAllRolesAsync();
-                    var permsTask = permissionContracts.GetPermissionsForUserAsync(UserId.From(id));
-                    var sessionsTask = sessionContracts.GetActiveSessionsForUserAsync(id);
-                    await Task.WhenAll(rolesTask, permsTask, sessionsTask);
-
-                    var allRoles = await rolesTask;
-                    var userPermissions = (await permsTask).ToList();
-                    var activeSessions = await sessionsTask;
+                    // Await sequentially, not via Task.WhenAll: these contracts can
+                    // resolve services backed by the same scoped DbContext, and EF Core
+                    // forbids concurrent operations on one context instance. Parallel
+                    // awaits intermittently surfaced as HTTP 500 (same class as #242).
+                    var allRoles = await roleAdmin.GetAllRolesAsync();
+                    var userPermissions = (
+                        await permissionContracts.GetPermissionsForUserAsync(UserId.From(id))
+                    ).ToList();
+                    var activeSessions = await sessionContracts.GetActiveSessionsForUserAsync(id);
 
                     var permissionsByModule = permissionRegistry.ByModule.ToDictionary(
                         kvp => kvp.Key,

--- a/modules/Admin/src/SimpleModule.Admin/Pages/Admin/UsersEditEndpoint.cs
+++ b/modules/Admin/src/SimpleModule.Admin/Pages/Admin/UsersEditEndpoint.cs
@@ -35,15 +35,21 @@ public class UsersEditEndpoint : IViewEndpoint
                     if (user is null)
                         return TypedResults.NotFound();
 
-                    // Await sequentially, not via Task.WhenAll: these contracts can
-                    // resolve services backed by the same scoped DbContext, and EF Core
-                    // forbids concurrent operations on one context instance. Parallel
-                    // awaits intermittently surfaced as HTTP 500 (same class as #242).
-                    var allRoles = await roleAdmin.GetAllRolesAsync();
-                    var userPermissions = (
-                        await permissionContracts.GetPermissionsForUserAsync(UserId.From(id))
-                    ).ToList();
-                    var activeSessions = await sessionContracts.GetActiveSessionsForUserAsync(id);
+                    // These three contracts are backed by DISTINCT stores —
+                    // IRoleAdminContracts → UsersDbContext, IPermissionContracts →
+                    // PermissionsDbContext, ISessionContracts → the OpenIddict token
+                    // store / Keycloak — so unlike the AdminService case (#242) there
+                    // is no shared-DbContext concurrency hazard and they run in
+                    // parallel. (GetAdminUserByIdAsync above already completed, so no
+                    // other in-flight UsersDbContext operation overlaps GetAllRolesAsync.)
+                    var rolesTask = roleAdmin.GetAllRolesAsync();
+                    var permsTask = permissionContracts.GetPermissionsForUserAsync(UserId.From(id));
+                    var sessionsTask = sessionContracts.GetActiveSessionsForUserAsync(id);
+                    await Task.WhenAll(rolesTask, permsTask, sessionsTask);
+
+                    var allRoles = await rolesTask;
+                    var userPermissions = (await permsTask).ToList();
+                    var activeSessions = await sessionsTask;
 
                     var permissionsByModule = permissionRegistry.ByModule.ToDictionary(
                         kvp => kvp.Key,

--- a/modules/FileStorage/src/SimpleModule.FileStorage/Endpoints/Files/UploadEndpoint.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/Endpoints/Files/UploadEndpoint.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using SimpleModule.Core;
 using SimpleModule.Core.Authorization;
@@ -14,15 +15,30 @@ public class UploadEndpoint : IEndpoint
     public const string Route = FileStorageConstants.Routes.Upload;
     public const string Method = "POST";
 
-    public void Map(IEndpointRouteBuilder app) =>
+    public void Map(IEndpointRouteBuilder app)
+    {
+        // FileStorageModuleOptions is an IOptions singleton, so the size limit and
+        // the parsed extension allowlist are resolved once at registration time
+        // and captured — not re-split into a new HashSet on every upload request.
+        var options = app
+            .ServiceProvider.GetRequiredService<IOptions<FileStorageModuleOptions>>()
+            .Value;
+        var maxBytes = options.MaxFileSizeMb * 1024L * 1024L;
+        // An empty allowlist means "no restriction".
+        var allowedExtensions = options
+            .AllowedExtensions.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         app.MapPost(
                 Route,
                 async Task<IResult> (
                     IFormFile? file,
                     string? folder,
                     HttpContext context,
-                    IFileStorageContracts files,
-                    IOptions<FileStorageModuleOptions> options
+                    IFileStorageContracts files
                 ) =>
                 {
                     if (file is null || file.Length == 0)
@@ -30,23 +46,15 @@ public class UploadEndpoint : IEndpoint
                         return TypedResults.BadRequest("A file is required.");
                     }
 
-                    var maxBytes = options.Value.MaxFileSizeMb * 1024L * 1024L;
                     if (file.Length > maxBytes)
                     {
                         return TypedResults.Problem(
                             detail: $"File exceeds the maximum allowed size of "
-                                + $"{options.Value.MaxFileSizeMb} MB.",
+                                + $"{options.MaxFileSizeMb} MB.",
                             statusCode: StatusCodes.Status413PayloadTooLarge
                         );
                     }
 
-                    // An empty AllowedExtensions list means "no restriction".
-                    var allowedExtensions = options
-                        .Value.AllowedExtensions.Split(
-                            ',',
-                            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                        )
-                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
                     var extension = Path.GetExtension(file.FileName);
                     if (
                         allowedExtensions.Count > 0
@@ -58,7 +66,7 @@ public class UploadEndpoint : IEndpoint
                     {
                         return TypedResults.BadRequest(
                             $"File type '{extension}' is not allowed. Allowed extensions: "
-                                + $"{options.Value.AllowedExtensions}"
+                                + $"{options.AllowedExtensions}"
                         );
                     }
 
@@ -76,4 +84,5 @@ public class UploadEndpoint : IEndpoint
             )
             .RequirePermission(FileStoragePermissions.Upload)
             .DisableAntiforgery();
+    }
 }

--- a/modules/FileStorage/src/SimpleModule.FileStorage/Endpoints/Files/UploadEndpoint.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/Endpoints/Files/UploadEndpoint.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 using SimpleModule.Core;
 using SimpleModule.Core.Authorization;
 using SimpleModule.Core.Extensions;
@@ -20,12 +21,45 @@ public class UploadEndpoint : IEndpoint
                     IFormFile? file,
                     string? folder,
                     HttpContext context,
-                    IFileStorageContracts files
+                    IFileStorageContracts files,
+                    IOptions<FileStorageModuleOptions> options
                 ) =>
                 {
                     if (file is null || file.Length == 0)
                     {
                         return TypedResults.BadRequest("A file is required.");
+                    }
+
+                    var maxBytes = options.Value.MaxFileSizeMb * 1024L * 1024L;
+                    if (file.Length > maxBytes)
+                    {
+                        return TypedResults.Problem(
+                            detail: $"File exceeds the maximum allowed size of "
+                                + $"{options.Value.MaxFileSizeMb} MB.",
+                            statusCode: StatusCodes.Status413PayloadTooLarge
+                        );
+                    }
+
+                    // An empty AllowedExtensions list means "no restriction".
+                    var allowedExtensions = options
+                        .Value.AllowedExtensions.Split(
+                            ',',
+                            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                        )
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                    var extension = Path.GetExtension(file.FileName);
+                    if (
+                        allowedExtensions.Count > 0
+                        && (
+                            string.IsNullOrEmpty(extension)
+                            || !allowedExtensions.Contains(extension)
+                        )
+                    )
+                    {
+                        return TypedResults.BadRequest(
+                            $"File type '{extension}' is not allowed. Allowed extensions: "
+                                + $"{options.Value.AllowedExtensions}"
+                        );
                     }
 
                     var userId = context.User.GetUserId();

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModule.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModule.cs
@@ -70,7 +70,7 @@ public class FileStorageModule : IModule
                     "Comma-separated list of allowed file extensions (e.g., .jpg,.pdf,.zip).",
                 Group = "FileStorage",
                 Scope = SettingScope.Application,
-                DefaultValue = "\".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip\"",
+                DefaultValue = ".txt,.csv,.jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip",
                 Type = SettingType.Text,
             }
         );

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModuleOptions.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageModuleOptions.cs
@@ -13,9 +13,10 @@ public class FileStorageModuleOptions : IModuleOptions
     public int MaxFileSizeMb { get; set; } = 50;
 
     /// <summary>
-    /// Comma-separated list of allowed file extensions for uploads.
-    /// Default: ".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip"
+    /// Comma-separated list of allowed file extensions for uploads. An empty
+    /// string disables the extension check (any type allowed, size limit still
+    /// applies). The default covers common documents, plain text, and images.
     /// </summary>
     public string AllowedExtensions { get; set; } =
-        ".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip";
+        ".txt,.csv,.jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.xls,.xlsx,.zip";
 }

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageService.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageService.cs
@@ -63,28 +63,26 @@ public sealed partial class FileStorageService(
 
         var result = await storageProvider.SaveAsync(storagePath, content, contentType);
 
+        var storedFile = new StoredFile
+        {
+            FileName = fileName,
+            StoragePath = result.Path,
+            ContentType = contentType,
+            Size = result.Size,
+            Folder = normalizedFolder,
+            CreatedByUserId = userId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        db.StoredFiles.Add(storedFile);
+
+        // FileStorageId is database-generated, so the row must be saved before
+        // the event can carry it. The explicit transaction keeps the row and the
+        // outbox envelope atomic.
+        await using var transaction = await db.Database.BeginTransactionAsync();
+
         try
         {
-            var storedFile = new StoredFile
-            {
-                FileName = fileName,
-                StoragePath = result.Path,
-                ContentType = contentType,
-                Size = result.Size,
-                Folder = normalizedFolder,
-                CreatedByUserId = userId,
-                CreatedAt = DateTimeOffset.UtcNow,
-            };
-
-            db.StoredFiles.Add(storedFile);
-
-            // FileStorageId is database-generated, so the row must be saved before
-            // the event can carry it. The explicit transaction keeps the row and the
-            // outbox envelope atomic: SaveChangesAndFlushMessagesAsync persists the
-            // envelope, commits the open transaction, and only then releases the
-            // event to the bus. The previous SaveChanges-then-PublishAsync pattern
-            // lost the event when the process died between the two calls.
-            await using var transaction = await db.Database.BeginTransactionAsync();
             await db.SaveChangesAsync();
             await outbox.PublishAsync(
                 new FileUploadedEvent(
@@ -94,17 +92,26 @@ public sealed partial class FileStorageService(
                     storedFile.ContentType
                 )
             );
-            await outbox.SaveChangesAndFlushMessagesAsync();
-
-            LogFileUploaded(logger, storedFile.Id, storedFile.FileName);
-
-            return storedFile;
         }
         catch
         {
+            // The row is not yet committed — roll back the orphaned blob. The blob
+            // cleanup MUST stay scoped to the pre-commit window: once the row is
+            // committed below, deleting the blob would dangle a committed StoredFile
+            // against a missing file.
             await storageProvider.DeleteAsync(result.Path);
             throw;
         }
+
+        // Commits the transaction (row + envelope), then flushes messages. A
+        // failure here is post-persist: the row may already be committed, so the
+        // blob must be left in place. The previous SaveChanges-then-PublishAsync
+        // pattern lost the event when the process died between the two calls.
+        await outbox.SaveChangesAndFlushMessagesAsync();
+
+        LogFileUploaded(logger, storedFile.Id, storedFile.FileName);
+
+        return storedFile;
     }
 
     public async Task DeleteFileAsync(FileStorageId id)
@@ -122,10 +129,13 @@ public sealed partial class FileStorageService(
 
         db.StoredFiles.Remove(file);
 
-        // Publish through the outbox so the delete and the event commit atomically.
-        // Previously the event was published only after blob deletion succeeded, so
-        // a crash — or a failed blob delete — after the DB commit silently dropped
-        // FileDeletedEvent even though the file was gone from the system of record.
+        // The DB row is the system of record: once it is gone, the file is deleted
+        // as far as the application is concerned. Publish through the outbox so the
+        // row removal and FileDeletedEvent commit atomically — previously the event
+        // fired only after blob deletion succeeded, so a crash (or a failed blob
+        // delete) after the DB commit silently dropped the event. Blob deletion
+        // below is best-effort cleanup; a failure there leaves an orphaned blob (a
+        // storage-sweep concern), not a lost event or a dangling row.
         await outbox.PublishAsync(new FileDeletedEvent(file.Id, file.FileName));
         await outbox.SaveChangesAndFlushMessagesAsync();
 

--- a/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageService.cs
+++ b/modules/FileStorage/src/SimpleModule.FileStorage/FileStorageService.cs
@@ -3,14 +3,14 @@ using Microsoft.Extensions.Logging;
 using SimpleModule.FileStorage.Contracts;
 using SimpleModule.FileStorage.Contracts.Events;
 using SimpleModule.Storage;
-using Wolverine;
+using Wolverine.EntityFrameworkCore;
 
 namespace SimpleModule.FileStorage;
 
 public sealed partial class FileStorageService(
     FileStorageDbContext db,
     IStorageProvider storageProvider,
-    IMessageBus bus,
+    IDbContextOutbox<FileStorageDbContext> outbox,
     ILogger<FileStorageService> logger
 ) : IFileStorageContracts
 {
@@ -77,11 +77,16 @@ public sealed partial class FileStorageService(
             };
 
             db.StoredFiles.Add(storedFile);
+
+            // FileStorageId is database-generated, so the row must be saved before
+            // the event can carry it. The explicit transaction keeps the row and the
+            // outbox envelope atomic: SaveChangesAndFlushMessagesAsync persists the
+            // envelope, commits the open transaction, and only then releases the
+            // event to the bus. The previous SaveChanges-then-PublishAsync pattern
+            // lost the event when the process died between the two calls.
+            await using var transaction = await db.Database.BeginTransactionAsync();
             await db.SaveChangesAsync();
-
-            LogFileUploaded(logger, storedFile.Id, storedFile.FileName);
-
-            await bus.PublishAsync(
+            await outbox.PublishAsync(
                 new FileUploadedEvent(
                     storedFile.Id,
                     storedFile.FileName,
@@ -89,6 +94,9 @@ public sealed partial class FileStorageService(
                     storedFile.ContentType
                 )
             );
+            await outbox.SaveChangesAndFlushMessagesAsync();
+
+            LogFileUploaded(logger, storedFile.Id, storedFile.FileName);
 
             return storedFile;
         }
@@ -113,7 +121,13 @@ public sealed partial class FileStorageService(
         var storagePath = file.StoragePath;
 
         db.StoredFiles.Remove(file);
-        await db.SaveChangesAsync();
+
+        // Publish through the outbox so the delete and the event commit atomically.
+        // Previously the event was published only after blob deletion succeeded, so
+        // a crash — or a failed blob delete — after the DB commit silently dropped
+        // FileDeletedEvent even though the file was gone from the system of record.
+        await outbox.PublishAsync(new FileDeletedEvent(file.Id, file.FileName));
+        await outbox.SaveChangesAndFlushMessagesAsync();
 
         try
         {
@@ -128,8 +142,6 @@ public sealed partial class FileStorageService(
         }
 
         LogFileDeleted(logger, file.Id, file.FileName);
-
-        await bus.PublishAsync(new FileDeletedEvent(file.Id, file.FileName));
     }
 
     public async Task<Stream?> DownloadFileAsync(FileStorageId id)

--- a/modules/FileStorage/tests/SimpleModule.FileStorage.Tests/FileStorageServiceTests.cs
+++ b/modules/FileStorage/tests/SimpleModule.FileStorage.Tests/FileStorageServiceTests.cs
@@ -38,7 +38,7 @@ public sealed partial class FileStorageServiceTests : IDisposable
         _service = new FileStorageService(
             _db,
             _storageProvider,
-            new TestMessageBus(),
+            new FakeDbContextOutbox<FileStorageDbContext>(_db),
             NullLogger<FileStorageService>.Instance
         );
     }
@@ -229,7 +229,7 @@ public sealed partial class FileStorageServiceTests : IDisposable
         var failingService = new FileStorageService(
             _db,
             failingProvider,
-            new TestMessageBus(),
+            new FakeDbContextOutbox<FileStorageDbContext>(_db),
             NullLogger<FileStorageService>.Instance
         );
 

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/ConfigKeys.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict.Contracts/ConfigKeys.cs
@@ -3,6 +3,13 @@ namespace SimpleModule.OpenIddict.Contracts;
 public static class ConfigKeys
 {
     public const string OpenIddictBaseUrl = "OpenIddict:BaseUrl";
+
+    /// <summary>
+    /// Enables the ROPC (resource-owner password credentials) grant. Intended for
+    /// local load testing only — <c>OpenIddictProductionGuard</c> refuses it in
+    /// real deployments.
+    /// </summary>
+    public const string OpenIddictAllowPasswordGrant = "OpenIddict:AllowPasswordGrant";
     public const string OpenIddictEncryptionCertPath = "OpenIddict:EncryptionCertificatePath";
     public const string OpenIddictSigningCertPath = "OpenIddict:SigningCertificatePath";
     public const string OpenIddictCertPassword = "OpenIddict:CertificatePassword";

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
@@ -66,7 +66,9 @@ public class OpenIddictModule : IModule
 
                 options.AllowRefreshTokenFlow();
 
-                // Enable password grant in Development for load testing (k6, etc.)
+                // Enable password grant in Development for load testing (k6, etc.).
+                // OpenIddictProductionGuard fails host startup if this is ever
+                // turned on in Production.
                 if (configuration.GetValue<bool>("OpenIddict:AllowPasswordGrant"))
                 {
                     options.AllowPasswordFlow();
@@ -103,7 +105,9 @@ public class OpenIddictModule : IModule
                 }
                 else
                 {
-                    // Development/Testing: use ephemeral keys (avoids macOS keychain issues)
+                    // Development/Testing: use ephemeral keys (avoids macOS keychain
+                    // issues). OpenIddictProductionGuard fails host startup if
+                    // Production runs without certificates.
                     options.AddEphemeralEncryptionKey().AddEphemeralSigningKey();
                 }
 
@@ -126,6 +130,9 @@ public class OpenIddictModule : IModule
                 options.UseLocalServer();
                 options.UseAspNetCore();
             });
+
+        // Refuses unsafe Production configurations (password grant, ephemeral keys)
+        services.AddHostedService<OpenIddictProductionGuard>();
 
         // Seed service
         services.AddHostedService<OpenIddictSeedService>();

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/OpenIddictModule.cs
@@ -68,8 +68,8 @@ public class OpenIddictModule : IModule
 
                 // Enable password grant in Development for load testing (k6, etc.).
                 // OpenIddictProductionGuard fails host startup if this is ever
-                // turned on in Production.
-                if (configuration.GetValue<bool>("OpenIddict:AllowPasswordGrant"))
+                // turned on in a real deployment.
+                if (configuration.GetValue<bool>(ConfigKeys.OpenIddictAllowPasswordGrant))
                 {
                     options.AllowPasswordFlow();
                 }

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictProductionGuard.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictProductionGuard.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using SimpleModule.Core.Hosting;
 using SimpleModule.OpenIddict.Contracts;
 
 namespace SimpleModule.OpenIddict.Services;
 
 /// <summary>
-/// Fails host startup when the OpenIddict configuration is unsafe for Production:
-/// the ROPC password grant must stay off (it lets anyone exchange leaked or default
-/// credentials for a fully-privileged token in a single request), and token
-/// signing/encryption must use real certificates — ephemeral keys are regenerated
-/// on every restart, invalidating all issued tokens, and signal a copy-pasted
-/// Development configuration.
+/// Fails host startup when the OpenIddict configuration is unsafe for a real
+/// deployment (anything but Development/Testing): the ROPC password grant must
+/// stay off (it lets anyone exchange leaked or default credentials for a
+/// fully-privileged token in a single request), and token signing/encryption
+/// must use real certificates — ephemeral keys are regenerated on every restart,
+/// invalidating all issued tokens, and signal a copy-pasted Development config.
+/// Shares <see cref="HostEnvironmentExtensions.IsLocalOrTest"/> with
+/// <c>UserSeedService</c> so the two guards never disagree about whether an
+/// environment is a real deployment.
 /// </summary>
 public sealed class OpenIddictProductionGuard(
     IConfiguration configuration,
@@ -19,16 +23,17 @@ public sealed class OpenIddictProductionGuard(
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (!environment.IsProduction())
+        if (environment.IsLocalOrTest())
         {
             return Task.CompletedTask;
         }
 
-        if (configuration.GetValue<bool>("OpenIddict:AllowPasswordGrant"))
+        if (configuration.GetValue<bool>(ConfigKeys.OpenIddictAllowPasswordGrant))
         {
             throw new InvalidOperationException(
-                "'OpenIddict:AllowPasswordGrant' must not be enabled in Production. "
-                    + "The ROPC password grant exists for local load testing only."
+                $"'{ConfigKeys.OpenIddictAllowPasswordGrant}' must not be enabled in the "
+                    + $"'{environment.EnvironmentName}' environment. The ROPC password grant "
+                    + "exists for local load testing only."
             );
         }
 

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictProductionGuard.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictProductionGuard.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using SimpleModule.OpenIddict.Contracts;
+
+namespace SimpleModule.OpenIddict.Services;
+
+/// <summary>
+/// Fails host startup when the OpenIddict configuration is unsafe for Production:
+/// the ROPC password grant must stay off (it lets anyone exchange leaked or default
+/// credentials for a fully-privileged token in a single request), and token
+/// signing/encryption must use real certificates — ephemeral keys are regenerated
+/// on every restart, invalidating all issued tokens, and signal a copy-pasted
+/// Development configuration.
+/// </summary>
+public sealed class OpenIddictProductionGuard(
+    IConfiguration configuration,
+    IHostEnvironment environment
+) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!environment.IsProduction())
+        {
+            return Task.CompletedTask;
+        }
+
+        if (configuration.GetValue<bool>("OpenIddict:AllowPasswordGrant"))
+        {
+            throw new InvalidOperationException(
+                "'OpenIddict:AllowPasswordGrant' must not be enabled in Production. "
+                    + "The ROPC password grant exists for local load testing only."
+            );
+        }
+
+        var encryptionCertPath = configuration[ConfigKeys.OpenIddictEncryptionCertPath];
+        var signingCertPath = configuration[ConfigKeys.OpenIddictSigningCertPath];
+
+        if (string.IsNullOrEmpty(encryptionCertPath) || string.IsNullOrEmpty(signingCertPath))
+        {
+            throw new InvalidOperationException(
+                $"'{ConfigKeys.OpenIddictSigningCertPath}' and "
+                    + $"'{ConfigKeys.OpenIddictEncryptionCertPath}' must be configured in "
+                    + "Production. Without certificates OpenIddict falls back to ephemeral "
+                    + "keys that are regenerated on every restart, invalidating all issued "
+                    + "tokens."
+            );
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
+++ b/modules/OpenIddict/src/SimpleModule.OpenIddict/Services/OpenIddictSeedService.cs
@@ -70,7 +70,7 @@ public partial class OpenIddictSeedService(
         };
 
         // Allow password grant in Development for load testing (k6, etc.)
-        if (configuration.GetValue<bool>("OpenIddict:AllowPasswordGrant"))
+        if (configuration.GetValue<bool>(ConfigKeys.OpenIddictAllowPasswordGrant))
         {
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Password);
         }

--- a/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Unit/OpenIddictProductionGuardTests.cs
+++ b/modules/OpenIddict/tests/SimpleModule.OpenIddict.Tests/Unit/OpenIddictProductionGuardTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using SimpleModule.OpenIddict.Contracts;
+using SimpleModule.OpenIddict.Services;
+
+namespace SimpleModule.OpenIddict.Tests.Unit;
+
+public class OpenIddictProductionGuardTests
+{
+    private const string CertPath = "/certs/example.pfx";
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Testing")]
+    public async Task StartAsync_LocalOrTest_DoesNotThrow_EvenWithUnsafeConfig(string environment)
+    {
+        // Password grant on + no certs would be refused in a real deployment,
+        // but is tolerated locally.
+        var guard = CreateGuard(environment, (ConfigKeys.OpenIddictAllowPasswordGrant, "true"));
+
+        await guard.Invoking(g => g.StartAsync(default)).Should().NotThrowAsync();
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("QA")]
+    public async Task StartAsync_RealDeployment_PasswordGrantEnabled_Throws(string environment)
+    {
+        var guard = CreateGuard(
+            environment,
+            (ConfigKeys.OpenIddictAllowPasswordGrant, "true"),
+            (ConfigKeys.OpenIddictEncryptionCertPath, CertPath),
+            (ConfigKeys.OpenIddictSigningCertPath, CertPath)
+        );
+
+        (
+            await guard
+                .Invoking(g => g.StartAsync(default))
+                .Should()
+                .ThrowAsync<InvalidOperationException>()
+        ).WithMessage($"*{ConfigKeys.OpenIddictAllowPasswordGrant}*");
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    public async Task StartAsync_RealDeployment_MissingCertificates_Throws(string environment)
+    {
+        var guard = CreateGuard(environment); // no cert paths configured
+
+        (
+            await guard
+                .Invoking(g => g.StartAsync(default))
+                .Should()
+                .ThrowAsync<InvalidOperationException>()
+        ).WithMessage("*certificate*");
+    }
+
+    [Fact]
+    public async Task StartAsync_RealDeployment_FullyConfigured_DoesNotThrow()
+    {
+        var guard = CreateGuard(
+            "Production",
+            (ConfigKeys.OpenIddictEncryptionCertPath, CertPath),
+            (ConfigKeys.OpenIddictSigningCertPath, CertPath)
+        );
+
+        await guard.Invoking(g => g.StartAsync(default)).Should().NotThrowAsync();
+    }
+
+    private static OpenIddictProductionGuard CreateGuard(
+        string environment,
+        params (string Key, string Value)[] settings
+    )
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(s => s.Key, s => (string?)s.Value))
+            .Build();
+
+        return new OpenIddictProductionGuard(configuration, new FakeHostEnvironment(environment));
+    }
+
+    private sealed class FakeHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = "Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/TenantFeatureHelper.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/Endpoints/TenantFeatures/TenantFeatureHelper.cs
@@ -14,16 +14,24 @@ internal static class TenantFeatureHelper
         var tenantIdStr = tenantId.Value.ToString(
             System.Globalization.CultureInfo.InvariantCulture
         );
-        var overrideTasks = flags
-            .Where(f => !f.IsDeprecated)
-            .Select(f => featureFlags.GetOverridesAsync(f.Name));
-        var allOverrides = await Task.WhenAll(overrideTasks);
-        return allOverrides
-            .SelectMany(o => o)
-            .Where(o =>
-                o.OverrideType == OverrideType.Tenant
-                && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
-            )
-            .ToList();
+
+        // Await sequentially, not via Task.WhenAll: every GetOverridesAsync call
+        // hits the same scoped FeatureFlagsDbContext, and EF Core forbids
+        // concurrent operations on one context instance. With 2+ active flags
+        // the parallel version reliably threw "A second operation was started
+        // on this context instance..." → HTTP 500 (same class as #242).
+        var result = new List<FeatureFlagOverride>();
+        foreach (var flag in flags.Where(f => !f.IsDeprecated))
+        {
+            var overrides = await featureFlags.GetOverridesAsync(flag.Name);
+            result.AddRange(
+                overrides.Where(o =>
+                    o.OverrideType == OverrideType.Tenant
+                    && string.Equals(o.OverrideValue, tenantIdStr, StringComparison.Ordinal)
+                )
+            );
+        }
+
+        return result;
     }
 }

--- a/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
+++ b/modules/Tenants/src/SimpleModule.Tenants/TenantService.cs
@@ -3,14 +3,12 @@ using Microsoft.Extensions.Logging;
 using SimpleModule.Core.Exceptions;
 using SimpleModule.Tenants.Contracts;
 using SimpleModule.Tenants.Contracts.Events;
-using Wolverine;
 using Wolverine.EntityFrameworkCore;
 
 namespace SimpleModule.Tenants;
 
 public sealed partial class TenantService(
     TenantsDbContext db,
-    IMessageBus bus,
     IDbContextOutbox<TenantsDbContext> outbox,
     ILogger<TenantService> logger
 ) : ITenantContracts
@@ -81,10 +79,19 @@ public sealed partial class TenantService(
         }
 
         db.Tenants.Add(entity);
+
+        // TenantId is database-generated, so the entity must be saved before the
+        // event can carry it. The explicit transaction keeps the tenant row and
+        // the outbox envelope atomic: SaveChangesAndFlushMessagesAsync persists
+        // the envelope, commits the open transaction, and only then releases the
+        // event to the bus. The previous SaveChanges-then-PublishAsync pattern
+        // lost the event when the process died between the two calls.
+        await using var transaction = await db.Database.BeginTransactionAsync();
         await db.SaveChangesAsync();
+        await outbox.PublishAsync(new TenantCreatedEvent(entity.Id, entity.Name, entity.Slug));
+        await outbox.SaveChangesAndFlushMessagesAsync();
 
         LogTenantCreated(logger, entity.Id, entity.Name);
-        await bus.PublishAsync(new TenantCreatedEvent(entity.Id, entity.Name, entity.Slug));
 
         return MapToDto(entity);
     }

--- a/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantServiceTests.cs
+++ b/modules/Tenants/tests/SimpleModule.Tenants.Tests/Unit/TenantServiceTests.cs
@@ -2,13 +2,11 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using NSubstitute;
 using SimpleModule.Core.Exceptions;
 using SimpleModule.Database;
 using SimpleModule.Tenants;
 using SimpleModule.Tenants.Contracts;
 using SimpleModule.Tests.Shared.Fakes;
-using Wolverine;
 
 namespace Tenants.Tests.Unit;
 
@@ -16,7 +14,6 @@ public sealed class TenantServiceTests : IDisposable
 {
     private readonly TenantsDbContext _db;
     private readonly TenantService _sut;
-    private readonly IMessageBus _bus = Substitute.For<IMessageBus>();
     private readonly FakeDbContextOutbox<TenantsDbContext> _outbox;
 
     public TenantServiceTests()
@@ -37,7 +34,7 @@ public sealed class TenantServiceTests : IDisposable
         _db.Database.OpenConnection();
         _db.Database.EnsureCreated();
         _outbox = new FakeDbContextOutbox<TenantsDbContext>(_db);
-        _sut = new TenantService(_db, _bus, _outbox, NullLogger<TenantService>.Instance);
+        _sut = new TenantService(_db, _outbox, NullLogger<TenantService>.Instance);
     }
 
     public void Dispose() => _db.Dispose();
@@ -89,10 +86,12 @@ public sealed class TenantServiceTests : IDisposable
         tenant.Status.Should().Be(TenantStatus.Active);
         tenant.Hosts.Should().HaveCount(1);
         tenant.Hosts[0].HostName.Should().Be("new.localhost");
-        await _bus.Received(1)
-            .PublishAsync(
-                Arg.Any<SimpleModule.Tenants.Contracts.Events.TenantCreatedEvent>(),
-                Arg.Any<DeliveryOptions?>()
+        _outbox
+            .PublishedMessages.Should()
+            .ContainSingle(m =>
+                m is SimpleModule.Tenants.Contracts.Events.TenantCreatedEvent
+                && ((SimpleModule.Tenants.Contracts.Events.TenantCreatedEvent)m).TenantId
+                    == tenant.Id
             );
     }
 
@@ -105,9 +104,7 @@ public sealed class TenantServiceTests : IDisposable
         updated.Name.Should().Be("Updated Acme");
         _outbox
             .PublishedMessages.Should()
-            .ContainSingle(m =>
-                m is SimpleModule.Tenants.Contracts.Events.TenantUpdatedEvent
-            );
+            .ContainSingle(m => m is SimpleModule.Tenants.Contracts.Events.TenantUpdatedEvent);
     }
 
     [Fact]

--- a/modules/Users/src/SimpleModule.Users/Services/SeedConfigurationException.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/SeedConfigurationException.cs
@@ -1,0 +1,19 @@
+namespace SimpleModule.Users.Services;
+
+/// <summary>
+/// Thrown when seeding cannot proceed safely — e.g. a required seed password is
+/// missing outside Development. Unlike transient database errors (which the seed
+/// service logs and tolerates), this exception is allowed to escape
+/// <see cref="UserSeedService.StartAsync"/> so host startup fails loudly instead
+/// of seeding a publicly known default credential.
+/// </summary>
+public sealed class SeedConfigurationException : InvalidOperationException
+{
+    public SeedConfigurationException() { }
+
+    public SeedConfigurationException(string message)
+        : base(message) { }
+
+    public SeedConfigurationException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/modules/Users/src/SimpleModule.Users/Services/SeedPasswordOutcome.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/SeedPasswordOutcome.cs
@@ -1,0 +1,20 @@
+namespace SimpleModule.Users.Services;
+
+/// <summary>
+/// The decision made by <see cref="UserSeedService.ResolveSeedPassword"/> for a
+/// single seed account.
+/// </summary>
+internal enum SeedPasswordOutcome
+{
+    /// <summary>Seed the account with the resolved password.</summary>
+    Seed,
+
+    /// <summary>Skip the (optional) account — unconfigured in a real deployment.</summary>
+    Skip,
+
+    /// <summary>
+    /// Fail host startup — a required account is unconfigured in a real
+    /// deployment and must not fall back to the compiled-in default.
+    /// </summary>
+    Fail,
+}

--- a/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SimpleModule.Core.Hosting;
 using SimpleModule.Users.Constants;
 using SimpleModule.Users.Contracts;
 
@@ -108,30 +109,32 @@ public partial class UserSeedService(
         if (await userManager.FindByEmailAsync(email) is not null)
             return;
 
-        // The compiled-in default passwords are a Development convenience only.
-        // Outside Development, creating the admin account with a published
-        // default password would leave the deployment one POST /connect/token
-        // away from a fully-privileged token — fail host startup instead.
-        // The optional test user is simply skipped when no password is set.
+        // The compiled-in default passwords are a local/CI convenience only.
+        // In a real deployment (anything but Development/Testing) the configured
+        // password is mandatory: creating the admin account with a published
+        // default would leave it one POST /connect/token away from a
+        // fully-privileged token. Fail host startup for the required (admin)
+        // account; simply skip the optional demo user.
         var password = configuration[passwordConfigKey];
         if (string.IsNullOrEmpty(password))
         {
-            if (!environment.IsDevelopment())
+            if (environment.IsLocalOrTest())
             {
-                if (requiredOutsideDevelopment)
-                {
-                    throw new SeedConfigurationException(
-                        $"'{passwordConfigKey}' must be configured outside the Development "
-                            + $"environment. Refusing to create '{email}' with the compiled-in "
-                            + "default password."
-                    );
-                }
-
+                password = defaultPassword;
+            }
+            else if (requiredOutsideDevelopment)
+            {
+                throw new SeedConfigurationException(
+                    $"'{passwordConfigKey}' must be configured in the '{environment.EnvironmentName}' "
+                        + $"environment. Refusing to create '{email}' with the compiled-in default "
+                        + "password."
+                );
+            }
+            else
+            {
                 LogSkippingSeedUser(logger, email, passwordConfigKey);
                 return;
             }
-
-            password = defaultPassword;
         }
 
         LogSeedingUser(logger, email);

--- a/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
@@ -43,7 +43,8 @@ public partial class UserSeedService(
                 SeedConstants.AdminDisplayName,
                 ConfigKeys.SeedAdminPassword,
                 SeedConstants.DefaultAdminPassword,
-                SeedConstants.AdminRole
+                SeedConstants.AdminRole,
+                requiredOutsideDevelopment: true
             );
             await SeedUserAsync(
                 userManager,
@@ -51,11 +52,12 @@ public partial class UserSeedService(
                 SeedConstants.UserDisplayName,
                 ConfigKeys.SeedUserPassword,
                 SeedConstants.DefaultUserPassword,
-                SeedConstants.UserRole
+                SeedConstants.UserRole,
+                requiredOutsideDevelopment: false
             );
         }
 #pragma warning disable CA1031 // Seed service must not crash the host on database errors
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not SeedConfigurationException)
 #pragma warning restore CA1031
         {
             LogSeedError(logger, ex.Message);
@@ -99,11 +101,38 @@ public partial class UserSeedService(
         string displayName,
         string passwordConfigKey,
         string defaultPassword,
-        string role
+        string role,
+        bool requiredOutsideDevelopment
     )
     {
         if (await userManager.FindByEmailAsync(email) is not null)
             return;
+
+        // The compiled-in default passwords are a Development convenience only.
+        // Outside Development, creating the admin account with a published
+        // default password would leave the deployment one POST /connect/token
+        // away from a fully-privileged token — fail host startup instead.
+        // The optional test user is simply skipped when no password is set.
+        var password = configuration[passwordConfigKey];
+        if (string.IsNullOrEmpty(password))
+        {
+            if (!environment.IsDevelopment())
+            {
+                if (requiredOutsideDevelopment)
+                {
+                    throw new SeedConfigurationException(
+                        $"'{passwordConfigKey}' must be configured outside the Development "
+                            + $"environment. Refusing to create '{email}' with the compiled-in "
+                            + "default password."
+                    );
+                }
+
+                LogSkippingSeedUser(logger, email, passwordConfigKey);
+                return;
+            }
+
+            password = defaultPassword;
+        }
 
         LogSeedingUser(logger, email);
 
@@ -116,9 +145,6 @@ public partial class UserSeedService(
             CreatedAt = DateTime.UtcNow,
         };
 
-        var password = configuration[passwordConfigKey] ?? defaultPassword;
-        if (password == defaultPassword && !environment.IsDevelopment())
-            LogDefaultPasswordWarning(logger, email, passwordConfigKey);
         var result = await userManager.CreateAsync(user, password);
         if (result.Succeeded)
         {
@@ -140,14 +166,10 @@ public partial class UserSeedService(
     private static partial void LogSeedingUser(ILogger logger, string email);
 
     [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "Seeding {Email} with default password. Set '{ConfigKey}' in configuration before deploying to production."
+        Level = LogLevel.Information,
+        Message = "Skipping seed user {Email}: '{ConfigKey}' is not configured and default passwords are disabled outside Development."
     )]
-    private static partial void LogDefaultPasswordWarning(
-        ILogger logger,
-        string email,
-        string configKey
-    );
+    private static partial void LogSkippingSeedUser(ILogger logger, string email, string configKey);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Seed error: {ErrorDescription}")]
     private static partial void LogSeedError(ILogger logger, string errorDescription);

--- a/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
+++ b/modules/Users/src/SimpleModule.Users/Services/UserSeedService.cs
@@ -109,32 +109,25 @@ public partial class UserSeedService(
         if (await userManager.FindByEmailAsync(email) is not null)
             return;
 
-        // The compiled-in default passwords are a local/CI convenience only.
-        // In a real deployment (anything but Development/Testing) the configured
-        // password is mandatory: creating the admin account with a published
-        // default would leave it one POST /connect/token away from a
-        // fully-privileged token. Fail host startup for the required (admin)
-        // account; simply skip the optional demo user.
-        var password = configuration[passwordConfigKey];
-        if (string.IsNullOrEmpty(password))
+        var outcome = ResolveSeedPassword(
+            configuration[passwordConfigKey],
+            defaultPassword,
+            environment.IsLocalOrTest(),
+            requiredOutsideDevelopment,
+            out var password
+        );
+
+        switch (outcome)
         {
-            if (environment.IsLocalOrTest())
-            {
-                password = defaultPassword;
-            }
-            else if (requiredOutsideDevelopment)
-            {
+            case SeedPasswordOutcome.Fail:
                 throw new SeedConfigurationException(
                     $"'{passwordConfigKey}' must be configured in the '{environment.EnvironmentName}' "
                         + $"environment. Refusing to create '{email}' with the compiled-in default "
                         + "password."
                 );
-            }
-            else
-            {
+            case SeedPasswordOutcome.Skip:
                 LogSkippingSeedUser(logger, email, passwordConfigKey);
                 return;
-            }
         }
 
         LogSeedingUser(logger, email);
@@ -148,7 +141,9 @@ public partial class UserSeedService(
             CreatedAt = DateTime.UtcNow,
         };
 
-        var result = await userManager.CreateAsync(user, password);
+        // Only SeedPasswordOutcome.Seed falls through the switch above, and it
+        // always yields a non-null password.
+        var result = await userManager.CreateAsync(user, password!);
         if (result.Succeeded)
         {
             await userManager.AddToRoleAsync(user, role);
@@ -160,6 +155,47 @@ public partial class UserSeedService(
                 LogSeedError(logger, error.Description);
             }
         }
+    }
+
+    /// <summary>
+    /// Decides how to seed a user's password. Extracted as a pure function so the
+    /// security-critical branching — never seed a real deployment with the
+    /// compiled-in default — is unit-testable without an Identity stack.
+    /// </summary>
+    /// <param name="configuredPassword">The password from configuration, if any.</param>
+    /// <param name="defaultPassword">The compiled-in fallback (local/CI only).</param>
+    /// <param name="isLocalOrTest">True for Development/Testing environments.</param>
+    /// <param name="requiredOutsideLocal">
+    /// True for the admin account (must fail closed); false for the optional demo
+    /// user (skipped when unconfigured in a real deployment).
+    /// </param>
+    /// <param name="password">The password to use when the outcome is <c>Seed</c>.</param>
+    internal static SeedPasswordOutcome ResolveSeedPassword(
+        string? configuredPassword,
+        string defaultPassword,
+        bool isLocalOrTest,
+        bool requiredOutsideLocal,
+        out string? password
+    )
+    {
+        if (!string.IsNullOrEmpty(configuredPassword))
+        {
+            password = configuredPassword;
+            return SeedPasswordOutcome.Seed;
+        }
+
+        // The compiled-in default passwords are a local/CI convenience only. In a
+        // real deployment (anything but Development/Testing) the configured
+        // password is mandatory: seeding the admin with a published default would
+        // leave it one POST /connect/token away from a fully-privileged token.
+        if (isLocalOrTest)
+        {
+            password = defaultPassword;
+            return SeedPasswordOutcome.Seed;
+        }
+
+        password = null;
+        return requiredOutsideLocal ? SeedPasswordOutcome.Fail : SeedPasswordOutcome.Skip;
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Seeding role: {RoleName}")]

--- a/modules/Users/tests/SimpleModule.Users.Tests/Unit/UserSeedServiceTests.cs
+++ b/modules/Users/tests/SimpleModule.Users.Tests/Unit/UserSeedServiceTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using SimpleModule.Users.Services;
+
+namespace SimpleModule.Users.Tests.Unit;
+
+public class UserSeedServiceTests
+{
+    private const string Default = "Default123!";
+    private const string Configured = "Configured123!";
+
+    [Theory]
+    [InlineData(true, true)] // local, required (admin)
+    [InlineData(true, false)] // local, optional (demo)
+    [InlineData(false, true)] // real deployment, required
+    [InlineData(false, false)] // real deployment, optional
+    public void ResolveSeedPassword_ConfiguredPassword_AlwaysUsed(
+        bool isLocalOrTest,
+        bool requiredOutsideLocal
+    )
+    {
+        var outcome = UserSeedService.ResolveSeedPassword(
+            Configured,
+            Default,
+            isLocalOrTest,
+            requiredOutsideLocal,
+            out var password
+        );
+
+        outcome.Should().Be(SeedPasswordOutcome.Seed);
+        password.Should().Be(Configured);
+    }
+
+    [Theory]
+    [InlineData(true)] // required (admin)
+    [InlineData(false)] // optional (demo)
+    public void ResolveSeedPassword_LocalOrTest_NoConfig_UsesDefault(bool requiredOutsideLocal)
+    {
+        var outcome = UserSeedService.ResolveSeedPassword(
+            configuredPassword: null,
+            Default,
+            isLocalOrTest: true,
+            requiredOutsideLocal,
+            out var password
+        );
+
+        outcome.Should().Be(SeedPasswordOutcome.Seed);
+        password.Should().Be(Default);
+    }
+
+    [Fact]
+    public void ResolveSeedPassword_RealDeployment_RequiredAndUnconfigured_Fails()
+    {
+        // The security-critical path: the admin account must never fall back to
+        // the compiled-in default outside a local/test environment.
+        var outcome = UserSeedService.ResolveSeedPassword(
+            configuredPassword: null,
+            Default,
+            isLocalOrTest: false,
+            requiredOutsideLocal: true,
+            out var password
+        );
+
+        outcome.Should().Be(SeedPasswordOutcome.Fail);
+        password.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveSeedPassword_RealDeployment_OptionalAndUnconfigured_Skips()
+    {
+        var outcome = UserSeedService.ResolveSeedPassword(
+            configuredPassword: null,
+            Default,
+            isLocalOrTest: false,
+            requiredOutsideLocal: false,
+            out var password
+        );
+
+        outcome.Should().Be(SeedPasswordOutcome.Skip);
+        password.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveSeedPassword_EmptyConfiguredPassword_TreatedAsUnconfigured()
+    {
+        var outcome = UserSeedService.ResolveSeedPassword(
+            configuredPassword: "",
+            Default,
+            isLocalOrTest: false,
+            requiredOutsideLocal: true,
+            out _
+        );
+
+        outcome.Should().Be(SeedPasswordOutcome.Fail);
+    }
+}

--- a/packages/SimpleModule.UI/components/layouts/layout-provider.tsx
+++ b/packages/SimpleModule.UI/components/layouts/layout-provider.tsx
@@ -24,7 +24,9 @@ function AutoLayout({ children }: { children: React.ReactNode }) {
 }
 
 interface PageModule {
-  default: { layout?: (content: React.ReactNode) => React.ReactNode };
+  default: React.ComponentType & {
+    layout?: (content: React.ReactNode) => React.ReactNode;
+  };
 }
 
 export function resolveLayout(page: PageModule) {

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -3,9 +3,9 @@
 /**
  * typecheck.mjs
  *
- * Runs `tsc --noEmit` in every module and package that has a tsconfig.json.
- * Each project is checked independently so @/* path aliases resolve correctly.
- * All checks run in parallel for speed.
+ * Runs `tsc --noEmit` in every module and package that has a tsconfig.json,
+ * plus the Host ClientApp. Each project is checked independently so @/* path
+ * aliases resolve correctly. All checks run in parallel for speed.
  *
  * Exit codes:
  *   0 = All projects pass type checking
@@ -68,9 +68,26 @@ function checkProject(dir) {
   });
 }
 
+// The Host ClientApp must always be in this list — it is the Inertia
+// bootstrap that every module page loads through. It went unchecked once
+// (no tsconfig.json, not listed here) and shipped a ReferenceError in its
+// page-load error handler.
+const clientAppDir = path.join(
+  projectRoot,
+  'template',
+  'SimpleModule.Host',
+  'ClientApp',
+);
+
+if (!fs.existsSync(path.join(clientAppDir, 'tsconfig.json'))) {
+  console.error(`Missing tsconfig.json in ${clientAppDir} — ClientApp must be type-checked.`);
+  process.exit(1);
+}
+
 const projects = [
   ...findProjects(modulesDir, 'nested'),
   ...findProjects(packagesDir, 'flat'),
+  clientAppDir,
 ];
 
 const results = await Promise.all(projects.map(checkProject));

--- a/scripts/validate-i18n.mjs
+++ b/scripts/validate-i18n.mjs
@@ -56,9 +56,16 @@ function parseJsonFile(filePath) {
 // Main
 const localesDirs = findModuleLocales(modulesDir);
 
+// Self-check: modules ship Locales directories today, so finding zero means the
+// scan path drifted out from under this script — the same silent-no-op failure
+// that let validate-pages.mjs validate nothing for months. Fail loudly rather
+// than report success over an empty set.
 if (localesDirs.length === 0) {
-  console.log('No Locales directories found. Nothing to validate.');
-  process.exit(0);
+  console.error(
+    `ERROR: No Locales directories found under '${modulesDir}'. The module layout ` +
+      'has likely changed — update findModuleLocales / the scan path.',
+  );
+  process.exit(1);
 }
 
 for (const { localesDir, project } of localesDirs) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,78 +1,63 @@
-# Task: Design-system consistency pass across all module pages
+# Fix critical issues from framework review (2026-06-09)
 
-Goal: every page uses the design system consistently → run /qa → open PR with screenshots.
+## Critical 1 — page-registry guard broken on both ends
+- [x] Fix `validate-pages.mjs` path: scan `modules/*/src/*/` (real layout is `src/SimpleModule.<Name>`), skip `obj`/`bin`
+- [x] Add self-check: fail when zero C# files or zero view endpoints are found repo-wide (path drift can never silently disable the guard again)
+- [x] Fix `app.tsx:232` `showErrorToast(...)` → `showToast({ variant: 'error', ... })` (ReferenceError on failed page load)
+- [x] Add `ClientApp/tsconfig.json` and include ClientApp in `scripts/typecheck.mjs`
 
-Scope: 13 tracked modules with `.tsx` source. The 8 untracked dirs (Agents, Chat, Datasets,
-Map, Marketplace, Orders, PageBuilder, Products) are stale build artifacts with NO source — left untouched, flagged to user.
+## Critical 2 — default deployment one request from admin token
+- [x] `UserSeedService`: fail fast in non-Development when `Seed:AdminPassword` unset; never seed test user with default password outside Development
+- [x] OpenIddict: refuse `AllowPasswordFlow` in Production; fail fast on ephemeral signing/encryption keys in Production
+- [x] `SimpleModuleHostExtensions`: stop clearing `KnownProxies`/`KnownIPNetworks` unconditionally — config-driven (`ForwardedHeaders:KnownProxies`/`KnownNetworks`/`TrustAllProxies`)
+- [x] `docker-compose.yml`: explicit `OpenIddict__AllowPasswordGrant: "false"`, required seed-password env vars
+- [x] Enforce `FileStorageModuleOptions` (MaxFileSizeMb / AllowedExtensions) in UploadEndpoint
 
-Out of scope (noted, not changed): i18n hardcoded-string gaps; the intentional centered-card
-auth-page layout (only token/control bugs inside auth pages are fixed, not forced into PageShell).
+## Critical 3 — remaining #242-class DbContext races
+- [x] `AdminService.GetAdminOverviewAsync` — sequential awaits
+- [x] `Admin/Pages/Admin/UsersEditEndpoint` — sequential awaits
+- [x] `TenantFeatureHelper.GetOverridesForTenantAsync` — sequential awaits (throws with 2+ active flags)
 
-## Fixes (from parallel line-level audit)
+## Outbox gaps (events lost on crash after SaveChanges)
+- [x] `TenantService.CreateTenantAsync` — use `IDbContextOutbox` like UpdateTenantAsync already does
+- [x] `FileStorageService.UploadFileAsync` — same
 
-### HIGH — color tokens breaking dark mode / raw controls
-- [ ] Tenants/tenantStatus.ts — raw palette → Badge variant map (success/warning/danger)
-- [ ] Tenants/Browse.tsx, Manage.tsx — status span → <Badge>
-- [ ] Tenants/Features.tsx — text-green/red-600 → <Badge>
-- [ ] BackgroundJobs/Dashboard.tsx — text-red-500, border-red-200, hover:bg-red-50 → semantic
-- [ ] BackgroundJobs/Detail.tsx — text-red-600, border-red-200, bg-red-50/text-red-800 → semantic
-- [ ] FeatureFlags/Manage.tsx:264 — raw <input type=checkbox> → <Checkbox>
-- [ ] RateLimiting/components/RulesTable.tsx — text-muted-foreground (undefined) → text-text-muted
-- [ ] Email/History.tsx — text-destructive (undefined) → text-danger
-- [ ] OpenIddict/OAuthCallback.tsx — text-muted → text-text-muted
-- [ ] Dashboard/Home.tsx — text-white → text-text-inverse
-- [ ] Users/Login.tsx, Register.tsx — text-white + inline var → bg-primary text-text-inverse; raw checkbox → Checkbox
-- [ ] Users/LoginWith2fa.tsx — raw checkbox → Checkbox
+## Critical 4 — docs describe phantom modules
+- [x] CLAUDE.md: load-test section lists 11 scenarios incl. Products/Orders/Marketplace/PageBuilder — only 6 exist (Admin, AuditLogs, FeatureFlags, FileStorage, Settings, Users)
+- [x] CLAUDE.md: `modules/Products/src/Products` examples use wrong layout (`src/SimpleModule.<Name>`) — likely origin of the validate-pages bug
+- [x] Sweep docs/CONSTITUTION.md + skills for phantom-module/wrong-layout references
+- (untracked WIP dirs in the main checkout are stale build artifacts — left alone)
 
-### MEDIUM — hand-rolled layout → PageShell; custom markup → DS components
-- [ ] Settings/UserSettings.tsx — Container+h1 → PageShell; error banner → Alert
-- [ ] Settings/AdminSettings.tsx — error banner → Alert
-- [ ] Admin/RolesCreate, RolesEdit, UsersCreate, UsersEdit — Container+Breadcrumb+h1 → PageShell
-- [ ] Admin/Roles.tsx — raw <button> dismiss → Button
-- [ ] OpenIddict/ClientsCreate, ClientsEdit — Container+Breadcrumb+h1 → PageShell
-- [ ] OpenIddict/ActiveSessions.tsx — custom empty <p> → EmptyState
-- [ ] Tenants/Create, Edit, Features — Container+Breadcrumb+h1 → PageShell
-- [ ] Tenants/Features.tsx — custom empty → EmptyState
-- [ ] Notifications/Inbox.tsx — custom empty → EmptyState
-- [ ] Users/ManageIndex.tsx, Email.tsx — custom span badge → Badge
-- [ ] Users/ExternalLogins.tsx — raw <table> → Table
-- [ ] Users/Logout.tsx, PersonalData.tsx — <a class=btn-*> → Button
-- [ ] Users/ManagePasskeys.tsx — custom empty → EmptyState
+## CI gaps
+- [ ] PostgreSQL test leg — DEFERRED: `SimpleModuleWebApplicationFactory` is deeply SQLite-coupled (shared in-memory connection, static env bootstrap, Wolverine SQLite file); a reliable dual-provider factory is its own change. Docs no longer claim it exists.
+- [x] CodeQL workflow
+- [x] Dependabot config (nuget, npm, github-actions)
+- [x] `dotnet list package --vulnerable` CI step
 
-### LOW
-- [ ] BackgroundJobs — bare border/border-b → border-border
-- [ ] FileStorage/Browse.tsx — hover:bg-muted/50 → hover:bg-surface-raised
-
-## Verify
-- [ ] npm run check (biome) + typecheck
-- [ ] dotnet build
-- [ ] npm run validate-pages
-- [ ] /qa
-- [ ] PR with screenshots
+## Deferred (follow-ups)
+- Roslyn diagnostic (SM0060) for Task.WhenAll-over-contracts and SaveChanges+Publish-without-outbox — analyzer-grade flow analysis, separate PR
+- Generator decomposition to ForAttributeWithMetadataName
+- @simplemodule/ui vendoring + stale wwwroot chunk cleanup
 
 ## Review
 
-34 page files across 13 modules refactored onto the design system. Net −120 LOC
-(PageShell migrations removed boilerplate). No behavior/i18n changes.
+All four criticals addressed, plus the concrete improvements. Verified with:
+`dotnet build` (0 warnings/errors), `dotnet test` (19/19 assemblies, 0 failures),
+`npm run check` (biome + validate-pages + i18n + framework-scope + typecheck 14/14),
+`npm run build` (production bundles), plus a negative test proving validate-pages
+now fails when a page registration is removed.
 
-- **PageShell migrations:** Admin Roles/Users Create+Edit, OpenIddict Clients Create+Edit,
-  Tenants Create/Edit/Features, Settings UserSettings — hand-rolled Container+Breadcrumb+h1
-  replaced with `<PageShell>`.
-- **Semantic color tokens:** removed raw palette (text-red/green/yellow-*, text-white) and
-  undefined tokens (text-destructive, text-muted-foreground, text-muted) across BackgroundJobs,
-  Tenants, Email, Dashboard, RateLimiting, OpenIddict, Users → dark-mode-correct semantic tokens.
-- **DS component swaps:** Checkbox (FeatureFlags, Login, LoginWith2fa), Badge (Tenants, Users),
-  Table (Users ExternalLogins), Alert (Settings), Button (Users), EmptyState (Tenants,
-  Notifications, OpenIddict, Users).
-- **Bonus fix:** FeatureFlags override form `form.reset()` crash (pre-existing; found in QA).
+Notable finds while fixing:
+- The resurrected guard immediately caught that `UnlockAccountEndpoint` renders via a
+  `const string ComponentName` — the script now resolves same-file string consts and
+  reports unresolvable `Inertia.Render` arguments as failures.
+- The new ClientApp typecheck exposed two latent runtime bugs beyond the reported
+  `showErrorToast`: `router.on('exception', ...)` is not an Inertia v3 event (the
+  network-error toast was dead code — now `networkError`), and the page resolver
+  returned a module where Inertia's types want the component.
+- `FileStorageService.DeleteFileAsync` had the same lost-event bug as Upload (worse:
+  a failed blob delete also skipped the event after the DB commit) — fixed via outbox.
+- Create flows with DB-generated ids (Tenant, StoredFile) use an explicit transaction +
+  `SaveChangesAndFlushMessagesAsync`, which per Wolverine commits the open transaction
+  before flushing. `FakeDbContextOutbox` now mirrors that commit behavior.
 
-Out of scope (left as-is): i18n hardcoded strings; the intentional centered-card auth layout;
-8 untracked stale build-artifact dirs (Agents/Chat/Datasets/Map/Marketplace/Orders/PageBuilder/
-Products) — flagged to the user, not touched.
-
-## Verification (done)
-- [x] biome check · validate-pages · validate:i18n (0/0) · validate:framework-scope · typecheck 13/13
-- [x] dotnet build SimpleModule.Host — 0 warnings, 0 errors
-- [x] npm run build:dev — all workspaces
-- [x] /qa in real browser (light + dark): PageShell, color tokens, Badge/Table/EmptyState/Alert,
-      Checkbox form posting — all verified; 1 pre-existing bug found + fixed + re-tested

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -34,10 +34,26 @@
 - [x] Dependabot config (nuget, npm, github-actions)
 - [x] `dotnet list package --vulnerable` CI step
 
-## Deferred (follow-ups)
-- Roslyn diagnostic (SM0060) for Task.WhenAll-over-contracts and SaveChanges+Publish-without-outbox — analyzer-grade flow analysis, separate PR
-- Generator decomposition to ForAttributeWithMetadataName
-- @simplemodule/ui vendoring + stale wwwroot chunk cleanup
+## Code-review round 1 — fixes applied
+- [x] ForwardedHeaders KnownProxies/KnownNetworks: accept comma-separated scalar (the form the docker-compose comment documents) as well as arrays; TryParse with a clear error instead of an opaque FormatException
+- [x] docker-compose worker: add Seed__AdminPassword/Seed__UserPassword — the worker runs UserSeedService too and would otherwise race-seed the default admin password
+- [x] FileStorageService.UploadFileAsync: scope blob-rollback to the pre-commit window so a post-commit outbox-flush failure can't dangle a committed row against a deleted blob
+- [x] Env-predicate consistency: shared HostEnvironmentExtensions.IsLocalOrTest (Development+Testing) used by both UserSeedService and OpenIddictProductionGuard — closes the Staging bypass and the Testing-startup-crash in one predicate
+- [x] UsersEditEndpoint: reverted to Task.WhenAll — the three contracts use distinct DbContexts (Users/Permissions/OpenIddict), so there was no race; corrected the misleading comment
+- [x] ConfigKeys.OpenIddictAllowPasswordGrant constant — replaced the three hardcoded "OpenIddict:AllowPasswordGrant" string literals (drift would silently disable the guard)
+- [x] validate-pages: detect interpolated Inertia.Render($"…") as unresolved instead of silently skipping it
+- [x] validate-i18n: same fail-on-zero self-check as validate-pages (locale dirs exist today; zero = path drift)
+- [x] UploadEndpoint: hoist size/extension parse to Map() time (resolve IOptions once, capture) instead of allocating a HashSet per request
+
+## Deferred (follow-ups — recorded, not silently dropped)
+- **Roslyn diagnostic (SM0060)** for Task.WhenAll-over-shared-DbContext and SaveChanges+Publish-without-outbox — durable fix for the recurring race/outbox classes (fixed by hand 3× now). Analyzer-grade flow analysis; separate PR. An interim regex guard like validate-framework-scope.mjs is a cheaper stopgap.
+- **Shared outbox helper** (`SaveAndPublishAsync<TDb>`) in SimpleModule.Database to encode the BeginTransaction→SaveChanges→Publish→flush ritual once — currently duplicated across TenantService/FileStorageService. Also: WolverineConfiguration wires PublishDomainEventsFromEntityFrameworkCore<IHasDomainEvents> but no entity implements it (dead idiom) — reconcile.
+- **Framework production-config validation abstraction** (IValidateOptions/ValidateOnStart) — OpenIddictProductionGuard + UserSeedService are two ad-hoc startup guards; a shared mechanism is the right altitude and fixes implicit guard ordering.
+- **Module options ↔ Settings store / appsettings binding**: generated RegisterModuleOptionsDefaults only calls AddOptions<T>() with no config binding, so the FileStorage admin Settings/appsettings keys don't drive the enforced IOptions values (enforcement honors code-configured/default values only).
+- **TenantFeatureHelper N+1**: serial GetOverridesAsync per flag; needs a bulk IFeatureFlagContracts method to collapse to one query.
+- **ForwardedHeaders typed options** on SimpleModuleOptions (typo'd keys currently silently yield loopback-only trust).
+- Generator decomposition to ForAttributeWithMetadataName.
+- @simplemodule/ui vendoring + stale wwwroot chunk cleanup.
 
 ## Review
 

--- a/template/SimpleModule.Host/ClientApp/app.tsx
+++ b/template/SimpleModule.Host/ClientApp/app.tsx
@@ -120,7 +120,10 @@ router.on('httpException', (event) => {
   showToast({ variant: 'error', title: 'Error', message, autoDismissMs: 8000 });
 });
 
-router.on('exception', (event) => {
+// Inertia v3 renamed this event — 'exception' no longer exists, so the old
+// router.on('exception', ...) handler was dead code and network failures
+// surfaced nothing.
+router.on('networkError', (event) => {
   event.preventDefault();
   showToast({
     variant: 'error',
@@ -222,14 +225,18 @@ const ERROR_PAGES: Record<string, { default: React.ComponentType }> = {
 createInertiaApp({
   resolve: async (name) => {
     if (name in ERROR_PAGES) {
-      return ERROR_PAGES[name];
+      return ERROR_PAGES[name].default;
     }
 
     try {
       const page = await resolvePage(name);
-      return resolveLayout(page);
+      return resolveLayout(page).default;
     } catch (err) {
-      showErrorToast(`Failed to load page "${name}". Try refreshing the page.`);
+      showToast({
+        variant: 'error',
+        title: 'Error',
+        message: `Failed to load page "${name}". Try refreshing the page.`,
+      });
       throw err;
     }
   },

--- a/template/SimpleModule.Host/ClientApp/tsconfig.json
+++ b/template/SimpleModule.Host/ClientApp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@simplemodule/tsconfig/base",
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/template/SimpleModule.Host/ClientApp/validate-pages.mjs
+++ b/template/SimpleModule.Host/ClientApp/validate-pages.mjs
@@ -7,15 +7,22 @@
  * between C# endpoints and TypeScript Pages/index.ts files.
  *
  * This script:
- * 1. Scans all C# files in each module's src/{ModuleName} directory
+ * 1. Scans all C# files in each module's src/ directory (the implementation
+ *    project lives at src/SimpleModule.{ModuleName}; obj/bin/wwwroot are skipped)
  * 2. Finds all Inertia.Render("ComponentName/...") calls
  * 3. Scans the module's Pages/index.ts file
  * 4. Finds all keys in the pages object export
  * 5. Compares the two lists and reports mismatches
  *
+ * Self-check: if zero C# files or zero Inertia.Render endpoints are found
+ * across the whole repo, the script fails. A layout change must never be able
+ * to silently turn this guard into a no-op again (it did once: the script
+ * scanned src/{ModuleName} while the real layout is src/SimpleModule.{ModuleName},
+ * so it validated zero files and always reported success).
+ *
  * Exit codes:
  *   0 = All modules have valid registrations
- *   1 = Mismatches found
+ *   1 = Mismatches found, or self-check failed
  */
 
 import fs from 'node:fs';
@@ -25,6 +32,10 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '../../..');
 const modulesDir = path.resolve(projectRoot, 'modules');
+
+// Build-output and vendor directories that must never be scanned — stale
+// artifacts in obj/bin can contain Inertia.Render strings for deleted pages.
+const SKIPPED_DIRS = new Set(['obj', 'bin', 'node_modules', 'wwwroot', 'dist']);
 
 /**
  * Recursively find all .cs files in a directory
@@ -39,6 +50,7 @@ function findCSharpFiles(dir) {
       const fullPath = path.join(currentPath, entry.name);
 
       if (entry.isDirectory()) {
+        if (SKIPPED_DIRS.has(entry.name)) continue;
         walk(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.cs')) {
         files.push(fullPath);
@@ -54,19 +66,40 @@ function findCSharpFiles(dir) {
 }
 
 /**
- * Extract all Inertia.Render component names from a C# file
- * Pattern: Inertia\.Render\s*\(\s*"([^"]+)"
+ * Extract all Inertia.Render component names from a C# file.
+ * Handles both inline literals — Inertia.Render("Module/Page", ...) — and
+ * identifiers resolved against `const string Name = "Module/Page";`
+ * declarations in the same file (the ComponentName pattern).
+ * Returns { names, unresolved } where unresolved lists identifier arguments
+ * that could not be resolved to a string in this file.
  */
 function findCSharpEndpoints(content) {
-  const pattern = /Inertia\.Render\s*\(\s*"([^"]+)"/g;
-  const matches = new Set();
-  let match = pattern.exec(content);
+  const names = new Set();
+  const unresolved = new Set();
+
+  const literalPattern = /Inertia\.Render\s*\(\s*"([^"]+)"/g;
+  let match = literalPattern.exec(content);
   while (match !== null) {
-    matches.add(match[1]);
-    match = pattern.exec(content);
+    names.add(match[1]);
+    match = literalPattern.exec(content);
   }
 
-  return matches;
+  const identifierPattern = /Inertia\.Render\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*[,)]/g;
+  match = identifierPattern.exec(content);
+  while (match !== null) {
+    const identifier = match[1];
+    const constName = identifier.split('.').pop();
+    const constPattern = new RegExp(`const\\s+string\\s+${constName}\\s*=\\s*"([^"]+)"`);
+    const constMatch = constPattern.exec(content);
+    if (constMatch) {
+      names.add(constMatch[1]);
+    } else {
+      unresolved.add(identifier);
+    }
+    match = identifierPattern.exec(content);
+  }
+
+  return { names, unresolved };
 }
 
 /**
@@ -100,32 +133,55 @@ function findTypeScriptPages(content) {
  */
 function validateModule(modulePath) {
   const moduleName = path.basename(modulePath);
-  const srcPath = path.join(modulePath, 'src', moduleName);
+  const srcRoot = path.join(modulePath, 'src');
+
+  // Implementation projects live at src/SimpleModule.{ModuleName} (plus a
+  // Contracts sibling). Scan every project directory under src/ rather than
+  // hard-coding one name, so a layout rename cannot silently skip files.
+  const projectDirs = fs.existsSync(srcRoot)
+    ? fs
+        .readdirSync(srcRoot, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && !SKIPPED_DIRS.has(e.name))
+        .map((e) => path.join(srcRoot, e.name))
+    : [];
 
   // Find all C# endpoints
-  const csharpFiles = findCSharpFiles(srcPath);
   const csharpEndpoints = new Set();
+  const unresolvedRenders = [];
+  let csharpFileCount = 0;
 
-  for (const filePath of csharpFiles) {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    const endpoints = findCSharpEndpoints(content);
+  for (const projectDir of projectDirs) {
+    for (const filePath of findCSharpFiles(projectDir)) {
+      csharpFileCount += 1;
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const { names, unresolved } = findCSharpEndpoints(content);
 
-    for (const endpoint of endpoints) {
-      csharpEndpoints.add(endpoint);
+      for (const endpoint of names) {
+        csharpEndpoints.add(endpoint);
+      }
+
+      for (const identifier of unresolved) {
+        unresolvedRenders.push(`${path.relative(modulePath, filePath)}: ${identifier}`);
+      }
     }
   }
 
-  // Find all TS pages
-  const pagesIndexPath = path.join(srcPath, 'Pages', 'index.ts');
-  let tsPages = new Set();
+  // Find all TS pages (Pages/index.ts in the implementation project)
+  const tsPages = new Set();
   let hasPages = false;
 
-  try {
-    const content = fs.readFileSync(pagesIndexPath, 'utf-8');
-    tsPages = findTypeScriptPages(content);
-    hasPages = true;
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err; // Re-throw non-file-not-found errors
+  for (const projectDir of projectDirs) {
+    const pagesIndexPath = path.join(projectDir, 'Pages', 'index.ts');
+
+    try {
+      const content = fs.readFileSync(pagesIndexPath, 'utf-8');
+      for (const page of findTypeScriptPages(content)) {
+        tsPages.add(page);
+      }
+      hasPages = true;
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err; // Re-throw non-file-not-found errors
+    }
   }
 
   // Compare
@@ -135,9 +191,12 @@ function validateModule(modulePath) {
   return {
     moduleName,
     hasPages,
+    csharpFileCount,
+    endpointCount: csharpEndpoints.size,
     missing,
     extra,
-    isValid: missing.length === 0 && extra.length === 0,
+    unresolvedRenders,
+    isValid: missing.length === 0 && extra.length === 0 && unresolvedRenders.length === 0,
   };
 }
 
@@ -164,10 +223,30 @@ function main() {
   // Print results
   console.log('\n=== Pages Registry Validation ===\n');
 
+  // Self-check: this guard once silently validated nothing because the module
+  // layout changed underneath it. If the scan finds no C# files or no
+  // Inertia.Render endpoints at all, the paths are wrong — fail loudly.
+  const totalCsFiles = results.reduce((sum, r) => sum + r.csharpFileCount, 0);
+  const totalEndpoints = results.reduce((sum, r) => sum + r.endpointCount, 0);
+
+  if (totalCsFiles === 0) {
+    console.error('❌ Self-check failed: scanned 0 C# files across all modules.');
+    console.error('   The module source layout has likely changed — update validate-pages.mjs.\n');
+    process.exit(1);
+  }
+
+  if (totalEndpoints === 0) {
+    console.error('❌ Self-check failed: found 0 Inertia.Render endpoints across all modules.');
+    console.error('   The module source layout has likely changed — update validate-pages.mjs.\n');
+    process.exit(1);
+  }
+
   const invalid = results.filter((r) => !r.isValid);
 
   if (invalid.length === 0) {
-    console.log('✅ All modules have valid Pages/index.ts registrations\n');
+    console.log(
+      `✅ All modules valid (${totalEndpoints} endpoints across ${totalCsFiles} C# files)\n`,
+    );
     process.exit(0);
   }
 
@@ -180,6 +259,16 @@ function main() {
 
     if (result.extra.length > 0) {
       console.log(`   Extra in Pages/index.ts: ${result.extra.join(', ')}`);
+    }
+
+    if (result.unresolvedRenders.length > 0) {
+      console.log(
+        '   Inertia.Render arguments that could not be resolved to a string ' +
+          '(use a literal or a same-file const):',
+      );
+      for (const entry of result.unresolvedRenders) {
+        console.log(`     ${entry}`);
+      }
     }
 
     console.log();

--- a/template/SimpleModule.Host/ClientApp/validate-pages.mjs
+++ b/template/SimpleModule.Host/ClientApp/validate-pages.mjs
@@ -99,6 +99,18 @@ function findCSharpEndpoints(content) {
     match = identifierPattern.exec(content);
   }
 
+  // Interpolated names — Inertia.Render($"{Module}/Browse", ...) — can't be
+  // resolved statically and would otherwise slip past both patterns above
+  // (the '$' is neither a quote nor an identifier start), letting an
+  // unregistered page pass validation. Report them so they're caught, not
+  // silently skipped — the exact failure mode this guard exists to prevent.
+  const interpolatedPattern = /Inertia\.Render\s*\(\s*\$"/g;
+  match = interpolatedPattern.exec(content);
+  while (match !== null) {
+    unresolved.add('$"…" (interpolated component name — use a literal or const)');
+    match = interpolatedPattern.exec(content);
+  }
+
   return { names, unresolved };
 }
 

--- a/tests/SimpleModule.Core.Tests/Hosting/HostEnvironmentExtensionsTests.cs
+++ b/tests/SimpleModule.Core.Tests/Hosting/HostEnvironmentExtensionsTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using SimpleModule.Core.Hosting;
+
+namespace SimpleModule.Core.Tests.Hosting;
+
+public class HostEnvironmentExtensionsTests
+{
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("Testing", true)]
+    [InlineData("Production", false)]
+    [InlineData("Staging", false)]
+    [InlineData("QA", false)]
+    [InlineData("Local", false)]
+    public void IsLocalOrTest_ClassifiesEnvironment(string environmentName, bool expected)
+    {
+        var environment = new FakeHostEnvironment(environmentName);
+
+        environment.IsLocalOrTest().Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsLocalOrTest_Null_Throws()
+    {
+        var act = () => ((IHostEnvironment)null!).IsLocalOrTest();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private sealed class FakeHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = "Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/SimpleModule.Tests.Shared/Fakes/FakeDbContextOutbox.cs
+++ b/tests/SimpleModule.Tests.Shared/Fakes/FakeDbContextOutbox.cs
@@ -44,6 +44,14 @@ public sealed class FakeDbContextOutbox<TDbContext>(TDbContext context)
     public async Task SaveChangesAndFlushMessagesAsync(CancellationToken token = default)
     {
         await DbContext.SaveChangesAsync(token);
+
+        // Mirror the production outbox, which commits an externally-started
+        // transaction before flushing messages (services that need a
+        // database-generated id save inside an explicit transaction first).
+        if (DbContext.Database.CurrentTransaction is not null)
+        {
+            await DbContext.Database.CommitTransactionAsync(token);
+        }
     }
 
     public Task FlushOutgoingMessagesAsync() => Task.CompletedTask;

--- a/tests/e2e/tests/flows/filestorage-crud.spec.ts
+++ b/tests/e2e/tests/flows/filestorage-crud.spec.ts
@@ -138,6 +138,36 @@ test.describe
     });
   });
 
+test.describe('FileStorage upload validation', () => {
+  test('rejects a file whose extension is not in the allowlist', async ({ request }) => {
+    const response = await request.post('/api/files', {
+      multipart: {
+        file: {
+          name: `blocked-${faker.string.alphanumeric(8)}.exe`,
+          mimeType: 'application/octet-stream',
+          buffer: Buffer.from('MZ'),
+        },
+      },
+    });
+
+    // UploadEndpoint enforces FileStorageModuleOptions.AllowedExtensions.
+    expect(response.status()).toBe(400);
+  });
+
+  test('accepts a file whose extension is in the allowlist', async ({ request }) => {
+    const name = `allowed-${faker.string.alphanumeric(8)}.txt`;
+    const response = await request.post('/api/files', {
+      multipart: {
+        file: { name, mimeType: 'text/plain', buffer: Buffer.from('hello') },
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const data = await response.json();
+    await request.delete(`/api/files/${data.id}`).catch(() => {});
+  });
+});
+
 test.describe('FileStorage permissions', () => {
   test.describe('unauthenticated', () => {
     test.use({ storageState: { cookies: [], origins: [] } });


### PR DESCRIPTION
## Summary

Addresses the four critical issues from the framework review, the recurring bug classes behind them, and the doc/CI gaps — verified by automated CI, two adversarial code-review rounds, a browser QA pass, and the e2e suite.

**1. Page-registry footgun guard — resurrected on both ends.**
- `validate-pages.mjs` scanned `modules/<Name>/src/<Name>` but the real layout is `src/SimpleModule.<Name>`, so it validated **zero** C# files and printed success in CI and `npm run check`. Fixed the path (scan every project dir under `src/`, skip `obj`/`bin`/`wwwroot`), resolve `Inertia.Render` calls that use same-file string consts, flag interpolated `Render($"…")`, and add a **fail-on-zero self-check** so path drift can never silently disable it again. Now validates 73 endpoints across 553 files.
- The runtime fallback was equally dead: `app.tsx` called `showErrorToast(...)` (doesn't exist → `ReferenceError`). Root cause: ClientApp had no `tsconfig.json` and was excluded from `typecheck.mjs`. Added the tsconfig + wired ClientApp into typecheck, which then exposed two more latent bugs — `router.on('exception')` isn't an Inertia v3 event (now `networkError`), and the resolver returned a module wrapper where Inertia needs the component.

**2. Default deployment hardened (was one request from an admin token).**
- `UserSeedService` fails host startup outside Development/Testing when `Seed:AdminPassword` is unset instead of seeding the published `Admin123!` default.
- New `OpenIddictProductionGuard` refuses the ROPC password grant and ephemeral signing keys in real deployments. Both guards share `HostEnvironmentExtensions.IsLocalOrTest` so they never disagree.
- Forwarded-header trust is now explicit (config-driven `KnownProxies`/`KnownNetworks`/`TrustAllProxies`) instead of trusting any spoofed `X-Forwarded-For`.
- `docker-compose.yml` pins `OpenIddict__AllowPasswordGrant=false`, requires `SEED_ADMIN_PASSWORD` (api **and** worker), and documents proxy config.
- `UploadEndpoint` now enforces `FileStorageModuleOptions` (413 over `MaxFileSizeMb`, 400 outside `AllowedExtensions`).

**3. Remaining #242-class DbContext races + lost-event outbox gaps.**
- Sequentialized the genuinely-shared-context site (`AdminService`); reverted `UsersEditEndpoint` to parallel after verifying its 3 contracts use distinct DbContexts; fixed `TenantFeatureHelper` (threw with 2+ active flags).
- Routed `TenantService.CreateTenantAsync` and `FileStorageService` upload/delete through `IDbContextOutbox` so events commit atomically with the DB write (the old SaveChanges-then-Publish lost events on crash; delete also dropped the event on a failed blob delete).

**4. Docs reconciled with the tracked codebase.**
- CLAUDE.md / Constitution described phantom modules (Products/Orders/Marketplace/PageBuilder) and a dual-provider CI that doesn't exist. Rewrote the test/benchmark/load-test sections around the real 17-module system and the actual 6 NBomber scenarios / 5 benchmark classes; switched examples off the phantom Products module (whose wrong `src/<Name>` layout was the origin of the validate-pages bug).
- Added the security scanning the Constitution claims: **CodeQL** (C#/JS), **Dependabot** (nuget/npm/actions), and a **`dotnet list package --vulnerable`** CI gate.

## Verification
- `dotnet build -warnaserror`: 0 warnings / 0 errors
- `dotnet test`: **19/19 assemblies, 0 failures** (incl. 24 new tests covering the security guards: `HostEnvironmentExtensions`, `OpenIddictProductionGuard`, `UserSeedService.ResolveSeedPassword`)
- `npm run check`: biome + validate-pages + i18n + framework-scope + typecheck 14/14
- `npm run build`: all workspaces
- **Browser QA** (logged in as seeded admin): page hydration, file upload limits (`.txt`/`.csv`/`.png`→201, `.exe`→400), upload/delete outbox flows, admin user-edit parallel revert (all tabs render), 404 error page, **zero JS console errors**
- **e2e**: filestorage flow **15/15** (incl. new upload-validation regression test) + smoke suite **66/66**

> The e2e gate caught a real regression: enforcing `AllowedExtensions` (default omitted plain `.txt`) broke the framework's own `.txt`-upload test. Fixed by adding `.txt`/`.csv` to the default allowlist (resolving the framework's self-contradiction) rather than weakening the test, plus a durable regression spec.

Deferred follow-ups (recorded in `tasks/todo.md`, not silently dropped): the SM0060 analyzer for the race/outbox bug classes, a shared outbox helper, a framework production-config validation abstraction, module-options↔Settings binding, the `TenantFeatureHelper` N+1, and a PostgreSQL CI leg.

## Test plan
- [ ] CI green (build, tests, lint, validators, CodeQL, vulnerable-package audit)
- [ ] Reviewer confirms `npm run validate-pages` now reports a non-zero endpoint count
- [ ] Reviewer confirms a Production-env boot without `Seed:AdminPassword` fails fast